### PR TITLE
fix(ruff): use the same command for the ci for python checks

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ jobs:
         run: uv run --directory python ruff format --check .
 
       - name: Lint with ruff
-        run: uv run --directory python ruff check .
+        run: uv run --directory python ruff check --select I .
 
       - name: Static type check
         run: uv run --directory python mypy .

--- a/bin/setup
+++ b/bin/setup
@@ -95,7 +95,6 @@ function dotpromptz::install_prerequisites() {
       fd \
       gh \
       go \
-      node \
       python3 \
       ripgrep
   elif [[ -x "$(command -v apt)" ]]; then
@@ -114,7 +113,6 @@ function dotpromptz::install_prerequisites() {
       curl \
       fd-find \
       gh \
-      nodejs \
       python3 \
       ripgrep
   elif [[ -x "$(command -v dnf)" ]]; then
@@ -124,7 +122,6 @@ function dotpromptz::install_prerequisites() {
       fd-find \
       gh \
       go \
-      node \
       python3 \
       ripgrep
   else


### PR DESCRIPTION
CHANGELOG:
- [ ] Use consistent command for ruff check throughout.
- [ ] Don't install node as prerequisite since nvm installs it.
