### PR TITLE
[PARKED] feat: add the ability to skip tests by runtime and flag #56

### DIFF
--- a/js/src/dotprompt.ts
+++ b/js/src/dotprompt.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import * as Handlebars from 'handlebars';

--- a/js/src/helpers.ts
+++ b/js/src/helpers.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { SafeString } from 'handlebars';

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { Dotprompt, DotpromptOptions } from './dotprompt.js';

--- a/js/src/parse.ts
+++ b/js/src/parse.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { parse } from 'yaml';

--- a/js/src/picoschema.ts
+++ b/js/src/picoschema.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { JSONSchema, SchemaResolver } from './types.js';

--- a/js/src/types.d.ts
+++ b/js/src/types.d.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 export type Schema = Record<string, any>;

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 export function removeUndefinedFields(obj: any): any {

--- a/js/test/spec.test.ts
+++ b/js/test/spec.test.ts
@@ -1,39 +1,196 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
-import { describe, expect, it, suite } from 'vitest';
+import { afterAll, describe, expect, it, suite } from 'vitest';
 import { parse } from 'yaml';
 import { Dotprompt } from '../src/dotprompt';
 import type { DataArgument, JSONSchema, ToolDefinition } from '../src/types';
 
-const specDir = join('..', 'spec');
-const files = readdirSync(specDir, { recursive: true, withFileTypes: true });
+// Define supported runtimes
+enum Runtime {
+  Go = 'go',
+  Python = 'python',
+  JavaScript = 'js',
+}
+
+interface TestCase {
+  id?: string;
+  desc?: string;
+  skip?: boolean;
+  runtimes?: Runtime[];
+  data: DataArgument;
+  expect: any;
+  options: object;
+}
 
 interface SpecSuite {
   name: string;
   template: string;
+  skip?: boolean;
+  runtimes?: Runtime[];
   data?: DataArgument;
   schemas?: Record<string, JSONSchema>;
   tools?: Record<string, ToolDefinition>;
   partials?: Record<string, string>;
   resolverPartials?: Record<string, string>;
-  tests: { desc?: string; data: DataArgument; expect: any; options: object }[];
+  tests: TestCase[];
 }
+
+const specDir = join('..', 'spec');
+const files = readdirSync(specDir, { recursive: true, withFileTypes: true });
+
+/**
+ * Determines whether a test should be skipped.
+ *
+ * @param test The test to check
+ * @param currentRuntime The current runtime in use; default 'js' for
+ *   this one.
+ * @return boolean indicating whether the test should be skipped.
+ */
+function shouldSkipTest(
+  test: Partial<TestCase> & { data: DataArgument },
+  currentRuntime: Runtime = Runtime.JavaScript
+): boolean {
+  if (test.skip) {
+    return true;
+  }
+  if (test.runtimes && !test.runtimes.includes(currentRuntime)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Determines whether a test suite should be skipped.
+ *
+ * @param suite The test suite to check
+ * @param currentRuntime The current runtime in use; default 'js' for
+ *   this one.
+ * @return boolean indicating whether the test suite should be skipped.
+ */
+function shouldSkipTestSuite(
+  suite: Partial<SpecSuite> & { tests: TestCase[] },
+  currentRuntime: Runtime = Runtime.JavaScript
+): boolean {
+  if (suite.skip) {
+    return true;
+  }
+  if (suite.runtimes && !suite.runtimes.includes(currentRuntime)) {
+    return true;
+  }
+  return false;
+}
+
+// Self-testing for harness.
+describe('harness', () => {
+  describe('shouldSkipTest', () => {
+    const baseTest: TestCase = {
+      desc: 'test',
+      data: {},
+      expect: { messages: [] },
+    };
+
+    it('returns true for explicitly skipped tests', () => {
+      expect(shouldSkipTest({ ...baseTest, skip: true })).toBe(true);
+    });
+
+    it('returns false for non-skipped tests without runtime constraints', () => {
+      expect(shouldSkipTest(baseTest)).toBe(false);
+    });
+
+    it('returns true when test requires different runtime', () => {
+      expect(shouldSkipTest({ ...baseTest, runtimes: [Runtime.Go] })).toBe(
+        true
+      );
+    });
+
+    it('returns false when test supports current runtime', () => {
+      expect(
+        shouldSkipTest({ ...baseTest, runtimes: [Runtime.JavaScript] })
+      ).toBe(false);
+    });
+
+    it('returns false when test supports multiple runtimes including current', () => {
+      expect(
+        shouldSkipTest({
+          ...baseTest,
+          runtimes: [Runtime.Go, Runtime.JavaScript],
+        })
+      ).toBe(false);
+    });
+
+    it('handles custom runtime parameter', () => {
+      expect(
+        shouldSkipTest(
+          { ...baseTest, runtimes: [Runtime.Python] },
+          Runtime.Python
+        )
+      ).toBe(false);
+      expect(
+        shouldSkipTest(
+          { ...baseTest, runtimes: [Runtime.JavaScript] },
+          Runtime.Python
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('shouldSkipTestSuite', () => {
+    const baseSuite = {
+      tests: [],
+      skip: false,
+    };
+
+    it('returns true for explicitly skipped suites', () => {
+      expect(shouldSkipTestSuite({ ...baseSuite, skip: true })).toBe(true);
+    });
+
+    it('returns false for non-skipped suites without runtime constraints', () => {
+      expect(shouldSkipTestSuite(baseSuite)).toBe(false);
+    });
+
+    it('returns true when suite requires different runtime', () => {
+      expect(
+        shouldSkipTestSuite({ ...baseSuite, runtimes: [Runtime.Go] })
+      ).toBe(true);
+    });
+
+    it('returns false when suite requires current runtime', () => {
+      expect(
+        shouldSkipTestSuite({ ...baseSuite, runtimes: [Runtime.JavaScript] })
+      ).toBe(false);
+    });
+
+    it('returns false when suite supports multiple runtimes including current', () => {
+      expect(
+        shouldSkipTestSuite({
+          ...baseSuite,
+          runtimes: [Runtime.Go, Runtime.JavaScript, Runtime.Python],
+        })
+      ).toBe(false);
+    });
+
+    it('handles custom runtime parameter', () => {
+      expect(
+        shouldSkipTestSuite(
+          { ...baseSuite, runtimes: [Runtime.Python] },
+          Runtime.Python
+        )
+      ).toBe(false);
+
+      expect(
+        shouldSkipTestSuite(
+          { ...baseSuite, runtimes: [Runtime.JavaScript] },
+          Runtime.Python
+        )
+      ).toBe(true);
+    });
+  });
+});
 
 // Process each YAML file
 files
@@ -49,73 +206,94 @@ files
 
     // Create a describe block for each YAML file
     suite(suiteName, () => {
-      // Create a describe block for each suite in the file
-      suites.forEach((s) => {
-        describe(s.name, () => {
-          // Create a test for each test case in the suite
-          s.tests.forEach((tc) => {
-            it(tc.desc || 'should match expected output', async () => {
-              const env = new Dotprompt({
-                schemas: s.schemas,
-                tools: s.tools,
-                partialResolver: (name: string) =>
-                  s.resolverPartials?.[name] || null,
-              });
+      // Process each suite in the YAML file
+      suites
+        .filter((s) => !shouldSkipTestSuite(s))
+        .forEach((s) => {
+          describe(s.name, () => {
+            s.tests.forEach((test) => {
+              // Create test title
+              const testTitle = [
+                test.id && `[${test.id}]`,
+                test.desc || 'unnamed test',
+                test.runtimes && `(runtimes: ${test.runtimes.join(', ')})`,
+              ]
+                .filter(Boolean)
+                .join(' ');
 
-              if (s.partials) {
-                for (const [name, template] of Object.entries(s.partials)) {
-                  env.definePartial(name, template);
+              // Skip test if explicitly marked or if runtime is not supported
+              const shouldSkip = shouldSkipTest(test, Runtime.JavaScript);
+              if (shouldSkip) {
+                it.skip(testTitle, () => {
+                  // Test body is not executed when skipped
+                });
+                return;
+              }
+
+              it(testTitle, async () => {
+                const env = new Dotprompt({
+                  schemas: s.schemas,
+                  tools: s.tools,
+                  partialResolver: (name: string) =>
+                    s.resolverPartials?.[name] || null,
+                });
+
+                if (s.partials) {
+                  for (const [name, template] of Object.entries(s.partials)) {
+                    env.definePartial(name, template);
+                  }
                 }
-              }
 
-              const result = await env.render(
-                s.template,
-                { ...s.data, ...tc.data },
-                tc.options
-              );
-              const { raw, ...prunedResult } = result;
-              const {
-                raw: expectRaw,
-                input: discardInputForRender,
-                ...expected
-              } = tc.expect;
-              expect(
-                prunedResult,
-                'render should produce the expected result'
-              ).toEqual({
-                ...expected,
-                ext: expected.ext || {},
-                config: expected.config || {},
-                metadata: expected.metadata || {},
-              });
-              // only compare raw if the spec demands it
-              if (tc.expect.raw) {
-                expect(raw).toEqual(expectRaw);
-              }
+                const result = await env.render(
+                  s.template,
+                  { ...s.data, ...test.data },
+                  test.options
+                );
+                const { raw, ...prunedResult } = result;
+                const {
+                  raw: expectRaw,
+                  input: discardInputForRender,
+                  ...expected
+                } = test.expect;
+                expect(
+                  prunedResult,
+                  'render should produce the expected result'
+                ).toEqual({
+                  ...expected,
+                  ext: expected.ext || {},
+                  config: expected.config || {},
+                  metadata: expected.metadata || {},
+                });
+                if (test.expect.raw) {
+                  expect(raw).toEqual(expectRaw);
+                }
 
-              const metadataResult = await env.renderMetadata(
-                s.template,
-                tc.options
-              );
-              const { raw: metadataResultRaw, ...prunedMetadataResult } =
-                metadataResult;
-              const {
-                messages,
-                raw: metadataExpectRaw,
-                ...expectedMetadata
-              } = tc.expect;
-              expect(
-                prunedMetadataResult,
-                'renderMetadata should produce the expected result'
-              ).toEqual({
-                ...expectedMetadata,
-                ext: expectedMetadata.ext || {},
-                config: expectedMetadata.config || {},
-                metadata: expectedMetadata.metadata || {},
+                const metadataResult = await env.renderMetadata(
+                  s.template,
+                  test.options
+                );
+                const { raw: metadataResultRaw, ...prunedMetadataResult } =
+                  metadataResult;
+                const {
+                  messages,
+                  raw: metadataExpectRaw,
+                  ...expectedMetadata
+                } = test.expect;
+                expect(
+                  prunedMetadataResult,
+                  'renderMetadata should produce the expected result'
+                ).toEqual({
+                  ...expectedMetadata,
+                  ext: expectedMetadata.ext || {},
+                  config: expectedMetadata.config || {},
+                  metadata: expectedMetadata.metadata || {},
+                });
+                if (metadataExpectRaw) {
+                  expect(metadataResultRaw).toEqual(metadataExpectRaw);
+                }
               });
             });
           });
         });
-      });
     });
   });


### PR DESCRIPTION
ISSUE: https://github.com/google/dotprompt/issues/56

RATIONALE:

Since we use YAML test suites to ensure that runtimes are at feature parity, while we are working on some of these and some runtimes are catching up, there are 2 ways in which to "catch up."

1. Maintain a list of working tests in the runtime code and add a way to identify the test. Over time the list would shrink as more features are implemented.

2. Add the ability to filter tests by runtime and flag to the test harness itself so that we can have a single source of truth indicating which tests work on which runtimes.

The first approach also requires adding a means to uniquely identify a test and the second one appears to be a feature of the test harness that would be useful later on if we have to deal with inconsistencies between runtimes. I believe the latter approach is more declarative and makes it easier to identify the tests that should be filtered at the point of declaration.

EXAMPLE:

```
zsh❯ pnpm -C js run test

> dotprompt@1.0.1 test /Users/yesudeep/code/github.com/google/dotprompt/js
> vitest --run

The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.

 RUN  v3.0.5 /Users/yesudeep/code/github.com/google/dotprompt/js

 ✓ test/stores/dir.test.ts (18 tests) 265ms
 ✓ test/spec.test.ts (58 tests | 1 skipped) 57ms

 Test Files  2 passed (2)
      Tests  75 passed | 1 skipped (76)
   Start at  13:07:38
   Duration  927ms (transform 161ms, setup 0ms, collect 513ms, tests 322ms, environment 0ms, prepare 246ms)
```

CHANGELOG:
- [ ] Update the `spec.test.ts` test harness implementation to filter tests based on runtime support and an explicit flag.
- [ ] Add some tests to the harness itself to ensure that the filtering works as expected.
- [ ] Autoformat license headers in source.

SCREENSHOTS:

Filter test by runtime:
<img width="1072" alt="skip-by-runtime" src="https://github.com/user-attachments/assets/f8154db8-60db-4b43-81a2-218c3b7b675a" />

Skip suite by flag:
<img width="1072" alt="skip-suite-by-flag" src="https://github.com/user-attachments/assets/5e93132c-2286-48b4-ac86-b8a1e8407d91" />

Filter suite by runtime:
<img width="1072" alt="skip-suite-by-runtime" src="https://github.com/user-attachments/assets/547bb979-c85b-41bb-9c1d-ef4a6cc5b849" />

Filter test by flag:
<img width="1072" alt="skip-tests-by-flag" src="https://github.com/user-attachments/assets/9e875ebb-cc36-45f8-8691-13cdea78cbea" />
