### PR TITLE
chore(ci): use node versions 20 through 23 for GitHub actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,5 @@
 # Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Deploy to GitHub Pages
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,5 @@
 # Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: Release JS
 
@@ -25,7 +14,7 @@ on:
         options:
           - next
           - latest
-        
+
 jobs:
   build:
     name: Run build tasks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,5 @@
 # Copyright 2024 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 name: "JS: Run Tests"
 
@@ -26,14 +15,18 @@ on:
 
 jobs:
   test:
+    name: Run tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20', '21', '22', '23']
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js v${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": true
   },
@@ -12,6 +12,7 @@
   "files": {
     "ignoreUnknown": true,
     "ignore": [
+      "**/.cache/**",
       "**/.dist/**",
       "**/.eggs/**",
       "**/.idea/**",
@@ -31,15 +32,14 @@
       ".nx/**",
       ".trunk/**",
       "bazel-*/**",
+      "go/**",
       "node_modules/**",
+      "python/**",
       "third_party/**"
     ]
   },
   "formatter": {
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineEnding": "lf",
-    "lineWidth": 80
+    "useEditorconfig": true
   },
   "vcs": {
     "clientKind": "git",
@@ -49,7 +49,7 @@
   },
   "javascript": {
     "formatter": {
-      "arrowParentheses": "asNeeded",
+      "arrowParentheses": "always",
       "attributePosition": "auto",
       "bracketSpacing": true,
       "jsxQuoteStyle": "double",

--- a/js/src/adapters/gemini.ts
+++ b/js/src/adapters/gemini.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { RenderedPrompt, Part, Message } from '../types.js';
+import type { Message, Part, RenderedPrompt } from '../types.js';
 
 export interface GeminiContent {
   role: 'user' | 'model';
@@ -119,7 +119,7 @@ function convertTools(prompt: RenderedPrompt): GeminiTool | undefined {
   if (!prompt.toolDefs?.length) return undefined;
 
   return {
-    functionDeclarations: prompt.toolDefs.map(tool => ({
+    functionDeclarations: prompt.toolDefs.map((tool) => ({
       name: tool.name,
       description: tool.description,
       parameters: tool.inputSchema,

--- a/js/src/adapters/openai.ts
+++ b/js/src/adapters/openai.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { RenderedPrompt, Part, Message } from '../types.js';
+import type { Message, Part, RenderedPrompt } from '../types.js';
 
 export interface OpenAIMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -116,7 +116,7 @@ function convertTools(
 ): OpenAIToolDefintiion[] | undefined {
   if (!prompt.toolDefs?.length) return undefined;
 
-  return prompt.toolDefs.map(tool => ({
+  return prompt.toolDefs.map((tool) => ({
     type: 'function',
     function: {
       name: tool.name,
@@ -127,7 +127,7 @@ function convertTools(
 }
 
 export function toOpenAIRequest(source: RenderedPrompt): OpenAIRequest {
-  const messages: OpenAIMessage[] = source.messages.map(msg => {
+  const messages: OpenAIMessage[] = source.messages.map((msg) => {
     const base: OpenAIMessage = {
       role: convertRole(msg.role),
       content: convertContent(msg.content),

--- a/js/src/dotprompt.ts
+++ b/js/src/dotprompt.ts
@@ -16,27 +16,27 @@
 
 import * as Handlebars from 'handlebars';
 import * as helpers from './helpers';
-import {
-  PromptFunction,
-  DataArgument,
-  JSONSchema,
-  PromptMetadata,
-  RenderedPrompt,
-  SchemaResolver,
-  ToolDefinition,
-  ToolResolver,
-  ParsedPrompt,
-  PromptStore,
-  PromptRefFunction,
-} from './types';
 import { parseDocument, toMessages } from './parse';
 import { picoschema } from './picoschema';
+import {
+  type DataArgument,
+  type JSONSchema,
+  type ParsedPrompt,
+  type PromptFunction,
+  type PromptMetadata,
+  PromptRefFunction,
+  type PromptStore,
+  type RenderedPrompt,
+  type SchemaResolver,
+  type ToolDefinition,
+  type ToolResolver,
+} from './types';
 import { removeUndefinedFields } from './util';
 
 /** Function to resolve partial names to their content */
-export interface PartialResolver {
-  (partialName: string): string | null | Promise<string | null>;
-}
+export type PartialResolver = (
+  partialName: string
+) => string | null | Promise<string | null>;
 
 export interface DotpromptOptions {
   /** A default model to use if none is supplied. */
@@ -194,7 +194,7 @@ export class Dotprompt {
       out.toolDefs = out.toolDefs || [];
 
       await Promise.all(
-        out.tools.map(async toolName => {
+        out.tools.map(async (toolName) => {
           if (this.tools[toolName]) {
             out.toolDefs!.push(this.tools[toolName]);
           } else if (this.toolResolver) {
@@ -243,7 +243,7 @@ export class Dotprompt {
 
     // Resolve and register each partial
     await Promise.all(
-      Array.from(partials).map(async name => {
+      Array.from(partials).map(async (name) => {
         if (!this.handlebars.partials[name]) {
           const content =
             (await this.partialResolver!(name)) ||

--- a/js/src/parse.ts
+++ b/js/src/parse.ts
@@ -15,7 +15,7 @@
  */
 
 import { parse } from 'yaml';
-import {
+import type {
   DataArgument,
   MediaPart,
   Message,
@@ -98,7 +98,7 @@ export function toMessages<ModelConfig = Record<string, any>>(
 
   for (const piece of renderedString
     .split(ROLE_REGEX)
-    .filter(s => s.trim() !== '')) {
+    .filter((s) => s.trim() !== '')) {
     if (piece.startsWith('<<<dotprompt:role:')) {
       const role = piece.substring(18);
       if (currentMessage.source.trim()) {
@@ -109,7 +109,7 @@ export function toMessages<ModelConfig = Record<string, any>>(
       }
     } else if (piece.startsWith('<<<dotprompt:history')) {
       messageSources.push(
-        ...(data?.messages?.map(m => {
+        ...(data?.messages?.map((m) => {
           return {
             ...m,
             metadata: { ...(m.metadata || {}), purpose: 'history' },
@@ -124,8 +124,8 @@ export function toMessages<ModelConfig = Record<string, any>>(
   }
 
   const messages: Message[] = messageSources
-    .filter(ms => ms.content || ms.source)
-    .map(m => {
+    .filter((ms) => ms.content || ms.source)
+    .map((m) => {
       const out: Message = {
         role: m.role as Message['role'],
         content: m.content || toParts(m.source!),
@@ -141,7 +141,7 @@ function insertHistory(
   messages: Message[],
   history: Message[] = []
 ): Message[] {
-  if (!history || messages.find(m => m.metadata?.purpose === 'history'))
+  if (!history || messages.find((m) => m.metadata?.purpose === 'history'))
     return messages;
   if (messages.at(-1)?.role === 'user') {
     return [...messages.slice(0, -1)!, ...history!, messages.at(-1)!];
@@ -153,7 +153,7 @@ const PART_REGEX = /(<<<dotprompt:(?:media:url|section).*?)>>>/g;
 
 function toParts(source: string): Part[] {
   const parts: Part[] = [];
-  const pieces = source.split(PART_REGEX).filter(s => s.trim() !== '');
+  const pieces = source.split(PART_REGEX).filter((s) => s.trim() !== '');
   for (let i = 0; i < pieces.length; i++) {
     const piece = pieces[i];
     if (piece.startsWith('<<<dotprompt:media:')) {

--- a/js/src/picoschema.ts
+++ b/js/src/picoschema.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JSONSchema, SchemaResolver } from './types.js';
+import type { JSONSchema, SchemaResolver } from './types.js';
 
 const JSON_SCHEMA_SCALAR_TYPES = [
   'string',

--- a/js/src/stores/dir.ts
+++ b/js/src/stores/dir.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+import { createHash } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { createHash } from 'crypto';
-import {
+import type {
+  PartialRef,
   PromptData,
   PromptRef,
   PromptStoreWritable,
-  PartialRef,
 } from '../types';
 
 interface DirStoreOptions {
@@ -60,7 +60,7 @@ export class DirStore implements PromptStoreWritable {
   }
 
   private async scanDirectory(
-    dir: string = '',
+    dir = '',
     results: string[] = []
   ): Promise<string[]> {
     const fullPath = path.join(this.directory, dir);

--- a/js/src/types.d.ts
+++ b/js/src/types.d.ts
@@ -158,18 +158,18 @@ export type JSONSchema = any;
  * an underlying JSON schema, utilized for shorthand to a schema library
  * provided by an external tool.
  **/
-export interface SchemaResolver {
-  (schemaName: string): JSONSchema | null | Promise<JSONSchema | null>;
-}
+export type SchemaResolver = (
+  schemaName: string
+) => JSONSchema | null | Promise<JSONSchema | null>;
 
 /**
  * SchemaResolver is a function that can resolve a provided tool name to
  * an underlying ToolDefinition, utilized for shorthand to a tool registry
  * provided by an external library.
  **/
-export interface ToolResolver {
-  (toolName: string): ToolDefinition | null | Promise<ToolDefinition | null>;
-}
+export type ToolResolver = (
+  toolName: string
+) => ToolDefinition | null | Promise<ToolDefinition | null>;
 
 /**
  * RenderedPrompt is the final result of rendering a Dotprompt template.

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -20,7 +20,7 @@ export function removeUndefinedFields(obj: any): any {
   }
 
   if (Array.isArray(obj)) {
-    return obj.map(item => removeUndefinedFields(item));
+    return obj.map((item) => removeUndefinedFields(item));
   }
 
   const result: { [key: string]: any } = {};

--- a/js/test/spec.test.ts
+++ b/js/test/spec.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, suite } from 'vitest';
-import { readdirSync, readFileSync } from 'node:fs';
-import { parse } from 'yaml';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
+import { describe, expect, it, suite } from 'vitest';
+import { parse } from 'yaml';
 import { Dotprompt } from '../src/dotprompt';
-import { DataArgument, JSONSchema, ToolDefinition } from '../src/types';
+import type { DataArgument, JSONSchema, ToolDefinition } from '../src/types';
 
 const specDir = join('..', 'spec');
 const files = readdirSync(specDir, { recursive: true, withFileTypes: true });
@@ -37,8 +37,8 @@ interface SpecSuite {
 
 // Process each YAML file
 files
-  .filter(file => !file.isDirectory() && file.name.endsWith('.yaml'))
-  .forEach(file => {
+  .filter((file) => !file.isDirectory() && file.name.endsWith('.yaml'))
+  .forEach((file) => {
     const suiteName = join(
       relative(specDir, file.path),
       file.name.replace(/\.yaml$/, '')
@@ -50,10 +50,10 @@ files
     // Create a describe block for each YAML file
     suite(suiteName, () => {
       // Create a describe block for each suite in the file
-      suites.forEach(s => {
+      suites.forEach((s) => {
         describe(s.name, () => {
           // Create a test for each test case in the suite
-          s.tests.forEach(tc => {
+          s.tests.forEach((tc) => {
             it(tc.desc || 'should match expected output', async () => {
               const env = new Dotprompt({
                 schemas: s.schemas,

--- a/js/test/stores/dir.test.ts
+++ b/js/test/stores/dir.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { createHash } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DirStore } from '../../src/stores/dir';
-import { PromptData } from '../../src/types';
+import type { PromptData } from '../../src/types';
 
 describe('DirStore', () => {
   const tempDir = path.join(process.cwd(), 'test-prompts');
@@ -38,10 +38,7 @@ describe('DirStore', () => {
     return createHash('sha1').update(content).digest('hex').substring(0, 8);
   }
 
-  async function createPromptFile(
-    name: string,
-    content: string = 'test source'
-  ) {
+  async function createPromptFile(name: string, content = 'test source') {
     const filePath = path.join(tempDir, name);
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, content);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "packageManager": "pnpm@9.13.2+sha256.ccce81bf7498c5f0f80e31749c1f8f03baba99d168f64590fc7e13fad3ea1938",
   "scripts": {
-    "format": "pnpm dlx @biomejs/biome format --write ."
+    "format": "pnpm dlx @biomejs/biome check --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=true --fix . && bin/add_license",
+    "format:check": "pnpm dlx @biomejs/biome ci --linter-enabled=false --formatter-enabled=true --organize-imports-enabled=false . && bin/check_license",
+    "lint": "pnpm dlx @biomejs/biome lint --fix . && bin/add_license"
   }
 }


### PR DESCRIPTION
ISSUE: https://github.com/firebase/genkit/issues/1995

CHANGELOG:
- [x] Update biome configuration to respect editorconfig and ignore some more directories.
- [x] Auto-fix some lint in TypeScript files.
- [x] Update .gitignore to exclude .cache dir.
- [x] Update workflows to use node version 20-23.
- [x] Update `bin/setup` to use node version 22 as default on eng workstations.
- [x] Adds additional script commands to run lint and format checks.
- [x] Clean up copyright headers in GitHub action configuration.