### PR TITLE
refactor(py): use the typing naming convention used by Pythonic libraries for type hint modules

### DIFF
--- a/python/dotpromptz/src/dotpromptz/typing.py
+++ b/python/dotpromptz/src/dotpromptz/typing.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Data models and interfaces definition."""
+"""Data models and interfaces type definitions."""
 
 from dataclasses import dataclass, field
 from typing import Any, Generic, Literal, Protocol, TypeVar


### PR DESCRIPTION
    RATIONALE:

    The convention in Python used by several libraries for names of modules
    containing type hints is `typing`. For example, the ASGI ref module from
    Django called `asgiref` also uses this convention as does the standard
    Python module `typing`. Other libraries include:

    - [ ] asgiref
    - [ ] sqlalchemy-stubs
    - [ ] sqlalchemy2-stubs
    - [ ] celery-types
    - [ ] djangoframework-stubs
