### PR TITLE
breaking: Removes dotprompt(), renames DotpromptEnvironment -> Dotprompt

### DIFF
--- a/js/examples/adapters.ts
+++ b/js/examples/adapters.ts
@@ -16,9 +16,9 @@
 
 import { toGeminiRequest } from "../src/adapters/gemini.js";
 import { toOpenAIRequest } from "../src/adapters/openai.js";
-import { dotprompt } from "../src/index.js";
+import { Dotprompt } from "../src/index.js";
 
-const prompts = dotprompt();
+const prompts = new Dotprompt();
 
 async function main() {
   const rendered = await prompts.render(

--- a/js/src/environment.ts
+++ b/js/src/environment.ts
@@ -61,7 +61,7 @@ export interface DotpromptOptions {
   store?: PromptStore;
 }
 
-export class DotpromptEnvironment {
+export class Dotprompt {
   private handlebars: typeof Handlebars;
   private knownHelpers: Record<string, true> = {};
   private defaultModel?: string;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-import { DotpromptEnvironment, DotpromptOptions } from "./environment.js";
+import { Dotprompt, DotpromptOptions } from "./environment.js";
 export { picoschema, PicoschemaOptions, PicoschemaParser } from "./picoschema.js";
 export type * from "./types.js";
-export { DotpromptEnvironment, DotpromptOptions };
-
-/**
- * Create a Dotprompt environment with a unique namespace for registering helpers, partials, and schemas.
- */
-export function dotprompt(options?: DotpromptOptions): DotpromptEnvironment {
-  return new DotpromptEnvironment(options);
-}
+export { Dotprompt, DotpromptOptions };

--- a/js/test/spec.test.ts
+++ b/js/test/spec.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect, suite } from "vitest";
 import { readdirSync, readFileSync } from "node:fs";
 import { parse } from "yaml";
 import { join, relative } from "node:path";
-import { DotpromptEnvironment } from "../src/environment";
+import { Dotprompt } from "../src/environment";
 import { DataArgument, JSONSchema, ToolDefinition } from "../src/types";
 
 const specDir = join("..", "spec");
@@ -50,7 +50,7 @@ files
           // Create a test for each test case in the suite
           s.tests.forEach((tc) => {
             it(tc.desc || "should match expected output", async () => {
-              const env = new DotpromptEnvironment({
+              const env = new Dotprompt({
                 schemas: s.schemas,
                 tools: s.tools,
                 partialResolver: (name: string) => s.resolverPartials?.[name] || null,


### PR DESCRIPTION
It's awkward to have `dotprompt` taken by the import since that's the most natural variable name for it.