### PR TITLE
fix(js): an issue with loose equality for helpers; add missing tests for some helpers #53 #54

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -31,6 +31,9 @@
           }
         },
         {
+          "run": "pnpm -C js install --frozen-lockfile"
+        },
+        {
           "run": "bin/fmt"
         },
         {
@@ -44,6 +47,9 @@
         },
         {
           "run": "bin/run_python_tests"
+        },
+        {
+          "run": "pnpm -C js run test"
         },
         {
           "run": "uv run mkdocs build"
@@ -68,6 +74,9 @@
           }
         },
         {
+          "run": "pnpm -C js install --frozen-lockfile"
+        },
+        {
           "run": "bin/fmt"
         },
         {
@@ -87,6 +96,9 @@
         },
         {
           "run": "bin/build_dists"
+        },
+        {
+          "run": "pnpm -C js run test"
         },
         {
           "run": ".hooks/commit-message-format-pre-push"

--- a/js/src/helpers.ts
+++ b/js/src/helpers.ts
@@ -51,7 +51,7 @@ export function ifEquals(
   arg2: any,
   options: Handlebars.HelperOptions
 ) {
-  return arg1 == arg2 ? options.fn(this) : options.inverse(this);
+  return arg1 === arg2 ? options.fn(this) : options.inverse(this);
 }
 
 export function unlessEquals(
@@ -60,5 +60,5 @@ export function unlessEquals(
   arg2: any,
   options: Handlebars.HelperOptions
 ) {
-  return arg1 != arg2 ? options.fn(this) : options.inverse(this);
+  return arg1 !== arg2 ? options.fn(this) : options.inverse(this);
 }

--- a/spec/helpers/history.yaml
+++ b/spec/helpers/history.yaml
@@ -1,0 +1,51 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Tests for the {{history}} helper which inserts previous conversation messages
+# at the current position in the template.
+
+# Tests that the history helper correctly inserts previous messages while
+# preserving their roles, content, and adding appropriate metadata.
+- name: basic_history
+  template: |
+    {{role "system"}}System prompt
+    {{history}}
+    {{role "user"}}Additional message
+  data:
+    messages:
+      - role: user
+        content: [{ text: "Hello" }]
+      - role: model
+        content: [{ text: "Hi there!" }]
+  tests:
+    - desc: inserts conversation history with proper metadata and roles
+      expect:
+        messages:
+          - role: system
+            content: [{ text: "System prompt\n" }]
+          - role: user
+            content: [{ text: "Hello" }]
+            metadata:
+              purpose: "history"
+          - role: model
+            content: [{ text: "Hi there!" }]
+            metadata:
+              purpose: "history"
+          - role: user
+            content: [{ text: "Additional message\n" }]
+
+# Tests that the history helper gracefully handles cases where there
+# are no previous messages to insert.
+- name: empty_history
+  template: |
+    {{role "system"}}System prompt
+    {{history}}
+    {{role "user"}}User message
+  tests:
+    - desc: handles empty history by only rendering the template content
+      expect:
+        messages:
+          - role: system
+            content: [{ text: "System prompt\n" }]
+          - role: user
+            content: [{ text: "User message\n" }]

--- a/spec/helpers/ifEquals.yaml
+++ b/spec/helpers/ifEquals.yaml
@@ -1,0 +1,55 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Tests for the {{#ifEquals}} helper which performs strict equality comparison
+# between two values and conditionally renders content based on the result.
+#
+# Note: This helper uses strict equality (===) rather than loose equality (==)
+# to ensure consistent behavior across different language runtimes (JavaScript,
+# Go, Python). This means that values of different types are always considered
+# unequal, even if they could be coerced to the same value (e.g., 5 !== "5").
+
+# Tests basic equality comparison with same-type values, verifying that
+# the appropriate branch is rendered based on strict equality.
+- name: basic
+  template: |
+    {{#ifEquals value1 value2}}
+    Values are equal
+    {{else}}
+    Values are not equal
+    {{/ifEquals}}
+  tests:
+    - desc: renders true branch when values are equal
+      data:
+        input: { value1: 5, value2: 5 }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are equal\n" }]
+
+    - desc: renders false branch when values are not equal
+      data:
+        input: { value1: 5, value2: 6 }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are not equal\n" }]
+
+# Tests that values of different types are considered unequal, even if they
+# could be coerced to the same value in some languages. This ensures consistent
+# behavior across different runtime environments.
+- name: type_safety
+  template: |
+    {{#ifEquals value1 value2}}
+    Values are equal
+    {{else}}
+    Values are not equal
+    {{/ifEquals}}
+  tests:
+    - desc: treats different types as not equal
+      data:
+        input: { value1: 5, value2: "5" }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are not equal\n" }]

--- a/spec/helpers/json.yaml
+++ b/spec/helpers/json.yaml
@@ -1,6 +1,11 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# Tests for the {{json}} helper which serializes JavaScript objects into
+# JSON strings with optional indentation.
+
+# Tests basic JSON serialization without indentation, ensuring objects
+# are properly stringified in a compact format.
 - name: basic
   template: "{{json this}}"
   tests:
@@ -10,6 +15,9 @@
         messages:
           - role: user
             content: [{ text: '{"test":true}' }]
+
+# Tests JSON serialization with custom indentation, ensuring proper
+# formatting for improved readability.
 - name: indented
   template: "{{json this indent=2}}"
   tests:

--- a/spec/helpers/media.yaml
+++ b/spec/helpers/media.yaml
@@ -1,6 +1,11 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# Tests for the {{media}} helper which formats media URLs with content type
+# information in message content.
+
+# Tests that media URLs are properly formatted with content type in the
+# message content array.
 - name: basic
   template: "{{media contentType=contentType url=url}}"
   tests:

--- a/spec/helpers/role.yaml
+++ b/spec/helpers/role.yaml
@@ -1,6 +1,11 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# Tests for the {{role}} helper which manages message roles in conversations,
+# supporting system, user, and model roles with proper message segmentation.
+
+# Tests role switching between system and user roles while preserving
+# variable substitution within each role's content.
 - name: system_role
   template: |
     {{role "system"}}{{systemGreeting}} from system
@@ -15,6 +20,9 @@
             { content: [{ text: "hi from system\n" }], role: "system" },
             { content: [{ text: "howdy from user\n" }], role: "user" },
           ]
+
+# Tests support for all available role types (system, user, model) and proper
+# message segmentation when switching roles.
 - name: all_roles
   template: |
     {{role "system"}}this is system
@@ -31,6 +39,9 @@
             { content: [{ text: "this is model\n" }], role: "model" },
             { content: [{ text: "this is user2\n" }], role: "user" },
           ]
+
+# Tests system prompt handling with existing message history, ensuring
+# proper ordering of system prompt and history.
 - name: system_only_prompt
   template: |
     {{role "system"}}This is the system prompt

--- a/spec/helpers/section.yaml
+++ b/spec/helpers/section.yaml
@@ -1,0 +1,75 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Tests for the {{section}} helper which allows organizing content into
+# named sections with metadata for structural organization.
+
+# Tests that sections are properly rendered in sequence with
+# appropriate metadata markers.
+- name: basic_section
+  template: |
+    {{section "intro"}}
+    Hello world
+    {{section "main"}}
+    Main content
+    {{section "conclusion"}}
+    Goodbye
+  tests:
+    - desc: renders sequential sections with proper metadata and content boundaries
+      expect:
+        messages:
+          - role: user
+            content:
+              # Intro section start marker
+              - metadata:
+                  pending: true
+                  purpose: "intro"
+              # Intro section content
+              - text: "\nHello world\n"
+              # Main section start marker
+              - metadata:
+                  pending: true
+                  purpose: "main"
+              # Main section content
+              - text: "\nMain content\n"
+              # Conclusion section start marker
+              - metadata:
+                  pending: true
+                  purpose: "conclusion"
+              # Conclusion section content
+              - text: "\nGoodbye\n"
+
+# Tests that sections can be nested and reopened, maintaining proper
+# structure and metadata throughout.
+- name: nested_sections
+  template: |
+    {{section "outer"}}
+    Outer content
+    {{section "inner"}}
+    Inner content
+    {{section "outer"}}
+    More outer content
+  tests:
+    - desc: handles nested and reopened sections with proper metadata boundaries
+      expect:
+        messages:
+          - role: user
+            content:
+              # First outer section start
+              - metadata:
+                  pending: true
+                  purpose: "outer"
+              # First outer section content
+              - text: "\nOuter content\n"
+              # Inner section start
+              - metadata:
+                  pending: true
+                  purpose: "inner"
+              # Inner section content
+              - text: "\nInner content\n"
+              # Second outer section start
+              - metadata:
+                  pending: true
+                  purpose: "outer"
+              # Second outer section content
+              - text: "\nMore outer content\n"

--- a/spec/helpers/unlessEquals.yaml
+++ b/spec/helpers/unlessEquals.yaml
@@ -1,0 +1,55 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Tests for the {{#unlessEquals}} helper which performs strict inequality comparison
+# between two values and conditionally renders content based on the result.
+#
+# Note: This helper uses strict inequality (!==) rather than loose inequality (!=)
+# to ensure consistent behavior across different language runtimes (JavaScript,
+# Go, Python). This means that values of different types are always considered
+# unequal, even if they could be coerced to the same value (e.g., 5 !== "5").
+
+# Tests basic inequality comparison with same-type values, verifying that
+# the appropriate branch is rendered based on strict inequality.
+- name: basic
+  template: |
+    {{#unlessEquals value1 value2}}
+    Values are not equal
+    {{else}}
+    Values are equal
+    {{/unlessEquals}}
+  tests:
+    - desc: renders true branch when values are different
+      data:
+        input: { value1: 5, value2: 6 }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are not equal\n" }]
+
+    - desc: renders false branch when values are equal
+      data:
+        input: { value1: 5, value2: 5 }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are equal\n" }]
+
+# Tests that values of different types are considered unequal, even if they
+# could be coerced to the same value in some languages. This ensures consistent
+# behavior across different runtime environments.
+- name: type_safety
+  template: |
+    {{#unlessEquals value1 value2}}
+    Values are not equal
+    {{else}}
+    Values are equal
+    {{/unlessEquals}}
+  tests:
+    - desc: treats different types as not equal
+      data:
+        input: { value1: 5, value2: "5" }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are not equal\n" }]

--- a/spec/metadata.yaml
+++ b/spec/metadata.yaml
@@ -1,6 +1,11 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# Tests for metadata handling in templates, including state access,
+# raw frontmatter, and extension field parsing.
+
+# Tests accessing state object values from metadata, including missing
+# values and nested objects.
 - name: metadata_state
   template: |
     Current count is {{@state.count}}
@@ -39,6 +44,9 @@
         messages:
           - role: user
             content: [{ text: "Current count is 100\nStatus is pending\n" }]
+
+# Tests that raw frontmatter is preserved alongside parsed frontmatter,
+# allowing access to both structured and unstructured metadata.
 - name: raw
   template: |
     ---
@@ -59,6 +67,9 @@
           config:
             temperature: 3
           custom: prop
+
+# Tests that extension fields are properly parsed and organized into
+# the ext object, maintaining their hierarchical structure.
 - name: ext
   template: |
     ---

--- a/spec/partials.yaml
+++ b/spec/partials.yaml
@@ -1,6 +1,10 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# Tests for partial templates, including basic inclusion, context passing,
+# and resolver-provided partials.
+
+# Tests basic partial inclusion without context.
 - name: basic_partial
   template: |
     {{> greeting}} This is the main template.
@@ -16,6 +20,7 @@
             content:
               [{ text: "Hello from a partial! This is the main template.\n" }]
 
+# Tests partial rendering with context variables passed from the main template.
 - name: partial_with_context
   template: |
     {{> userGreeting name=username}}
@@ -30,6 +35,7 @@
           - role: user
             content: [{ text: "Welcome back, Alice!" }]
 
+# Tests that partials can be provided by a resolver function.
 - name: resolved_partial
   template: |
     {{> resolved}}
@@ -42,6 +48,7 @@
           - role: user
             content: [{ text: "Hello from a resolved partial!" }]
 
+# Tests that resolver-provided partials can be nested within each other.
 - name: nested_resolved_partial
   template: |
     {{> resolvedOuter}}

--- a/spec/picoschema.yaml
+++ b/spec/picoschema.yaml
@@ -1,6 +1,13 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# Tests for the picoschema parser which converts simplified schema definitions
+# into full JSON Schema objects. The picoschema format provides a concise way
+# to define input and output schemas in templates.
+
+# Tests basic scalar type definition without a description.
+# This verifies that simple type names are correctly converted to
+# JSON Schema type definitions.
 - name: simple_scalar_no_description
   template: |
     ---
@@ -13,6 +20,9 @@
         messages: []
         output:
           schema: { type: string }
+
+# Tests that both input and output schemas can be defined in the same template.
+# This is common in templates that process data and return results.
 - name: input_and_output
   template: |
     ---
@@ -29,6 +39,10 @@
           schema: { type: string }
         input:
           schema: { type: string }
+
+# Tests scalar type definition with a description after a comma.
+# This verifies that descriptions are properly extracted and added
+# to the JSON Schema object.
 - name: simple_scalar_description
   template: |
     ---
@@ -41,6 +55,10 @@
         messages: []
         output:
           schema: { type: number, description: "the description" }
+
+# Tests that descriptions are correctly parsed even without whitespace
+# after the comma. This ensures the parser is resilient to different
+# formatting styles.
 - name: simple_scalar_description_no_whitespace
   template: |
     ---
@@ -53,6 +71,9 @@
         messages: []
         output:
           schema: { type: number, description: "the description" }
+
+# Tests that descriptions can contain commas, ensuring that only the first
+# comma is used to separate the type from the description.
 - name: simple_scalar_description_with_commas
   template: |
     ---
@@ -69,6 +90,9 @@
               type: number,
               description: "the description, which has, multiple commas",
             }
+
+# Tests that extra whitespace around the description is properly trimmed,
+# ensuring consistent output regardless of input formatting.
 - name: simple_scalar_description_extra_whitespace
   template: |
     ---
@@ -81,6 +105,9 @@
         messages: []
         output:
           schema: { type: number, description: "the description" }
+
+# Tests object type definition with multiple fields. This verifies that
+# nested field definitions are correctly converted to JSON Schema properties.
 - name: simple_object
   template: |
     ---
@@ -101,6 +128,9 @@
               field1: { type: boolean }
               field2: { type: string }
             required: ["field1", "field2"]
+
+# Tests that required fields are correctly marked in the JSON Schema.
+# Fields marked with an asterisk (*) are added to the required array.
 - name: required_field
   template: |
     ---
@@ -121,6 +151,9 @@
               req: { type: string, description: "required field" }
               nonreq: { type: [boolean, "null"], description: "optional field" }
             required: ["req"]
+
+# Tests array type definitions, ensuring that array items are properly
+# typed according to the specified schema.
 - name: array_of_scalars
   template: |
     ---
@@ -146,6 +179,9 @@
                 type: array
                 items: { type: number }
             required: ["tags", "vector"]
+
+# Tests complex nested structures with arrays and objects, verifying
+# that the full structure is correctly converted to JSON Schema.
 - name: nested_object_in_array_and_out
   template: |
     ---
@@ -181,6 +217,8 @@
                     nest2: { type: [boolean, "null"] }
             required: ["arr"]
 
+# Tests that JSON Schema type keywords are recognized and preserved,
+# allowing direct use of JSON Schema syntax when needed.
 - name: simple_json_schema_type
   template: |
     ---
@@ -196,6 +234,8 @@
           schema:
             type: string
 
+# Tests that properties can be inferred from the schema structure,
+# automatically generating the appropriate JSON Schema type definitions.
 - name: inferred_json_schema_from_properties
   template: |
     ---
@@ -214,6 +254,8 @@
             properties:
               foo: { type: string }
 
+# Tests enum field definitions, ensuring that enum values are correctly
+# captured in the JSON Schema.
 - name: enum_field
   template: |
     ---
@@ -234,6 +276,8 @@
                 enum: ["RED", "BLUE", "GREEN", null]
             additionalProperties: false
 
+# Tests the 'any' type definition, which allows any value to be used.
+# This should translate to removing type restrictions in the JSON Schema.
 - name: any_field
   template: |
     ---
@@ -255,6 +299,8 @@
             additionalProperties: false
             required: ["first"]
 
+# Tests that wildcard fields can be combined with specific fields,
+# allowing for flexible object structures with some defined properties.
 - name: wildcard_fields_with_other_fields
   template: |
     ---
@@ -275,6 +321,8 @@
             required: ["otherField"]
             type: object
 
+# Tests objects that only have wildcard fields, representing completely
+# flexible object structures.
 - name: wildcard_fields_without_other_fields
   template: |
     ---
@@ -291,6 +339,9 @@
             additionalProperties: { type: number, description: "lucky number" }
             properties: {}
             type: object
+
+# Tests that schema descriptions can override any existing descriptions,
+# allowing for more detailed documentation of schema elements.
 - name: named_schema_override_description
   template: |
     ---
@@ -309,6 +360,9 @@
           schema:
             type: number
             description: an overridden foo
+
+# Tests nested named schemas, ensuring that complex schema structures
+# can be built up from named components.
 - name: nested_named_schema
   template: |
     ---

--- a/spec/variables.yaml
+++ b/spec/variables.yaml
@@ -1,6 +1,8 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
+# Tests variable substitution in templates, including provided variables,
+# default values, and variable overriding behavior.
 - name: basic
   template: |
     Hello, {{name}}!


### PR DESCRIPTION
fix(js): an issue with loose equality for helpers; add missing tests for some helpers #53 #54

RATIONALE:

Loose equality as espoused by JavaScript's coercive operators, e.g. `==` will not translate to Python and Go. Since these tests expect cross-runtime behavior to be consistent, we also ensure that they are type-safe across language runtimes.

ISSUES:
- [x] https://github.com/google/dotprompt/issues/53 (strict equality)
- [x] https://github.com/google/dotprompt/issues/54 (missing helpers)

CHANGELOG:

- [x] Add YAML spec tests for these helpers:
  - [x] history
  - [x] ifEquals
  - [x] section
  - [x] unlessEquals
- [x] Strict equality for ifEquals and unlessEquals
- [x] Add commentary explaining each test to help understanding
- [x] Update the Git hooks to run JS tests.