### PR TITLE
Adds `raw` and `ext` to frontmatter parsing.

### DIFF
--- a/js/src/parse.ts
+++ b/js/src/parse.ts
@@ -26,24 +26,58 @@ import {
 } from "./types";
 
 const FRONTMATTER_REGEX = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+const RESERVED_METADATA_KEYWORDS: (keyof PromptMetadata)[] = [
+  "name",
+  "variant",
+  "version",
+  "description",
+  "model",
+  "tools",
+  "toolDefs",
+  "config",
+  "input",
+  "output",
+  "raw",
+  "ext",
+];
+
+const BASE_METADATA: PromptMetadata<ModelConfig> = {
+  ext: {},
+  metadata: {},
+  config: {} as ModelConfig,
+};
 
 export function parseDocument<ModelConfig = Record<string, any>>(
   source: string
 ): ParsedPrompt<ModelConfig> {
   const match = source.match(FRONTMATTER_REGEX);
-
   if (match) {
     const [, frontmatter, content] = match;
     try {
-      const metadata = parse(frontmatter) as PromptMetadata<ModelConfig>;
-      return { ...metadata, template: content.trim() };
+      const parsedMetadata = parse(frontmatter) as PromptMetadata<ModelConfig>;
+      const raw = { ...parsedMetadata };
+      const pruned: PromptMetadata<ModelConfig> = { ...BASE_METADATA };
+      const ext: PromptMetadata["ext"] = {};
+      for (const k in raw) {
+        const key = k as keyof PromptMetadata;
+        if (RESERVED_METADATA_KEYWORDS.includes(key)) {
+          pruned[key] = raw[key] as any;
+        } else if (key.includes(".")) {
+          const lastDotIndex = key.lastIndexOf(".");
+          const namespace = key.substring(0, lastDotIndex);
+          const fieldName = key.substring(lastDotIndex + 1);
+          ext[namespace] = ext[namespace] || {};
+          ext[namespace][fieldName] = raw[key];
+        }
+      }
+      return { ...pruned, raw, ext, template: content.trim() };
     } catch (error) {
       console.error("Dotprompt: Error parsing YAML frontmatter:", error);
-      return { template: source.trim() };
+      return { ...BASE_METADATA, template: source.trim() };
     }
   }
 
-  return { template: source };
+  return { ...BASE_METADATA, template: source };
 }
 
 const ROLE_REGEX = /(<<<dotprompt:(?:role:[a-z]+|history))>>>/g;

--- a/js/src/types.d.ts
+++ b/js/src/types.d.ts
@@ -72,6 +72,19 @@ export interface PromptMetadata<ModelConfig = Record<string, any>> extends HasMe
     /** Schema defining the output structure. */
     schema?: Schema;
   };
+  /**
+   * This field will contain the raw frontmatter as parsed with no additional processing
+   * or substitutions. If your implementation requires custom fields they will be available
+   * here.
+   **/
+  raw?: Record<string, any>;
+  /**
+   * Fields that contain a period will be considered "extension fields" in the frontmatter
+   * and will be gathered by namespace. For example, `myext.foo: 123` would be available
+   * at `parsedPrompt.ext.myext.foo`. Nested namespaces will be flattened, so `myext.foo.bar: 123`
+   * would be available at `parsedPrompt.ext["myext.foo"].bar`.
+   */
+  ext?: Record<string, Record<string, any>>;
 }
 
 export interface ParsedPrompt<ModelConfig = Record<string, any>>

--- a/js/test/spec.test.ts
+++ b/js/test/spec.test.ts
@@ -63,7 +63,18 @@ files
               }
 
               const result = await env.render(s.template, { ...s.data, ...tc.data }, tc.options);
-              expect(result).toEqual({ ...tc.expect, config: tc.expect.config || {} });
+              const { raw, ...prunedResult } = result;
+              const { raw: expectRaw, ...expected } = tc.expect;
+              expect(prunedResult).toEqual({
+                ...expected,
+                ext: expected.ext || {},
+                config: expected.config || {},
+                metadata: expected.metadata || {},
+              });
+              // only compare raw if the spec demands it
+              if (tc.expect.raw) {
+                expect(raw).toEqual(expectRaw);
+              }
             });
           });
         });

--- a/spec/metadata.yaml
+++ b/spec/metadata.yaml
@@ -50,3 +50,52 @@
         messages:
           - role: user
             content: [{ text: "Current count is 100\nStatus is pending\n" }]
+- name: raw
+  template: |
+    ---
+    config:
+      temperature: 3
+    custom: prop
+    ---
+    Hello, world.
+  tests:
+    - desc: raw frontmatter is provided on top of parsed frontmatter
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Hello, world." }]
+        config:
+          temperature: 3
+        raw:
+          config:
+            temperature: 3
+          custom: prop
+- name: ext
+  template: |
+    ---
+    model: cool-model
+    config:
+      temperature: 3
+    ext1.foo: bar
+    ext1.foo1: bar1
+    ext1.sub1.foo: baz
+    ext1.sub2.bar: qux
+    ext2.foo: bar2
+    ---
+  tests:
+    - desc: extension fields are parsed and added to 'ext'
+      expect:
+        messages: []
+        model: cool-model
+        config:
+          temperature: 3
+        ext:
+          ext1:
+            foo: bar
+            foo1: bar1
+          ext1.sub1:
+            foo: baz
+          ext1.sub2:
+            bar: qux
+          ext2:
+            foo: bar2

--- a/third_party/docsite/src/content/docs/reference/frontmatter.mdx
+++ b/third_party/docsite/src/content/docs/reference/frontmatter.mdx
@@ -132,3 +132,41 @@ metadata:
 ### `metadata`
 - **Type:** `Map<string, any>`
 - **Description:** Arbitrary metadata to be used by code, tools, and libraries.
+
+## Frontmatter Extensions
+
+In the frontmatter, Dotprompt implementations will automatically collect namespaced fields (i.e. fields with a `.` in them) into a special `ext` property on the resulting metadata. For example, the following frontmatter:
+
+```handlebars
+---
+config:
+  temperature: 3
+mycorp.auth:
+  type: FIREBASE
+  role: admin # only admins can use this
+mycorp.ownerId: 12345
+mycorp.subunit.level: 5
+---
+```
+
+Would be parsed into this equivalent metadata:
+
+```js
+{
+  config: {temperature: 3},
+  ext: {
+    mycorp: {
+      auth: {
+        type: 'FIREBASE',
+        role: 'admin',
+      },
+      ownerId: 12345,
+    },
+    'mycorp.subunit': {
+      level: 5,
+    },
+  }
+}
+```
+
+Note that nested namespaces are flattened into dotted keys to avoid conflicts between nested properties and nested namespaces.


### PR DESCRIPTION
This allows Dotprompt to be more flexible and extensible for implementors while not making it too hard to extend the spec in the future.

1. Parsed prompts now include a `raw` field that includes the unprocessed frontmatter directly from the YAML. This can be used if an implementation is modifying or extending base fields.
2. All fields with dotted names e.g. `myext.foo` are now gathered into an `ext` field and the Dotprompt spec will never have reserved fields that include a dot. This allows for arbitrary extension points to the frontmatter.