### PR TITLE
feat(go): add types.go implementation

### DIFF
--- a/go/dotprompt/doc.go
+++ b/go/dotprompt/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Package dotprompt provides functionality for parsing and working with
+// dotprompt templates.
+//
+// Dotprompt is a format for defining prompts for large language models (LLMs)
+// with support for templating, history management, and multi-modal content.
+// This Go implementation provides types and functions for parsing dotprompt
+// templates and converting them into structured messages that can be sent to
+// LLM APIs.
+//
+// The package includes:
+//   - Type definitions for messages, parts, documents, and other dotprompt
+//   concepts
+//   - Functions for parsing dotprompt templates into structured data
+//   - Utilities for handling message history and multi-modal content
+//   - Support for extracting and processing frontmatter metadata
+package dotprompt

--- a/go/dotprompt/types.go
+++ b/go/dotprompt/types.go
@@ -1,0 +1,332 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dotprompt
+
+import (
+	"encoding/json"
+)
+
+// Schema represents a generic schema definition.
+type Schema map[string]interface{}
+
+// ToolDefinition defines a tool that can be used in a prompt.
+type ToolDefinition struct {
+	Name         string  `json:"name"`
+	Description  string `json:"description,omitempty"`
+	InputSchema  Schema  `json:"inputSchema"`
+	OutputSchema Schema  `json:"outputSchema,omitempty"`
+}
+
+// ToolArgument can be either a string or a ToolDefinition.
+type ToolArgument interface{}
+
+// IsToolArgument returns true if the argument is a string or a ToolDefinition.
+func IsToolArgument(arg interface{}) bool {
+	_, okString := arg.(string)
+	if okString {
+		return true
+	}
+	_, okDefinition := arg.(ToolDefinition)
+	if okDefinition {
+		return true
+	}
+	return false
+}
+
+// Metadata is a generic map of string keys to any values.
+type Metadata map[string]interface{}
+
+// HasMetadata is an internal interface for types that can have metadata.
+type HasMetadata interface {
+	Metadata Metadata `json:"metadata,omitempty"`
+}
+
+// PromptRef references a prompt in a store.
+type PromptRef struct {
+	Name    string  `json:"name"`
+	Variant string `json:"variant,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// PromptData represents a prompt with its source content.
+type PromptData struct {
+	PromptRef
+	Source string `json:"source"`
+}
+
+// ModelConfig represents model-specific configuration.
+//
+// See: Definition for ModelConfig as PromptMetadata generic type in types.d.ts
+// for more information.
+type ModelConfig map[string]interface{}
+
+// Input represents the configuration for input variables.
+type PromptMetadataInput struct {
+	Default map[string]interface{} `json:"default,omitempty"`
+	Schema  Schema                 `json:"schema,omitempty"`
+}
+
+// Output represents the desired output format for a prompt.
+type PromptMetadataOutput struct {
+	Format string `json:"format,omitempty"`
+	Schema Schema `json:"schema,omitempty"`
+}
+
+// PromptMetadata contains metadata about a prompt.
+type PromptMetadata struct {
+	HasMetadata
+	// The name of the prompt.
+	Name        string                   `json:"name,omitempty"`
+	// The variant name for the prompt.
+	Variant     string                   `json:"variant,omitempty"`
+	// The version of the prompt.
+	Version     string                   `json:"version,omitempty"`
+	// A description of the prompt.
+	Description string                   `json:"description,omitempty"`
+	// The name of the model to use for this prompt, e.g. `vertexai/gemini-1.0-pro`
+	Model       string                   `json:"model,omitempty"`
+	// Names of tools (registered separately) to allow use of in this prompt.
+	Tools       []string                  `json:"tools,omitempty"`
+	// Definitions of tools to allow use of in this prompt.
+	ToolDefs    []ToolDefinition          `json:"toolDefs,omitempty"`
+	// Model configuration. Not all models support all options.
+	Config      ModelConfig               `json:"config,omitempty"`
+	// Configuration for input variables.
+	Input       PromptMetadataInput       `json:"input,omitempty"`
+	// Defines the expected model output format.
+	Output      PromptMetadataOutput      `json:"output,omitempty"`
+	// This field will contain the raw frontmatter as parsed with no additional
+	// processing or substitutions. If your implementation requires custom
+	// fields they will be available here.
+	Raw map[string]interface{} `json:"raw,omitempty"`
+	// Fields that contain a period will be considered "extension fields" in the
+	// frontmatter and will be gathered by namespace. For example, `myext.foo:
+	// 123` would be available at `parsedPrompt.ext.myext.foo`. Nested
+	// namespaces will be flattened, so `myext.foo.bar: 123` would be available
+	// at `parsedPrompt.ext["myext.foo"].bar`.
+	Ext map[string]map[string]any `json:"ext,omitempty"`
+}
+
+// ParsedPrompt represents a parsed prompt template with metadata.
+type ParsedPrompt struct {
+	PromptMetadata
+	// The source of the template with metadata / frontmatter already removed.
+	Template string `json:"template"`
+}
+
+// Part represents a part of a message content.
+type Part interface {
+	HasMetadata
+}
+
+// TextPart represents a text part of a message.
+type TextPart struct {
+	Part
+	Text string `json:"text"`
+}
+
+// DataPart represents a data part of a message.
+type DataPart struct {
+	Part
+	Data map[string]interface{} `json:"data"`
+}
+
+// MediaPart represents a media part of a message.
+type MediaPart struct {
+	Part
+	Media struct {
+		URL         string `json:"url"`
+		ContentType string `json:"contentType,omitempty"`
+	} `json:"media"`
+}
+
+// ToolRequestPart represents a tool request part of a message.
+type ToolRequestPart struct {
+	Part
+	ToolRequest map[string]interface{} `json:"toolRequest"`
+}
+
+// ToolResponsePart represents a tool response part of a message.
+type ToolResponsePart struct {
+	Part
+	ToolResponse map[string]interface{} `json:"toolResponse"`
+}
+
+// PendingPart represents a pending part of a message.
+type PendingPart struct {
+	Part
+}
+
+// NewPendingPart creates a new PendingPart with the pending flag set to true.
+func NewPendingPart() *PendingPart {
+	return &PendingPart{
+		Metadata: map[string]interface{}{
+			"pending": true,
+		},
+	}
+}
+
+// IsPending returns true if the pending flag is set to true.
+func (p *PendingPart) IsPending() bool {
+	return p.Metadata["pending"].(bool)
+}
+
+// SetPending sets the pending flag to the given value.
+func (p *PendingPart) SetPending(enabled bool) {
+	p.Metadata["pending"] = enabled
+}
+
+// Role represents the role of a message in a conversation.
+type Role string
+
+// Predefined roles.
+const (
+	RoleUser   Role = "user"
+	RoleModel  Role = "model"
+	RoleTool   Role = "tool"
+	RoleSystem Role = "system"
+)
+
+// Message represents a message in a conversation.
+type Message struct {
+	HasMetadata
+	Role    Role    `json:"role"`
+	Content []Part  `json:"content"`
+}
+
+// Document represents a document with content parts.
+type Document struct {
+	HasMetadata
+	Content []Part `json:"content"`
+}
+
+// DataArgument provides all of the information necessary to render a template
+// at runtime.
+type DataArgument struct {
+	// Input variables for the prompt template.
+	Input map[string]interface{} `json:"input,omitempty"`
+	// Relevant documents.
+	Docs []Document `json:"docs,omitempty"`
+	// Previous messages in the history of a multi-turn conversation.
+	Messages []Message `json:"messages,omitempty"`
+	// Items in the context argument are exposed as `@` variables, e.g.
+	// `context: {state: {...}}` is exposed as `@state`.
+	Context map[string]interface{} `json:"context,omitempty"`
+}
+
+// JSONSchema is a JSON schema.
+type JSONSchema interface{}
+
+// SchemaResolver is a function that resolves a schema name to a JSON schema.
+type SchemaResolver func(schemaName string) (JSONSchema, error)
+
+// ToolResolver is a function that resolves a tool name to a tool definition.
+type ToolResolver func(toolName string) (ToolDefinition, error)
+
+// RenderedPrompt is the final result of rendering a Dotprompt template.
+type RenderedPrompt struct {
+	PromptMetadata
+	Messages []Message `json:"messages"`
+}
+
+// PromptFunction is a function that takes runtime data/context and returns a
+// rendered prompt.
+type PromptFunction func(data DataArgument, options PromptMetadata) (RenderedPrompt, error)
+
+// PromptRefFunction is a function that takes runtime data/context and returns a
+// rendered prompt after loading a prompt via reference.
+type PromptRefFunction func(data DataArgument, options PromptMetadata) (RenderedPrompt, error)
+
+// PaginatedResponse represents a paginated response.
+type PaginatedResponse struct {
+	Cursor string `json:"cursor,omitempty"`
+}
+
+// PartialRef references a partial in a store.
+type PartialRef struct {
+	Name    string  `json:"name"`
+	Variant string `json:"variant,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// PartialData represents a partial with its source content.
+type PartialData struct {
+	PartialRef
+	Source string `json:"source"`
+}
+
+// ListPromptsOptions represents options for listing prompts or partials.
+type ListPromptsOptions struct {
+	Cursor string
+	Limit  int
+}
+
+// ListPromptsResult represents a list of items and a cursor.
+type ListPromptsResult[T any] struct {
+	Items  []T
+	Cursor string `json:"cursor,omitempty"`
+}
+
+// ListPartialsOptions represents options for listing partials.
+type ListPartialsOptions struct {
+	Cursor string
+	Limit  int
+}
+
+// ListPartialsResult represents a list of partials and a cursor.
+type ListPartialsResult[T any] struct {
+	Items  []T
+	Cursor string `json:"cursor,omitempty"`
+}
+
+// LoadPromptOptions represents options for loading a prompt.
+type LoadPromptOptions struct {
+	Variant string
+	Version string
+}
+
+// LoadPartialOptions represents options for loading a partial.
+type LoadPartialOptions struct {
+	Variant string
+	Version string
+}
+
+// PromptStore is an interface for storing and retrieving prompts.
+type PromptStore interface {
+	// List returns a list of all prompts in the store (optionally paginated).
+	List(options ListPromptsOptions) (ListPromptsResult[PromptRef], error)
+
+	// ListPartials returns a list of partial names available in this store.
+	ListPartials(options ListPartialsOptions) (ListPartialsResult[PartialRef], error)
+
+	// Load retrieves a prompt from the store.
+	Load(name string, options LoadPromptOptions) (PromptData, error)
+
+	// LoadPartial retrieves a partial from the store.
+	LoadPartial(name string, options LoadPartialOptions) (PartialData, error)
+}
+
+// PromptStoreDeleteOptions represents options for deleting a prompt or partial.
+type PromptStoreDeleteOptions struct {
+	Variant string
+}
+
+// PromptStoreWritable is a PromptStore that also has built-in methods for
+// writing prompts.
+type PromptStoreWritable interface {
+	PromptStore
+
+	// Save saves a prompt in the store. May be destructive for prompt stores
+	// without versioning.
+	Save(prompt PromptData) error
+
+	// Delete deletes a prompt from the store.
+	Delete(name string, options PromptStoreDeleteOptions) error
+}
+
+// PromptBundle represents a bundle of prompts and partials.
+type PromptBundle struct {
+	Partials []PartialData `json:"partials"`
+	Prompts  []PromptData  `json:"prompts"`
+}


### PR DESCRIPTION
feat(go): add types.go implementation
    
CHANGELOG:
- [ ] Add package documentation in doc.go.
- [ ] Add the types from types.d.ts in types.go.  Since Go doesn't have
  type unions like TypeScript, I have added utility functions to verify
  types.