### PR TITLE
feat: add implementation of helpers and util modules; move interfaces into dotpromptz project

### DIFF
--- a/js/examples/adapters.ts
+++ b/js/examples/adapters.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { toGeminiRequest } from '../src/adapters/gemini.js';

--- a/js/src/adapters/gemini.ts
+++ b/js/src/adapters/gemini.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { Message, Part, RenderedPrompt } from '../types.js';

--- a/js/src/adapters/openai.ts
+++ b/js/src/adapters/openai.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { Message, Part, RenderedPrompt } from '../types.js';

--- a/js/src/dotprompt.ts
+++ b/js/src/dotprompt.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import * as Handlebars from 'handlebars';

--- a/js/src/helpers.ts
+++ b/js/src/helpers.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { SafeString } from 'handlebars';

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { Dotprompt, DotpromptOptions } from './dotprompt.js';

--- a/js/src/picoschema.ts
+++ b/js/src/picoschema.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { JSONSchema, SchemaResolver } from './types.js';

--- a/js/src/stores/dir.ts
+++ b/js/src/stores/dir.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { createHash } from 'crypto';

--- a/js/src/types.d.ts
+++ b/js/src/types.d.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 export type Schema = Record<string, any>;

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 export function removeUndefinedFields(obj: any): any {

--- a/js/test/spec.test.ts
+++ b/js/test/spec.test.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { readFileSync, readdirSync } from 'node:fs';

--- a/js/test/stores/dir.test.ts
+++ b/js/test/stores/dir.test.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { createHash } from 'crypto';

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -1,17 +1,6 @@
 /**
  * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 const { defineConfig } = require('vitest/config');

--- a/python/dotpromptz/src/dotpromptz/helpers.py
+++ b/python/dotpromptz/src/dotpromptz/helpers.py
@@ -1,0 +1,161 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Handlebars helper functions for dotprompt."""
+
+import json
+
+from handlebarz import HelperCallable, RenderCallable
+
+# TODO: All of these implementations are subject to change. I have included only
+# a basic implementation for now since I couldn't get the handlebars library to
+# work, I've used a stub in its place.
+#
+# TODO: Do we need a "SafeString" in Python to wrap the rendered output returned
+# by these helpers?
+
+
+def register_helpers(env: dict[str, HelperCallable]) -> None:
+    """Register all dotprompt helpers with the Handlebars environment.
+
+    Args:
+        env: Dictionary of helper functions to register.
+
+    Returns:
+        None
+    """
+    env['json'] = json_helper
+    env['role'] = role_helper
+    env['history'] = history_helper
+    env['section'] = section_helper
+    env['media'] = media_helper
+    env['ifEquals'] = if_equals_helper
+    env['unlessEquals'] = unless_equals_helper
+
+
+def json_helper(
+    text: str, render: RenderCallable, indent: int | None = None
+) -> str:
+    """Serialize a value to JSON with optional indentation.
+
+    Args:
+        text: The text to parse as JSON.
+        render: Function to render the template.
+        indent: Optional indentation level.
+
+    Returns:
+        JSON string representation of the value.
+    """
+    try:
+        value = json.loads(render(text))
+        if isinstance(indent, int):
+            return json.dumps(value, indent=indent)
+        return json.dumps(value)
+    except Exception as e:
+        return f'Error serializing JSON: {e}'
+
+
+def role_helper(text: str, render: RenderCallable) -> str:
+    """Generate a role marker.
+
+    Args:
+        text: The role name.
+        render: Function to render the template.
+
+    Returns:
+        Role marker string.
+    """
+    role = render(text)
+    return f'<<<dotprompt:role:{role}>>>'
+
+
+def history_helper(text: str, render: RenderCallable) -> str:
+    """Generate a history marker.
+
+    Args:
+        text: The text to render.
+        render: Function to render the template.
+
+    Returns:
+        History marker string.
+    """
+    return '<<<dotprompt:history>>>'
+
+
+def section_helper(text: str, render: RenderCallable) -> str:
+    """Generate a section marker.
+
+    Args:
+        text: The section name.
+        render: Function to render the template.
+
+    Returns:
+        Section marker string.
+    """
+    name = render(text)
+    return f'<<<dotprompt:section {name}>>>'
+
+
+def media_helper(text: str, render: RenderCallable) -> str:
+    """Generate a media marker.
+
+    Args:
+        text: The media URL and optional content type.
+        render: Function to render the template.
+
+    Returns:
+        Media marker string.
+    """
+    parts = render(text).split()
+    url = parts[0]
+    content_type = parts[1] if len(parts) > 1 else None
+
+    if content_type is not None:
+        return f'<<<dotprompt:media:url {url} {content_type}>>>'
+    return f'<<<dotprompt:media:url {url}>>>'
+
+
+def if_equals_helper(text: str, render: RenderCallable) -> str:
+    """Compare two values and render the block if they are equal.
+
+    Args:
+        text: The values to compare and template to render.
+        render: Function to render the template.
+
+    Returns:
+        Rendered content based on comparison.
+    """
+    parts = text.split('|')
+    if len(parts) != 3:
+        return ''
+
+    arg1 = render(parts[0].strip())
+    arg2 = render(parts[1].strip())
+    template = parts[2].strip()
+
+    if arg1 == arg2:
+        return render(template)
+    return ''
+
+
+def unless_equals_helper(text: str, render: RenderCallable) -> str:
+    """Compare two values and render the block if they are not equal.
+
+    Args:
+        text: The values to compare and template to render.
+        render: Function to render the template.
+
+    Returns:
+        Rendered content based on comparison.
+    """
+    parts = text.split('|')
+    if len(parts) != 3:
+        return ''
+
+    arg1 = render(parts[0].strip())
+    arg2 = render(parts[1].strip())
+    template = parts[2].strip()
+
+    if arg1 != arg2:
+        return render(template)
+    return ''

--- a/python/dotpromptz/src/dotpromptz/helpers_test.py
+++ b/python/dotpromptz/src/dotpromptz/helpers_test.py
@@ -1,0 +1,159 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dotprompt helpers."""
+
+import json
+import unittest
+
+import handlebarz
+from handlebarz import HelperCallable
+
+from dotpromptz.helpers import (
+    history_helper,
+    if_equals_helper,
+    json_helper,
+    media_helper,
+    register_helpers,
+    role_helper,
+    section_helper,
+    unless_equals_helper,
+)
+
+
+class TestHelpers(unittest.TestCase):
+    """Test cases for dotprompt helpers."""
+
+    helpers: dict[str, HelperCallable] = {}
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.helpers = {}
+        register_helpers(self.helpers)
+
+    def test_json_helper(self) -> None:
+        """Test JSON serialization helper."""
+
+        def render(text: str) -> str:
+            return text
+
+        data = {'name': 'test', 'value': 42}
+        json_str = json.dumps(data)
+
+        # Test without indentation
+        result = json_helper(json_str, render)
+        self.assertEqual(result, json.dumps(data))
+
+        # Test with indentation
+        result = json_helper(json_str, render, indent=2)
+        self.assertEqual(result, json.dumps(data, indent=2))
+
+        # Test error handling
+        result = json_helper('invalid json', render)
+        self.assertTrue(result.startswith('Error serializing JSON'))
+
+    def test_role_helper(self) -> None:
+        """Test role marker generation."""
+
+        def render(text: str) -> str:
+            return text
+
+        result = role_helper('user', render)
+        self.assertEqual(result, '<<<dotprompt:role:user>>>')
+
+    def test_history_helper(self) -> None:
+        """Test history marker generation."""
+
+        def render(text: str) -> str:
+            return text
+
+        result = history_helper('', render)
+        self.assertEqual(result, '<<<dotprompt:history>>>')
+
+    def test_section_helper(self) -> None:
+        """Test section marker generation."""
+
+        def render(text: str) -> str:
+            return text
+
+        result = section_helper('test', render)
+        self.assertEqual(result, '<<<dotprompt:section test>>>')
+
+    def test_media_helper(self) -> None:
+        """Test media marker generation."""
+
+        def render(text: str) -> str:
+            return text
+
+        # Test with content type
+        result = media_helper('test.png image/png', render)
+        self.assertEqual(result, '<<<dotprompt:media:url test.png image/png>>>')
+
+        # Test without content type
+        result = media_helper('test.png', render)
+        self.assertEqual(result, '<<<dotprompt:media:url test.png>>>')
+
+    def test_if_equals_helper(self) -> None:
+        """Test ifEquals helper."""
+
+        def render(text: str) -> str:
+            return text
+
+        # Test equal values
+        result = if_equals_helper('test | test | equal', render)
+        self.assertEqual(result, 'equal')
+
+        # Test unequal values
+        result = if_equals_helper('test | other | equal', render)
+        self.assertEqual(result, '')
+
+        # Test invalid format
+        result = if_equals_helper('test | other', render)
+        self.assertEqual(result, '')
+
+    def test_unless_equals_helper(self) -> None:
+        """Test unlessEquals helper."""
+
+        def render(text: str) -> str:
+            return text
+
+        # Test equal values
+        result = unless_equals_helper('test | test | not equal', render)
+        self.assertEqual(result, '')
+
+        # Test unequal values
+        result = unless_equals_helper('test | other | not equal', render)
+        self.assertEqual(result, 'not equal')
+
+        # Test invalid format
+        result = unless_equals_helper('test | other', render)
+        self.assertEqual(result, '')
+
+    def test_template_rendering(self) -> None:
+        """Test helpers in actual template rendering."""
+        template = """
+        {{#json}}{"test": "value"}{{/json}}
+        {{#role}}user{{/role}}
+        {{#history}}{{/history}}
+        {{#section}}test{{/section}}
+        {{#media}}test.png image/png{{/media}}
+        {{#ifEquals}}a | a | equal{{/ifEquals}}
+        {{#unlessEquals}}a | b | not equal{{/unlessEquals}}
+        """
+
+        result = handlebarz.render(
+            template, data={}, partials={}, helpers=self.helpers
+        )
+
+        expected_json = json.dumps({'test': 'value'})
+        self.assertIn(expected_json, result)
+        self.assertIn('<<<dotprompt:role:user>>>', result)
+        self.assertIn('<<<dotprompt:history>>>', result)
+        self.assertIn('<<<dotprompt:section test>>>', result)
+        self.assertIn('<<<dotprompt:media:url test.png image/png>>>', result)
+        self.assertIn('equal', result)
+        self.assertIn('not equal', result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/dotpromptz/src/dotpromptz/interfaces.py
+++ b/python/dotpromptz/src/dotpromptz/interfaces.py
@@ -50,29 +50,29 @@ class PromptData(PromptRef):
 
 @dataclass
 class PromptMetadata(HasMetadata, Generic[T]):
-    """Promt metdata.
+    """Prompt metadata.
 
     Attributes:
-      name: The name of the prompt.
-      variant: The variant name for the prompt.
-      version: The version of the prompt.
-      description: A description of the prompt.
-      model: The name of the model to use for this prompt, e.g.
-        `vertexai/gemini-1.0-pro`.
-      tools: Names of tools (registered separately) to allow use of in this
-        prompt.
-      tool_defs: Definitions of tools to allow use of in this prompt.
-      config: Model configuration. Not all models support all options.
-      input: Configuration for input variables.
-      output: Defines the expected model output format.
-      raw: This field will contain the raw frontmatter as parsed with no
-        additional processing or substitutions. If your implementation requires
-        custom fields they will be available here.
-      ext: Fields that contain a period will be considered "extension fields" in
-        the frontmatter and will be gathered by namespace. For example,
-        `myext.foo: 123` would be available at `parsedPrompt.ext.myext.foo`.
-        Nested namespaces will be flattened, so `myext.foo.bar: 123` would be
-        available at `parsedPrompt.ext["myext.foo"].bar`.
+        name: The name of the prompt.
+        variant: The variant name for the prompt.
+        version: The version of the prompt.
+        description: A description of the prompt.
+        model: The name of the model to use for this prompt, e.g.
+            `vertexai/gemini-1.0-pro`.
+        tools: Names of tools (registered separately) to allow use of in this
+            prompt.
+        tool_defs: Definitions of tools to allow use of in this prompt.
+        config: Model configuration. Not all models support all options.
+        input: Configuration for input variables.
+        output: Defines the expected model output format.
+        raw: This field will contain the raw frontmatter as parsed with no
+            additional processing or substitutions. If your implementation
+            requires custom fields they will be available here.
+        ext: Fields that contain a period will be considered "extension fields"
+            in the frontmatter and will be gathered by namespace. For example,
+            `myext.foo: 123` would be available at `parsedPrompt.ext.myext.foo`.
+            Nested namespaces will be flattened, so `myext.foo.bar: 123` would
+            be available at `parsedPrompt.ext["myext.foo"].bar`.
     """
 
     name: str | None = None
@@ -169,7 +169,7 @@ class DataArgument(Generic[T]):
     context: dict[str, Any] | None = None
 
 
-type JsonSchema = Any
+type JSONSchema = Any
 
 
 class SchemaResolver(Protocol):
@@ -178,7 +178,7 @@ class SchemaResolver(Protocol):
     Utilized for shorthand to a schema library provided by an external tool.
     """
 
-    def __call__(self, schema_name: str) -> JsonSchema | None: ...
+    def __call__(self, schema_name: str) -> JSONSchema | None: ...
 
 
 class ToolResolver(Protocol):

--- a/python/dotpromptz/src/dotpromptz/util.py
+++ b/python/dotpromptz/src/dotpromptz/util.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utility functions for dotpromptz."""
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def remove_undefined_fields(obj: Any) -> Any:
+    """Remove undefined fields from an object recursively.
+
+    Args:
+        obj: Object to process.
+
+    Returns:
+        Object with undefined fields removed.
+    """
+    if obj is None or not isinstance(obj, Mapping | Sequence):
+        return obj
+
+    if isinstance(obj, Sequence) and not isinstance(obj, str | bytes):
+        return [
+            remove_undefined_fields(item) for item in obj if item is not None
+        ]
+
+    if isinstance(obj, Mapping):
+        return {
+            key: remove_undefined_fields(value)
+            for key, value in obj.items()
+            if value is not None
+        }
+
+    return obj

--- a/python/dotpromptz/src/dotpromptz/util_test.py
+++ b/python/dotpromptz/src/dotpromptz/util_test.py
@@ -1,0 +1,78 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for utility functions."""
+
+import unittest
+
+from dotpromptz.util import remove_undefined_fields
+
+
+class TestRemoveUndefinedFields(unittest.TestCase):
+    def test_remove_undefined_fields_none(self) -> None:
+        """Test removing undefined fields from None."""
+        assert remove_undefined_fields(None) is None
+
+    def test_remove_undefined_fields_primitive(self) -> None:
+        """Test removing undefined fields from primitive types."""
+        assert remove_undefined_fields(42) == 42
+        assert remove_undefined_fields('test') == 'test'
+        assert remove_undefined_fields(True) is True
+
+    def test_remove_undefined_fields_list(self) -> None:
+        """Test removing undefined fields from lists."""
+        input_list = [1, None, {'a': 2, 'b': None}, [3, None, 4]]
+        expected = [1, {'a': 2}, [3, 4]]
+        result = remove_undefined_fields(input_list)
+        assert result == expected, f'Expected {expected}, but got {result}'
+
+    def test_remove_undefined_fields_dict(self) -> None:
+        """Test removing undefined fields from dictionaries."""
+        input_dict = {
+            'a': 1,
+            'b': None,
+            'c': {'d': 2, 'e': None},
+            'f': [3, None, {'g': 4, 'h': None}],
+        }
+        expected = {
+            'a': 1,
+            'c': {'d': 2},
+            'f': [3, {'g': 4}],
+        }
+        result = remove_undefined_fields(input_dict)
+        assert result == expected, f'Expected {expected}, but got {result}'
+
+    def test_remove_undefined_fields_nested(self) -> None:
+        """Test removing undefined fields from nested structures."""
+        input_data = {
+            'a': {
+                'b': [
+                    {'c': 1, 'd': None},
+                    None,
+                    {'e': {'f': 2, 'g': None}},
+                ],
+                'h': None,
+            },
+            'i': None,
+        }
+        expected = {
+            'a': {
+                'b': [
+                    {'c': 1},
+                    {'e': {'f': 2}},
+                ],
+            },
+        }
+        result = remove_undefined_fields(input_data)
+        assert result == expected, f'Expected {expected}, but got {result}'
+
+    def test_remove_undefined_fields_empty(self) -> None:
+        """Test removing undefined fields from empty structures."""
+        assert remove_undefined_fields({}) == {}
+        assert remove_undefined_fields([]) == []
+        assert remove_undefined_fields({'a': {}}) == {'a': {}}
+        assert remove_undefined_fields({'a': []}) == {'a': []}
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/dotpromptz/src/handlebarz/__init__.py
+++ b/python/dotpromptz/src/handlebarz/__init__.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Handlebars template engine stub while we don't have a working implementation
+of handlebars."""
+
+from collections.abc import Callable
+from typing import Any
+
+# Defines a function that takes a string and returns a string.
+RenderCallable = Callable[[str], str]
+
+# Defines a helper function that takes a string and a render function and
+# returns a string.
+HelperCallable = Callable[[str, RenderCallable], str]
+
+
+def render(
+    template: str,
+    data: dict[str, Any],
+    partials: dict[str, str],
+    helpers: dict[str, HelperCallable],
+) -> str:
+    """Render a template with the given data, partials, and helpers.
+
+    Args:
+        template: The template to render.
+        data: The data to render the template with.
+        partials: The partials to render the template with.
+        helpers: The helpers to render the template with.
+
+    Returns:
+        The rendered template.
+    """
+    # TODO: Implement the rendering logic.
+    return 'TODO'
+
+
+__all__ = ['render', 'RenderCallable', 'HelperCallable']


### PR DESCRIPTION
feat: add implementation of helpers and util modules; move interfaces into dotpromptz project

CHANGELOG:
- [ ] Add an implementation of `helpers.py` and tests.
- [ ] Add an implementatin of `util.py` and tests.
- [ ] Move the `interfaces.py` module into the `dotpromptz` project.
- [ ] Add a stub implementation of `handlebarz` until we get `handlebars-py` working.
- [ ] Shorten JS license headers.