### PR TITLE
Fix typos in dotprompt file example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,22 @@ This combination of features makes it possible to treat a Dotprompt file as an e
 Here's an example of a Dotprompt file that extracts structured data from provided text:
 
 ```handlebars
---- model: googleai/gemini-1.5-pro input: schema: text: string output: format: json schema: title?:
-string, the title of the article if it has one summary: string, a 3-sentence summary of the text
-tags?(array, a list of string tag category for the text): String, --- Extract the requested
-information from the given text. If a piece of information is not present, omit that field from the
-output. Text:
-{{text}}
+---
+model: googleai/gemini-1.5-pro
+input:
+  schema:
+    text: string
+output:
+  format: json
+  schema:
+    name?: string, the full name of the person
+    age?: number, the age of the person
+    occupation?: string, the person's occupation
+---
+
+Extract the requested information from the given text.
+If a piece of information is not present, omit that field from the output.
+Text: {{text}}
 ```
 
 This Dotprompt file:


### PR DESCRIPTION
The prompt file did not match the example code below. This updates that, and fixes some format issues as well.