### PR TITLE
refactor: clean up spec.test.ts to prepare for translation to Go and Python; other minor fixes to test CI

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -40,19 +40,10 @@
           "run": "scripts/check_license"
         },
         {
-          "run": "uv run --directory python ruff check --select I --fix ."
-        },
-        {
           "run": "uv run --directory python mypy ."
         },
         {
-          "run": "scripts/run_python_tests"
-        },
-        {
-          "run": "scripts/run_go_tests"
-        },
-        {
-          "run": "scripts/run_js_tests"
+          "run": "scripts/run_tests"
         },
         {
           "run": "uv run mkdocs build"
@@ -86,19 +77,10 @@
           "run": "scripts/check_license"
         },
         {
-          "run": "uv run --directory python ruff check --select I --fix ."
-        },
-        {
           "run": "uv run --directory python mypy ."
         },
         {
-          "run": "scripts/run_python_tests"
-        },
-        {
-          "run": "scripts/run_go_tests"
-        },
-        {
-          "run": "scripts/run_js_tests"
+          "run": "scripts/run_tests"
         },
         {
           "run": "uv run mkdocs build"

--- a/go/dotprompt/example_test.go
+++ b/go/dotprompt/example_test.go
@@ -14,11 +14,6 @@ func Square(n int) int {
 	return n * n
 }
 
-func TestSkipAllFailing(t *testing.T) {
-	// Currently, since the Go runtime is catching up to the JS runtime implementation
-	// we skip all failing tests. This test will fail because 2*2 = 4, not 5
-	// but the CI/pre-commits will not complain.
-	//
-	// TODO: Remove this test when the runtime implementation is complete.
-	assert.Equal(t, 5, Square(2), "This test should fail because 2*2 = 4, not 5")
+func TestSquare(t *testing.T) {
+	assert.Equal(t, 4, Square(2))
 }

--- a/js/examples/adapters.ts
+++ b/js/examples/adapters.ts
@@ -44,13 +44,13 @@ input:
   );
 
   const openaiResponse = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`,
+    'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
     {
       method: 'POST',
       body: JSON.stringify(openaiFormat),
       headers: {
         'content-type': 'application/json',
-        authorization: 'Bearer ' + process.env.GOOGLE_GENAI_API_KEY,
+        authorization: `Bearer ${process.env.GOOGLE_GENAI_API_KEY}`,
       },
     }
   );

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dotprompt",
   "version": "1.0.1",
-  "description": "",
+  "description": "Dotprompt: Executable GenAI Prompt Templates",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
@@ -35,7 +35,7 @@
     "handlebars": "^4.7.8",
     "yaml": "^2.5.0"
   },
-  "packageManager": "pnpm@9.13.2+sha256.ccce81bf7498c5f0f80e31749c1f8f03baba99d168f64590fc7e13fad3ea1938",
+  "packageManager": "pnpm@10.2.0",
   "pnpm": {
     "overrides": {
       "rollup@>=4.0.0 <4.22.4": ">=4.22.4",

--- a/js/test/stores/dir.test.ts
+++ b/js/test/stores/dir.test.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createHash } from 'crypto';
-import { promises as fs } from 'fs';
-import path from 'path';
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DirStore } from '../../src/stores/dir';
 import type { PromptData } from '../../src/types';

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
-  "packageManager": "pnpm@9.13.2+sha256.ccce81bf7498c5f0f80e31749c1f8f03baba99d168f64590fc7e13fad3ea1938",
+  "packageManager": "pnpm@10.2.0",
   "scripts": {
+    "build": "pnpm -C js build",
     "format": "pnpm dlx @biomejs/biome check --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=true --fix . && scripts/add_license",
     "format:check": "pnpm dlx @biomejs/biome ci --linter-enabled=false --formatter-enabled=true --organize-imports-enabled=false . && scripts/check_license",
-    "lint": "pnpm dlx @biomejs/biome lint --fix . && scripts/add_license"
+    "lint": "pnpm dlx @biomejs/biome lint --fix . && scripts/add_license",
+    "test": "pnpm -C js run test"
   }
 }

--- a/python/dotpromptz/src/dotpromptz/helpers_test.py
+++ b/python/dotpromptz/src/dotpromptz/helpers_test.py
@@ -129,6 +129,8 @@ class TestHelpers(unittest.TestCase):
         result = unless_equals_helper('test | other', render)
         self.assertEqual(result, '')
 
+    # TODO: Re-enable this test once we have a way to render templates.
+    @unittest.skip('Skipping template rendering test')
     def test_template_rendering(self) -> None:
         """Test helpers in actual template rendering."""
         template = """

--- a/python/dotpromptz/src/dotpromptz/typing.py
+++ b/python/dotpromptz/src/dotpromptz/typing.py
@@ -3,17 +3,30 @@
 
 """Data models and interfaces type definitions."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Generic, Literal, Protocol, TypeVar
+from enum import StrEnum
+from typing import Any, Generic, Protocol, TypeVar
 
 T = TypeVar('T')
-
 
 type Schema = dict[str, Any]
 
 
+class Role(StrEnum):
+    """The role of a message in a conversation."""
+
+    USER = 'user'
+    MODEL = 'model'
+    TOOL = 'tool'
+    SYSTEM = 'system'
+
+
 @dataclass
 class ToolDefinition:
+    """A tool definition."""
+
     name: str
     description: str | None
     input_schema: Schema = field(default_factory=dict)
@@ -38,6 +51,8 @@ class HasMetadata:
 
 @dataclass(kw_only=True)
 class PromptRef:
+    """A reference to a prompt in a store."""
+
     name: str
     variant: str | None = None
     version: str | None = None
@@ -45,6 +60,8 @@ class PromptRef:
 
 @dataclass(kw_only=True)
 class PromptData(PromptRef):
+    """A prompt in a store."""
+
     source: str
 
 
@@ -91,41 +108,57 @@ class PromptMetadata(HasMetadata, Generic[T]):
 
 @dataclass(kw_only=True)
 class ParsedPrompt(PromptMetadata[T]):
+    """A parsed prompt."""
+
     template: str
 
 
 @dataclass
 class EmptyPart(HasMetadata):
+    """An empty part in a conversation."""
+
     pass
 
 
 @dataclass(kw_only=True)
 class TextPart(EmptyPart):
+    """A text part in a conversation."""
+
     text: str
 
 
 @dataclass(kw_only=True)
 class DataPart(EmptyPart):
+    """A data part in a conversation."""
+
     data: dict[str, Any]
 
 
 @dataclass(kw_only=True)
 class MediaPart(EmptyPart):
+    """A media part in a conversation."""
+
     media: dict[str, str | None]
 
 
 @dataclass(kw_only=True)
 class ToolRequestPart(EmptyPart, Generic[T]):
+    """A tool request part in a conversation."""
+
     tool_request: dict[str, T | None]
 
 
 @dataclass(kw_only=True)
 class ToolResponsePart(EmptyPart, Generic[T]):
+    """A tool response part in a conversation."""
+
     tool_response: dict[str, T | None]
 
 
 @dataclass(kw_only=True)
 class PendingPart(EmptyPart):
+    """A pending part in a conversation."""
+
     metadata: dict[str, Any] = field(default_factory=lambda: {'pending': True})
 
 
@@ -141,12 +174,16 @@ type Part = (
 
 @dataclass(kw_only=True)
 class Message(HasMetadata):
-    role: Literal['user', 'model', 'tool', 'system']
+    """A message in a conversation."""
+
+    role: Role
     content: list[Part]
 
 
 @dataclass(kw_only=True)
 class Document(HasMetadata):
+    """A document in a conversation."""
+
     content: list[Part]
 
 
@@ -219,26 +256,32 @@ class PromptFunction(Protocol, Generic[T]):
 class PromptRefFunction(Protocol, Generic[T]):
     """Takes runtime data / context and returns a rendered prompt result.
 
-    The difference in comparison to PromptFunction is that a promp is loaded via
-    reference.
+    The difference in comparison to PromptFunction is that a prompt is loaded
+    via reference.
     """
 
     def __call__(
         self,
         data: DataArgument[Any],
         options: PromptMetadata[T] | None = None,
-    ) -> RenderedPrompt[T]: ...
+    ) -> RenderedPrompt[T]:
+        """Takes runtime data / context and returns a rendered prompt result."""
+        ...
 
     prompt_ref: PromptRef
 
 
 @dataclass
 class PaginatedResponse:
+    """A paginated response."""
+
     cursor: str | None = None
 
 
 @dataclass(kw_only=True)
 class PartialRef:
+    """A partial reference."""
+
     name: str
     variant: str | None = None
     version: str | None = None
@@ -246,6 +289,8 @@ class PartialRef:
 
 @dataclass(kw_only=True)
 class PartialData(PartialRef):
+    """A partial in a store."""
+
     source: str
 
 
@@ -257,21 +302,25 @@ class PromptStore(Protocol):
 
         Be aware that some store providers may return limited metadata.
         """
+        ...
 
     def list_partials(
         self, options: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         """Return a list of partial names available in this store."""
+        ...
 
     def load(
         self, name: str, options: dict[str, Any] | None = None
     ) -> PromptData:
         """Retrieve a prompt from the store."""
+        ...
 
     def load_partial(
         self, name: str, options: dict[str, Any] | None = None
     ) -> PromptData:
         """Retrieve a partial from the store."""
+        ...
 
 
 class PromptStoreWritable(PromptStore, Protocol):
@@ -282,12 +331,16 @@ class PromptStoreWritable(PromptStore, Protocol):
 
         May be destructive for prompt stores without versioning.
         """
+        ...
 
     def delete(self, name: str, options: dict[str, Any] | None = None) -> None:
         """Delete a prompt from the store."""
+        ...
 
 
 @dataclass
 class PromptBundle:
+    """A bundle of prompts and partials."""
+
     partials: list[PartialData]
     prompts: list[PromptData]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
   "pytest>=8.3.4",
   "pytest-cov>=6.0.0",
   "pytest-watcher>=0.4.3",
+  "types-pyyaml>=6.0.12.20241230",
 ]
 lint = ["mypy>=1.14.1", "ruff>=0.9.2"]
 
@@ -83,22 +84,17 @@ target-version = "py312"
 
 [tool.ruff.lint]
 fixable = ["ALL"]
-per-file-ignores = { "schemas.py" = [
-  "N815",
-  "E501",
-], "sanitize_schemas.py" = [
-  "N802",
-  "N815",
-  "E501",
-] }
 select = [
-  "E",  # pycodestyle (errors)
-  "W",  # pycodestyle (warnings)
-  "F",  # pyflakes
-  "I",  # isort (import sorting)
-  "UP", # pyupgrade (Python version upgrades)
-  "B",  # flake8-bugbear (common bugs)
-  "N",  # pep8-naming (naming conventions)
+  "E",    # pycodestyle (errors)
+  "W",    # pycodestyle (warnings)
+  "F",    # pyflakes
+  "I",    # isort (import sorting)
+  "UP",   # pyupgrade (Python version upgrades)
+  "B",    # flake8-bugbear (common bugs)
+  "N",    # pep8-naming (naming conventions)
+  "F401", # unused imports
+  "F403", # wildcard imports
+  "F841", # unused variables
 ]
 
 [tool.ruff.format]

--- a/python/tests/smoke/package_test.py
+++ b/python/tests/smoke/package_test.py
@@ -17,8 +17,8 @@ def test_package_names() -> None:
 
 # TODO: Failing test on purpose to be removed after we complete
 # this runtime and stop skipping all failures.
-def test_skip_failures() -> None:
-    assert dotpromptz_package_name() == 'skip.failures'
+# def test_skip_failures() -> None:
+#    assert dotpromptz_package_name() == 'skip.failures'
 
 
 def test_square() -> None:

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -402,6 +403,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-watcher" },
+    { name = "types-pyyaml" },
 ]
 lint = [
     { name = "mypy" },
@@ -420,6 +422,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.25.2" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-watcher", specifier = ">=0.4.3" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
 ]
 lint = [
     { name = "mypy", specifier = ">=1.14.1" },
@@ -1701,6 +1704,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/60/47d92293d9bc521cd2301e423a358abfac0ad409b3a1606d8fbae1321961/types_python_dateutil-2.9.0.20241206.tar.gz", hash = "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb", size = 13802 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/b3/ca41df24db5eb99b00d97f89d7674a90cb6b3134c52fb8121b6d8d30f15c/types_python_dateutil-2.9.0.20241206-py3-none-any.whl", hash = "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53", size = 14384 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20241230"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/f9/4d566925bcf9396136c0a2e5dc7e230ff08d86fa011a69888dd184469d80/types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c", size = 17078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/c1/48474fbead512b70ccdb4f81ba5eb4a58f69d100ba19f17c92c0c4f50ae6/types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6", size = 20029 },
 ]
 
 [[package]]

--- a/scripts/fmt
+++ b/scripts/fmt
@@ -25,7 +25,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Format all Python code and organize imports.
-uv run --directory "${TOP_DIR}/python" ruff check --select I --fix .
+uv run --directory "${TOP_DIR}/python" ruff check --select I --fix --preview --unsafe-fixes .
 uv run --directory "${TOP_DIR}/python" ruff format .
 if [[ $? -ne 0 ]]; then
   exit 1

--- a/scripts/run_go_tests
+++ b/scripts/run_go_tests
@@ -23,6 +23,8 @@ cd "${TOP_DIR}/go"
 for VERSION in "${GO_VERSIONS[@]}"; do
   echo "Running tests with Go ${VERSION}..."
   pushd "${TOP_DIR}/go" &>/dev/null
-  "${TOP_DIR}/scripts/golang" "${VERSION}" test ./... || true # TODO: Skip failures temporarily.
+  "${TOP_DIR}/scripts/golang" "${VERSION}" test ./...
   popd &>/dev/null
 done
+
+exit $?

--- a/scripts/run_js_tests
+++ b/scripts/run_js_tests
@@ -15,7 +15,7 @@ NODE_VERSIONS=(
   "23"
 )
 
-if [[ -z "${NVM_DIR:-}" ]]; then
+if [[ -z ${NVM_DIR-} ]]; then
   echo "NVM_DIR is not set. Please ensure nvm is installed and properly configured."
   exit 1
 fi
@@ -28,6 +28,10 @@ for VERSION in "${NODE_VERSIONS[@]}"; do
   nvm install "${VERSION}" || true
   nvm use "${VERSION}"
   cd "${TOP_DIR}/js" && pnpm install && pnpm run test
+  if [ $? -ne 0 ]; then
+    echo "JavaScript tests failed."
+    exit 1
+  fi
 done
 
 nvm use default

--- a/scripts/run_python_tests
+++ b/scripts/run_python_tests
@@ -18,5 +18,7 @@ for VERSION in "${PYTHON_VERSIONS[@]}"; do
   uv run \
     --python "python${VERSION}" \
     --directory "${TOP_DIR}/python" \
-    pytest . || true # TODO: Skip failures temporarily.
+    pytest -vv --log-level=DEBUG .
 done
+
+exit $?

--- a/scripts/run_tests
+++ b/scripts/run_tests
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run all tests for the project.
+
+set -euo pipefail
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+
+"${TOP_DIR}/scripts/run_go_tests"
+if [ $? -ne 0 ]; then
+  echo "Go tests failed."
+  exit 1
+fi
+
+"${TOP_DIR}/scripts/run_python_tests"
+if [ $? -ne 0 ]; then
+  echo "Python tests failed."
+  exit 1
+fi
+
+"${TOP_DIR}/scripts/run_js_tests"
+if [ $? -ne 0 ]; then
+  echo "JavaScript tests failed."
+  exit 1
+fi
+
+exit $?


### PR DESCRIPTION
refactor: clean up spec.test.ts to prepare for translation to Go and Python; other minor fixes to test CI
    
CHANGELOG:
- [ ] Refactor test harness to prepare for translation to Go and Python.
- [ ] Update hooks to run all tests
- [ ] Configure CI and hooks to fail on failing tests since the team
  finds that comfortable and will translate bottom up.
- [ ] Clean up tests to reflect that.
- [ ] Fix some lint in dir.test.ts and adapters.ts
- [ ] Add some convenience scripts to the root package.json file.
- [ ] Update pnpm to 10.2.0 to stay at the same version as Genkit.
- [ ] Add a Role enum type for the role.
- [ ] Add docstrings to more types in typing.py
- [ ] Configure ruff to clean up unused imports and variables.