### PR TITLE
feat(go/parse): parse.go implementation #62

### DIFF
--- a/go/dotprompt/parse.go
+++ b/go/dotprompt/parse.go
@@ -1,0 +1,611 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dotprompt
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MessageSource is a message with a source string and optional content and
+// metadata.
+type MessageSource struct {
+	Role     Role           `json:"role" yaml:"role"`
+	Source   string         `json:"source" yaml:"source"`
+	Content  []Part         `json:"content" yaml:"content"`
+	Metadata map[string]any `json:"metadata" yaml:"metadata"`
+}
+
+const (
+	// Prefixes for the role markers in the template.
+	RoleMarkerPrefix = "<<<dotprompt:role:"
+
+	// Prefixes for the history markers in the template.
+	HistoryMarkerPrefix = "<<<dotprompt:history"
+
+	// Prefixes for the media markers in the template.
+	MediaMarkerPrefix = "<<<dotprompt:media:"
+
+	// Prefixes for the section markers in the template.
+	SectionMarkerPrefix = "<<<dotprompt:section"
+)
+
+var (
+	// FrontmatterAndBodyRegex is a regular expression to match YAML frontmatter
+	// delineated by `---` markers at the start of a .prompt content block.
+	FrontmatterAndBodyRegex = regexp.MustCompile(
+		`^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$`)
+
+	// EmptyFrontmatterRegex is a regular expression to match empty YAML
+	// frontmatter (where there's no content between the frontmatter markers).
+	EmptyFrontmatterRegex = regexp.MustCompile(`^---\s*\n---\s*\n([\s\S]*)$`)
+
+	// RoleAndHistoryMarkerRegex is a regular expression to match
+	// <<<dotprompt:role:xxx>>> and <<<dotprompt:history>>> markers in the
+	// template.
+	//
+	// Note: Only lowercase letters are allowed after 'role:'.
+	//
+	// Examples of matching patterns:
+	// - <<<dotprompt:role:user>>>
+	// - <<<dotprompt:role:assistant>>>
+	// - <<<dotprompt:role:system>>>
+	// - <<<dotprompt:history>>>
+	RoleAndHistoryMarkerRegex = regexp.MustCompile(
+		`(<<<dotprompt:(?:role:[a-z]+|history))>>>`)
+
+	// MediaAndSectionMarkerRegex is a regular expression to match
+	// <<<dotprompt:media:url>>> and <<<dotprompt:section>>> markers in the
+	// template.
+	//
+	// Examples of matching patterns:
+	// - <<<dotprompt:media:url>>>
+	// - <<<dotprompt:section>>>
+	MediaAndSectionMarkerRegex = regexp.MustCompile(
+		`(<<<dotprompt:(?:media:url|section).*?)>>>`)
+)
+
+// ReservedMetadataKeywords is a list of keywords that are reserved for metadata
+// in the frontmatter of a .prompt file. These keys are processed differently
+// from extension metadata.
+var ReservedMetadataKeywords = []string{
+	// NOTE: KEEP SORTED
+	"config",
+	"description",
+	"ext",
+	"input",
+	"model",
+	"name",
+	"output",
+	"raw",
+	"toolDefs",
+	"tools",
+	"variant",
+	"version",
+}
+
+// splitByRegex splits a string by a regular expression and includes the matched
+// regex patterns in the result while filtering out empty/whitespace-only
+// pieces.
+//
+// NOTE: Since the behavior of regexp.Split is different in Python, JS, and Go,
+// this function handles the different behavior between the specialized marker
+// regexes and simple splitting regexes to mimic their behavior.
+//
+// For marker regexes with capturing groups (delineated by parens), it includes
+// the capturing group in the result.  For simple regexes, it behaves like
+// regexp.Split, removing the matched separators.
+func splitByRegex(source string, regex *regexp.Regexp) []string {
+	// Check if the regex is one of the marker regexes by looking for capturing
+	// groups in the pattern.
+	hasCapturingGroups := strings.Contains(regex.String(), "(")
+
+	if !hasCapturingGroups {
+		pieces := regex.Split(source, -1)
+
+		// Filter out empty or whitespace-only pieces.
+		var result []string
+		for _, s := range pieces {
+			if strings.TrimSpace(s) != "" {
+				result = append(result, s)
+			}
+		}
+		return result
+	}
+
+	// For marker regexes with capturing groups, include the matched portions.
+	matches := regex.FindAllStringSubmatchIndex(source, -1)
+	if len(matches) == 0 {
+		if strings.TrimSpace(source) != "" {
+			return []string{source}
+		}
+		return []string{}
+	}
+
+	var result []string
+	lastEnd := 0
+
+	// Process each match and the text before it
+	for _, match := range matches {
+		start := match[0] // Start of the full match.
+		end := match[1]   // End of the full match.
+
+		// If there's text before the match that isn't empty...
+		if start > lastEnd {
+			textBefore := source[lastEnd:start]
+			if strings.TrimSpace(textBefore) != "" {
+				result = append(result, textBefore)
+			}
+		}
+
+		// Add the capturing group (not the full match).
+		groupStart := match[2] // Start of first capturing group.
+		groupEnd := match[3]   // End of first capturing group.
+
+		if groupStart >= 0 && groupEnd >= 0 {
+			matchText := source[groupStart:groupEnd]
+			if strings.TrimSpace(matchText) != "" {
+				result = append(result, matchText)
+			}
+		}
+
+		lastEnd = end
+	}
+
+	// If there's text after the last match that isn't empty...
+	if lastEnd < len(source) {
+		textAfter := source[lastEnd:]
+		if strings.TrimSpace(textAfter) != "" {
+			result = append(result, textAfter)
+		}
+	}
+
+	return result
+}
+
+// splitByRoleAndHistoryMarkers splits a string by role and history markers.
+func splitByRoleAndHistoryMarkers(source string) []string {
+	return splitByRegex(source, RoleAndHistoryMarkerRegex)
+}
+
+// splitByMediaAndSectionMarkers splits a string by media and section markers.
+func splitByMediaAndSectionMarkers(source string) []string {
+	return splitByRegex(source, MediaAndSectionMarkerRegex)
+}
+
+// convertNamespacedEntryToNestedObject converts a namespaced entry to a nested
+// object.
+//
+// For example, 'foo.bar': 'value' becomes { foo: { bar: 'value' } }
+func convertNamespacedEntryToNestedObject(
+	key string,
+	value any,
+	obj map[string]map[string]any) map[string]map[string]any {
+	// NOTE: Goes only a single level deep.
+	if obj == nil {
+		obj = make(map[string]map[string]any)
+	}
+
+	lastDotIndex := strings.LastIndex(key, ".")
+	ns := key[:lastDotIndex]
+	field := key[lastDotIndex+1:]
+
+	// Ensure the namespace exists.
+	if _, exists := obj[ns]; !exists {
+		obj[ns] = make(map[string]any)
+	}
+
+	obj[ns][field] = value
+	return obj
+}
+
+// extractFrontmatterAndBody extracts the frontmatter and body from a .prompt
+// file.
+func extractFrontmatterAndBody(source string) (string, string) {
+	match := FrontmatterAndBodyRegex.FindStringSubmatch(source)
+	if match == nil {
+		// Try the empty frontmatter pattern
+		match = EmptyFrontmatterRegex.FindStringSubmatch(source)
+		if match == nil {
+			return "", ""
+		}
+		return "", match[1]
+	}
+	frontmatter, body := match[1], match[2]
+	return frontmatter, body
+}
+
+// isReservedMetadataKeyword checks if a key is a reserved metadata keyword.
+func isReservedMetadataKeyword(key string) bool {
+	for _, reserved := range ReservedMetadataKeywords {
+		if key == reserved {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseDocument parses a document containing YAML frontmatter and a template
+// content section.  The frontmatter contains metadata and configuration for the
+// prompt.
+func ParseDocument(source string) (ParsedPrompt, error) {
+	frontmatter, body := extractFrontmatterAndBody(source)
+	promptMetadata := PromptMetadata{
+		Ext: make(map[string]map[string]any),
+	}
+
+	if frontmatter != "" {
+		var parsedMetadata map[string]any
+		err := yaml.Unmarshal([]byte(frontmatter), &parsedMetadata)
+		if err != nil {
+			fmt.Printf("Dotprompt: Error parsing YAML frontmatter: %v\n", err)
+			// Return a basic ParsedPrompt with just the template
+			return ParsedPrompt{
+				PromptMetadata: promptMetadata,
+				Template:       strings.TrimSpace(source),
+			}, nil
+		}
+
+		raw := copyMapping(parsedMetadata)
+		pruned := PromptMetadata{
+			Ext: make(map[string]map[string]any),
+		}
+		ext := make(map[string]map[string]any)
+
+		for key, value := range raw {
+			if isReservedMetadataKeyword(key) {
+				// Add to pruned metadata.
+				switch key {
+				case "name":
+					pruned.Name = stringOrEmpty(value)
+				case "description":
+					pruned.Description = stringOrEmpty(value)
+				case "variant":
+					pruned.Variant = stringOrEmpty(value)
+				case "version":
+					pruned.Version = stringOrEmpty(value)
+				case "model":
+					pruned.Model = stringOrEmpty(value)
+				case "config":
+					if configMap, ok := value.(map[string]any); ok {
+						pruned.Config = configMap
+					}
+				case "tools":
+					if toolsSlice, ok := value.([]any); ok {
+						tools := make([]string, 0, len(toolsSlice))
+						for _, t := range toolsSlice {
+							if toolStr, ok := t.(string); ok {
+								tools = append(tools, toolStr)
+							}
+						}
+						pruned.Tools = tools
+					}
+				case "toolDefs":
+					if toolDefsSlice, ok := value.([]any); ok {
+						toolDefs := make([]ToolDefinition, 0, len(toolDefsSlice))
+						for _, td := range toolDefsSlice {
+							if tdMap, ok := td.(map[string]any); ok {
+								toolDef := ToolDefinition{
+									Name:        stringOrEmpty(tdMap["name"]),
+									Description: stringOrEmpty(tdMap["description"]),
+								}
+								if inputSchema, ok := tdMap["inputSchema"].(map[string]any); ok {
+									toolDef.InputSchema = inputSchema
+								}
+								if outputSchema, ok := tdMap["outputSchema"].(map[string]any); ok {
+									toolDef.OutputSchema = outputSchema
+								}
+								toolDefs = append(toolDefs, toolDef)
+							}
+						}
+						pruned.ToolDefs = toolDefs
+					}
+				}
+			} else if strings.Contains(key, ".") {
+				convertNamespacedEntryToNestedObject(key, value, ext)
+			}
+		}
+
+		// Set the raw and ext fields
+		pruned.Raw = raw
+		pruned.Ext = ext
+
+		return ParsedPrompt{
+			PromptMetadata: pruned,
+			Template:       strings.TrimSpace(body),
+		}, nil
+	}
+
+	// If we have a body from frontmatter extraction, use it
+	if body != "" {
+		return ParsedPrompt{
+			PromptMetadata: promptMetadata,
+			Template:       strings.TrimSpace(body),
+		}, nil
+	}
+
+	// No frontmatter or body extracted, return the original source as template
+	return ParsedPrompt{
+		PromptMetadata: promptMetadata,
+		Template:       source,
+	}, nil
+}
+
+// ToMessages converts a rendered template string into an array of messages.
+func ToMessages(renderedString string, data *DataArgument) ([]Message, error) {
+	// Create the initial message source with empty content.
+	ms := MessageSource{
+		Role:   RoleUser,
+		Source: "",
+	}
+	messageSources := []MessageSource{ms}
+
+	for _, piece := range splitByRoleAndHistoryMarkers(renderedString) {
+		if strings.HasPrefix(piece, RoleMarkerPrefix) {
+			roleStr := piece[len(RoleMarkerPrefix):]
+			role := Role(roleStr)
+
+			if messageSources[len(messageSources)-1].Source != "" &&
+				strings.TrimSpace(messageSources[len(messageSources)-1].Source) != "" {
+				// If the current message has content, create a new message.
+				newMs := MessageSource{
+					Role:   role,
+					Source: "",
+				}
+				messageSources = append(messageSources, newMs)
+			} else {
+				// Otherwise, update the role of the current message.
+				messageSources[len(messageSources)-1].Role = role
+			}
+		} else if strings.HasPrefix(piece, HistoryMarkerPrefix) {
+			// Add the history messages to the message sources.
+			var msgs []Message
+			if data != nil && data.Messages != nil {
+				msgs = data.Messages
+			}
+
+			historyMessages, err := transformMessagesToHistory(msgs)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(historyMessages) > 0 {
+				for _, msg := range historyMessages {
+					messageSources = append(messageSources, MessageSource{
+						Role:     msg.Role,
+						Content:  msg.Content,
+						Metadata: msg.Metadata,
+					})
+				}
+			}
+
+			newMs := MessageSource{
+				Role:   RoleModel,
+				Source: "",
+			}
+			messageSources = append(messageSources, newMs)
+		} else {
+			// Otherwise, add the piece to the current message source.
+			messageSources[len(messageSources)-1].Source += piece
+		}
+	}
+
+	messages, err := messageSourcesToMessages(messageSources)
+	if err != nil {
+		return nil, err
+	}
+
+	if data != nil {
+		return insertHistory(messages, data.Messages)
+	}
+	return insertHistory(messages, []Message{})
+}
+
+// messageSourcesToMessages converts an array of message sources to an array of
+// messages.
+func messageSourcesToMessages(
+	messageSources []MessageSource) ([]Message, error) {
+	messages := []Message{}
+
+	for _, m := range messageSources {
+		// Only skip messages that have both empty Content and empty Source.
+		if m.Content == nil && strings.TrimSpace(m.Source) == "" {
+			continue
+		}
+
+		out := Message{
+			Role: m.Role,
+		}
+
+		if m.Content != nil {
+			out.Content = m.Content
+		} else {
+			parts, err := toParts(m.Source)
+			if err != nil {
+				return nil, err
+			}
+			out.Content = parts
+		}
+
+		if m.Metadata != nil {
+			out.Metadata = m.Metadata
+		}
+
+		messages = append(messages, out)
+	}
+
+	return messages, nil
+}
+
+// transformMessagesToHistory adds history metadata to an array of messages.
+func transformMessagesToHistory(messages []Message) ([]Message, error) {
+	result := make([]Message, len(messages))
+
+	for i, message := range messages {
+		newMetadata := copyMapping(message.Metadata)
+		newMetadata["purpose"] = "history"
+		result[i] = Message{
+			Role:        message.Role,
+			Content:     message.Content,
+			HasMetadata: HasMetadata{Metadata: newMetadata},
+		}
+	}
+
+	return result, nil
+}
+
+// messagesHaveHistory checks if the messages have history metadata.
+func messagesHaveHistory(messages []Message) bool {
+	for _, msg := range messages {
+		if msg.Metadata != nil {
+			if purpose, ok := msg.Metadata["purpose"]; ok {
+				if purpose == "history" {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// insertHistory inserts historical messages into the conversation.
+//
+// The history is inserted at:
+// - The end of the conversation if there is no history or no user message.
+// - Before the last user message if there is a user message.
+//
+// The history is not inserted:
+// - If it already exists in the messages.
+// - If there is no user message.
+func insertHistory(messages []Message, history []Message) ([]Message, error) {
+	// If we have no history or find an existing instance of history, return the
+	// original messages.
+	h := len(history)
+	if h == 0 || messagesHaveHistory(messages) {
+		return messages, nil
+	}
+
+	// If there are no messages, return the history.
+	if len(messages) == 0 {
+		return history, nil
+	}
+
+	// If the last message is a user message, insert history before it.
+	lastMessage := messages[len(messages)-1]
+	if lastMessage.Role == RoleUser {
+		m := len(messages)
+		result := make([]Message, 0, m-1+h+1)
+
+		// Sandwich the history between the last user message and the new user
+		// message.
+		result = append(result, messages[:m-1]...)
+		result = append(result, history...)
+		result = append(result, lastMessage)
+
+		return result, nil
+	}
+
+	// Otherwise, append history to the end of the messages.
+	return append(messages, history...), nil
+}
+
+// toParts converts a source string into an array of parts (text, media, or
+// metadata).
+//
+// Also processes media and section markers.
+func toParts(source string) ([]Part, error) {
+	parts := []Part{}
+
+	for _, piece := range splitByMediaAndSectionMarkers(source) {
+		part, err := parsePart(piece)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, part)
+	}
+
+	return parts, nil
+}
+
+// parsePart parses a part from piece of rendered template.
+func parsePart(piece string) (Part, error) {
+	if strings.HasPrefix(piece, MediaMarkerPrefix) {
+		return parseMediaPart(piece)
+	} else if strings.HasPrefix(piece, SectionMarkerPrefix) {
+		return parseSectionPart(piece)
+	} else {
+		return parseTextPart(piece)
+	}
+}
+
+// parseMediaPart parses a media part from a piece of rendered template.
+func parseMediaPart(piece string) (*MediaPart, error) {
+	if !strings.HasPrefix(piece, MediaMarkerPrefix) {
+		return nil, fmt.Errorf(
+			"invalid media piece: %s; expected prefix %s",
+			piece, MediaMarkerPrefix)
+	}
+
+	fields := strings.Split(piece, " ")
+	n := len(fields)
+
+	var url, contentType string
+	if n == 3 {
+		url, contentType = fields[1], fields[2]
+	} else if n == 2 {
+		url = fields[1]
+	} else {
+		return nil, fmt.Errorf(
+			"invalid media piece: %s; expected 2 or 3 fields, found %d",
+			piece, n)
+	}
+
+	mediaPart := &MediaPart{
+		Media: Media{
+			URL:         url,
+			ContentType: contentType,
+		},
+		HasMetadata: HasMetadata{},
+	}
+
+	if contentType != "" && strings.TrimSpace(contentType) != "" {
+		mediaPart.Media.ContentType = contentType
+	}
+
+	return mediaPart, nil
+}
+
+// parseSectionPart parses a section part from a piece of rendered template.
+func parseSectionPart(piece string) (*PendingPart, error) {
+	if !strings.HasPrefix(piece, SectionMarkerPrefix) {
+		return nil, fmt.Errorf(
+			"invalid section piece: %s; expected prefix %s",
+			piece, SectionMarkerPrefix)
+	}
+
+	fields := strings.Split(piece, " ")
+	n := len(fields)
+	if n != 2 {
+		return nil, fmt.Errorf(
+			"invalid section piece: %s; expected 2 fields, found %d", piece, n)
+	}
+
+	sectionType := strings.TrimSpace(fields[1])
+	pendingPart := NewPendingPart()
+	pendingPart.SetMetadata("purpose", sectionType)
+
+	return pendingPart, nil
+}
+
+// parseTextPart parses a text part from a piece of rendered template.
+func parseTextPart(piece string) (*TextPart, error) {
+	return &TextPart{
+		HasMetadata: HasMetadata{},
+		Text:        piece,
+	}, nil
+}

--- a/go/dotprompt/parse_test.go
+++ b/go/dotprompt/parse_test.go
@@ -1,0 +1,1306 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dotprompt
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrontmatterAndBodyRegex(t *testing.T) {
+	testCases := []struct {
+		name                string
+		source              string
+		expectedFrontmatter string
+		expectedBody        string
+		shouldMatch         bool
+	}{
+		{
+			name:                "Document with frontmatter and body",
+			source:              "---\nfoo: bar\n---\nThis is the body.",
+			expectedFrontmatter: "foo: bar",
+			expectedBody:        "This is the body.",
+			shouldMatch:         true,
+		},
+		{
+			name:                "Document with empty frontmatter",
+			source:              "---\n\n---\nBody only.",
+			expectedFrontmatter: "",
+			expectedBody:        "Body only.",
+			shouldMatch:         true,
+		},
+		{
+			name:                "Document with empty body",
+			source:              "---\nfoo: bar\n---\n",
+			expectedFrontmatter: "foo: bar",
+			expectedBody:        "",
+			shouldMatch:         true,
+		},
+		{
+			name:                "Document with multiline frontmatter",
+			source:              "---\nfoo: bar\nbaz: qux\n---\nThis is the body.",
+			expectedFrontmatter: "foo: bar\nbaz: qux",
+			expectedBody:        "This is the body.",
+			shouldMatch:         true,
+		},
+		{
+			name:                "Document with no frontmatter markers",
+			source:              "Just a body.",
+			expectedFrontmatter: "",
+			expectedBody:        "",
+			shouldMatch:         false,
+		},
+		{
+			name:                "Document with incomplete frontmatter markers",
+			source:              "---\nfoo: bar\nThis is the body.",
+			expectedFrontmatter: "",
+			expectedBody:        "",
+			shouldMatch:         false,
+		},
+		{
+			name:                "Document with extra frontmatter markers",
+			source:              "---\nfoo: bar\n---\nThis is the body.\n---\nExtra section.",
+			expectedFrontmatter: "foo: bar",
+			expectedBody:        "This is the body.\n---\nExtra section.",
+			shouldMatch:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			match := FrontmatterAndBodyRegex.FindStringSubmatch(tc.source)
+
+			if !tc.shouldMatch {
+				assert.Nil(t, match, "Regex should not match for: %s", tc.source)
+			} else {
+				assert.NotNil(t, match, "Regex should match for: %s", tc.source)
+				assert.Equal(t, 3, len(match), "Match should have 3 elements (full match + 2 groups)")
+				frontmatter := match[1]
+				body := match[2]
+				assert.Equal(t, tc.expectedFrontmatter, frontmatter, "Frontmatter should match")
+				assert.Equal(t, tc.expectedBody, body, "Body should match")
+			}
+		})
+	}
+}
+
+func TestRoleAndHistoryMarkerRegex(t *testing.T) {
+	t.Run("test valid patterns", func(t *testing.T) {
+		// NOTE: currently this doesn't validate the role.
+		validPatterns := []string{
+			"<<<dotprompt:role:user>>>",
+			"<<<dotprompt:role:model>>>",
+			"<<<dotprompt:role:system>>>",
+			"<<<dotprompt:history>>>",
+			"<<<dotprompt:role:bot>>>",
+			"<<<dotprompt:role:human>>>",
+			"<<<dotprompt:role:customer>>>",
+		}
+
+		for _, pattern := range validPatterns {
+			assert.NotNil(t, RoleAndHistoryMarkerRegex.FindStringSubmatch(pattern),
+				"Pattern should match: %s", pattern)
+		}
+	})
+
+	t.Run("test invalid patterns", func(t *testing.T) {
+		invalidPatterns := []string{
+			"<<<dotprompt:role:USER>>>",   // uppercase not allowed
+			"<<<dotprompt:role:model1>>>", // numbers not allowed
+			"<<<dotprompt:role:>>>",       // needs at least one letter
+			"<<<dotprompt:role>>>",        // missing role value
+			"<<<dotprompt:history123>>>",  // history should be exact
+			"<<<dotprompt:HISTORY>>>",     // history must be lowercase
+			"dotprompt:role:user",         // missing brackets
+			"<<<dotprompt:role:user",      // incomplete closing
+			"dotprompt:role:user>>>",      // incomplete opening
+		}
+
+		for _, pattern := range invalidPatterns {
+			assert.Nil(t, RoleAndHistoryMarkerRegex.FindStringSubmatch(pattern),
+				"Pattern should not match: %s", pattern)
+		}
+	})
+
+	t.Run("multiple markers", func(t *testing.T) {
+		text := `
+		<<<dotprompt:role:user>>> Hello
+		<<<dotprompt:role:model>>> Hi there
+		<<<dotprompt:history>>>
+		<<<dotprompt:role:user>>> How are you?
+	`
+
+		matches := RoleAndHistoryMarkerRegex.FindAllString(text, -1)
+		assert.Equal(t, 4, len(matches))
+	})
+}
+
+func TestMediaAndSectionMarkerRegex(t *testing.T) {
+	t.Run("test valid patterns", func(t *testing.T) {
+		validPatterns := []string{
+			"<<<dotprompt:media:url>>>",
+			"<<<dotprompt:section>>>",
+		}
+
+		for _, pattern := range validPatterns {
+			assert.NotNil(t, MediaAndSectionMarkerRegex.FindStringSubmatch(pattern),
+				"Pattern should match: %s", pattern)
+		}
+	})
+
+	t.Run("multiple matches", func(t *testing.T) {
+		text := `
+		<<<dotprompt:media:url>>> https://example.com/image.jpg
+		<<<dotprompt:section>>> Section 1
+		<<<dotprompt:media:url>>> https://example.com/video.mp4
+		<<<dotprompt:section>>> Section 2
+	`
+
+		matches := MediaAndSectionMarkerRegex.FindAllString(text, -1)
+		assert.Equal(t, 4, len(matches))
+	})
+}
+
+func TestSplitByRegex(t *testing.T) {
+	inputStr := "  one  ,  ,  two  ,  three  "
+	output := splitByRegex(inputStr, regexp.MustCompile(`,`))
+	assert.Equal(t, []string{"  one  ", "  two  ", "  three  "}, output)
+}
+
+func TestSplitByMediaAndSectionMarkers(t *testing.T) {
+	t.Run("BasicMarker", func(t *testing.T) {
+		inputStr := "<<<dotprompt:media:url>>> https://example.com/image.jpg"
+		output := splitByMediaAndSectionMarkers(inputStr)
+		expected := []string{
+			"<<<dotprompt:media:url",
+			" https://example.com/image.jpg",
+		}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+
+	t.Run("MultipleMarkers", func(t *testing.T) {
+		inputStr := "Start <<<dotprompt:media:url>>> https://example.com/image.jpg End <<<dotprompt:section>>> Code"
+		output := splitByMediaAndSectionMarkers(inputStr)
+		expected := []string{
+			"Start ",
+			"<<<dotprompt:media:url",
+			" https://example.com/image.jpg End ",
+			"<<<dotprompt:section",
+			" Code",
+		}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+
+	t.Run("NoMarkers", func(t *testing.T) {
+		inputStr := "Hello World"
+		output := splitByMediaAndSectionMarkers(inputStr)
+		expected := []string{"Hello World"}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+}
+
+func TestSplitByRoleAndHistoryMarkers(t *testing.T) {
+	t.Run("NoMarkers", func(t *testing.T) {
+		inputStr := "Hello World"
+		output := splitByRoleAndHistoryMarkers(inputStr)
+		expected := []string{"Hello World"}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+
+	t.Run("SingleMarker", func(t *testing.T) {
+		inputStr := "Hello <<<dotprompt:role:model>>> world"
+		output := splitByRoleAndHistoryMarkers(inputStr)
+		expected := []string{
+			"Hello ",
+			"<<<dotprompt:role:model",
+			" world",
+		}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+
+	t.Run("FilterEmpty", func(t *testing.T) {
+		inputStr := "  <<<dotprompt:role:system>>>   "
+		output := splitByRoleAndHistoryMarkers(inputStr)
+		expected := []string{"<<<dotprompt:role:system"}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+
+	t.Run("AdjacentMarkers", func(t *testing.T) {
+		inputStr := "<<<dotprompt:role:user>>><<<dotprompt:history>>>"
+		output := splitByRoleAndHistoryMarkers(inputStr)
+		expected := []string{
+			"<<<dotprompt:role:user",
+			"<<<dotprompt:history",
+		}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+
+	t.Run("InvalidFormat", func(t *testing.T) {
+		inputStr := "<<<dotprompt:ROLE:user>>>"
+		output := splitByRoleAndHistoryMarkers(inputStr)
+		expected := []string{"<<<dotprompt:ROLE:user>>>"}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+
+	t.Run("MultipleMarkers", func(t *testing.T) {
+		inputStr := "Start <<<dotprompt:role:user>>> middle <<<dotprompt:history>>> end"
+		output := splitByRoleAndHistoryMarkers(inputStr)
+		expected := []string{
+			"Start ",
+			"<<<dotprompt:role:user",
+			" middle ",
+			"<<<dotprompt:history",
+			" end",
+		}
+
+		assert.Equal(t, expected, output, "Split result should match expected output")
+	})
+}
+
+func TestConvertNamespacedEntryToNestedObject(t *testing.T) {
+	t.Run("test creating nested object", func(t *testing.T) {
+		result := convertNamespacedEntryToNestedObject("foo.bar", "hello", nil)
+
+		expected := map[string]map[string]any{
+			"foo": {
+				"bar": "hello",
+			},
+		}
+
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("test adding to existing namespace", func(t *testing.T) {
+		existing := map[string]map[string]any{
+			"foo": {
+				"bar": "hello",
+			},
+		}
+
+		result := convertNamespacedEntryToNestedObject("foo.baz", "world", existing)
+
+		expected := map[string]map[string]any{
+			"foo": {
+				"bar": "hello",
+				"baz": "world",
+			},
+		}
+
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("test handling multiple namespaces", func(t *testing.T) {
+		result := convertNamespacedEntryToNestedObject("foo.bar", "hello", nil)
+		finalResult := convertNamespacedEntryToNestedObject("baz.qux", "world", result)
+
+		expected := map[string]map[string]any{
+			"foo": {
+				"bar": "hello",
+			},
+			"baz": {
+				"qux": "world",
+			},
+		}
+
+		assert.Equal(t, expected, finalResult)
+	})
+}
+
+func TestExtractFrontmatterAndBody(t *testing.T) {
+	t.Run("should extract frontmatter and body", func(t *testing.T) {
+		inputStr := "---\nfoo: bar\n---\nThis is the body."
+		frontmatter, body := extractFrontmatterAndBody(inputStr)
+		assert.Equal(t, "foo: bar", frontmatter)
+		assert.Equal(t, "This is the body.", body)
+	})
+
+	t.Run("should extract frontmatter and body with empty frontmatter", func(t *testing.T) {
+		inputStr := "---\n\n---\nThis is the body."
+		frontmatter, body := extractFrontmatterAndBody(inputStr)
+		assert.Equal(t, "", frontmatter)
+		assert.Equal(t, "This is the body.", body)
+	})
+
+	t.Run("should return empty strings when there is no frontmatter marker", func(t *testing.T) {
+		// TODO: May be change this behavior to return a matching body when
+		// there is no frontmatter marker and we have a body. This may need to
+		// be done across all the runtimes.
+		inputStr := "Hello World"
+		frontmatter, body := extractFrontmatterAndBody(inputStr)
+		assert.Equal(t, "", frontmatter)
+		assert.Equal(t, "", body)
+	})
+}
+
+func TestTransformMessagesToHistory(t *testing.T) {
+	t.Run("add history metadata to messages", func(t *testing.T) {
+		messages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Hello"},
+				},
+			},
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Hi there"},
+				},
+			},
+		}
+
+		result, err := transformMessagesToHistory(messages)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(result))
+
+		for _, msg := range result {
+			assert.Contains(t, msg.Metadata, "purpose")
+			assert.Equal(t, "history", msg.Metadata["purpose"])
+		}
+	})
+
+	t.Run("preserve existing metadata while adding history purpose", func(t *testing.T) {
+		messages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Hello"},
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"foo": "bar",
+					},
+				},
+			},
+		}
+
+		result, err := transformMessagesToHistory(messages)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result))
+
+		// Check that history purpose was added and existing metadata preserved
+		assert.Contains(t, result[0].Metadata, "purpose")
+		assert.Equal(t, "history", result[0].Metadata["purpose"])
+		assert.Contains(t, result[0].Metadata, "foo")
+		assert.Equal(t, "bar", result[0].Metadata["foo"])
+	})
+
+	t.Run("handle empty array", func(t *testing.T) {
+		result, err := transformMessagesToHistory([]Message{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(result))
+	})
+}
+
+func TestMessageSourcesToMessages(t *testing.T) {
+	t.Run("should handle empty array", func(t *testing.T) {
+		messageSources := []MessageSource{}
+		messages, err := messageSourcesToMessages(messageSources)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(messages))
+	})
+
+	t.Run("should convert a single message source", func(t *testing.T) {
+		messageSources := []MessageSource{
+			{
+				Role:   RoleUser,
+				Source: "Hello",
+			},
+		}
+
+		messages, err := messageSourcesToMessages(messageSources)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(messages))
+		assert.Equal(t, []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Hello"},
+				},
+			},
+		}, messages)
+	})
+
+	t.Run("should handle message source with content", func(t *testing.T) {
+		textPart := &TextPart{Text: "Existing content"}
+		messageSources := []MessageSource{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					textPart,
+				},
+			},
+		}
+
+		messages, err := messageSourcesToMessages(messageSources)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(messages))
+		assert.Equal(t, []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					textPart,
+				},
+			},
+		}, messages)
+	})
+
+	t.Run("should handle message source with metadata", func(t *testing.T) {
+		textPart := &TextPart{Text: "Existing content"}
+		messageSources := []MessageSource{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					textPart,
+				},
+				Metadata: map[string]any{
+					"foo": "bar",
+				},
+			},
+		}
+
+		messages, err := messageSourcesToMessages(messageSources)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(messages))
+		assert.Equal(t, []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					textPart,
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"foo": "bar",
+					},
+				},
+			},
+		}, messages)
+	})
+
+	t.Run("should filter out message sources with empty source and content", func(t *testing.T) {
+		messageSources := []MessageSource{
+			{
+				Role:   RoleUser,
+				Source: "",
+			},
+			{
+				Role:    RoleModel,
+				Source:  "  ",
+				Content: []Part{}, // Empty content but still included
+			},
+			{
+				Role:   RoleUser,
+				Source: "Hello",
+			},
+		}
+
+		messages, err := messageSourcesToMessages(messageSources)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(messages))
+
+		// Check that the model message is included even with empty source
+		assert.Equal(t, RoleModel, messages[0].Role)
+
+		// Check that the user message is included
+		assert.Equal(t, RoleUser, messages[1].Role)
+		textPart, ok := messages[1].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Hello", textPart.Text)
+	})
+}
+
+func TestMessagesHaveHistory(t *testing.T) {
+	t.Run("should return true if messages have history metadata", func(t *testing.T) {
+		messages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Hello"},
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"purpose": "history",
+					},
+				},
+			},
+		}
+
+		result := messagesHaveHistory(messages)
+		assert.True(t, result)
+	})
+
+	t.Run("should return false if messages do not have history metadata", func(t *testing.T) {
+		messages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Hello"},
+				},
+			},
+		}
+
+		result := messagesHaveHistory(messages)
+		assert.False(t, result)
+	})
+}
+
+func TestToMessages(t *testing.T) {
+	t.Run("should handle a simple string with no markers", func(t *testing.T) {
+		renderedString := "Hello world"
+		result, err := ToMessages(renderedString, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, RoleUser, result[0].Role)
+
+		textPart, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Hello world", textPart.Text)
+	})
+
+	t.Run("should handle a string with a single role marker", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:model>>>Hello world"
+		result, err := ToMessages(renderedString, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, RoleModel, result[0].Role)
+
+		textPart, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Hello world", textPart.Text)
+	})
+
+	t.Run("should handle a string with multiple role markers", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:system>>>System instructions\n" +
+			"<<<dotprompt:role:user>>>User query\n" +
+			"<<<dotprompt:role:model>>>Model response"
+		result, err := ToMessages(renderedString, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(result))
+
+		assert.Equal(t, RoleSystem, result[0].Role)
+		textPart0, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "System instructions\n", textPart0.Text)
+
+		assert.Equal(t, RoleUser, result[1].Role)
+		textPart1, ok := result[1].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "User query\n", textPart1.Text)
+
+		assert.Equal(t, RoleModel, result[2].Role)
+		textPart2, ok := result[2].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Model response", textPart2.Text)
+	})
+
+	t.Run("should update the role of an empty message instead of creating a new one", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:user>>><<<dotprompt:role:model>>>Response"
+		result, err := ToMessages(renderedString, nil)
+
+		assert.NoError(t, err)
+		// Should only have one message since the first role marker doesn't have content
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, RoleModel, result[0].Role)
+
+		textPart, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Response", textPart.Text)
+	})
+
+	t.Run("should handle history markers and add metadata", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:user>>>Query<<<dotprompt:history>>>Follow-up"
+		historyMessages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Previous question"},
+				},
+			},
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Previous answer"},
+				},
+			},
+		}
+
+		data := &DataArgument{Messages: historyMessages}
+		result, err := ToMessages(renderedString, data)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 4, len(result))
+
+		// First message is the user query
+		assert.Equal(t, RoleUser, result[0].Role)
+		textPart0, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Query", textPart0.Text)
+
+		// Next two messages should be history messages with appropriate metadata
+		assert.Equal(t, RoleUser, result[1].Role)
+		assert.Contains(t, result[1].Metadata, "purpose")
+		assert.Equal(t, "history", result[1].Metadata["purpose"])
+
+		assert.Equal(t, RoleModel, result[2].Role)
+		assert.Contains(t, result[2].Metadata, "purpose")
+		assert.Equal(t, "history", result[2].Metadata["purpose"])
+
+		// Last message is the follow-up
+		assert.Equal(t, RoleModel, result[3].Role)
+		textPart3, ok := result[3].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Follow-up", textPart3.Text)
+	})
+
+	t.Run("should handle empty history gracefully", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:user>>>Query<<<dotprompt:history>>>Follow-up"
+		data := &DataArgument{Messages: []Message{}}
+		result, err := ToMessages(renderedString, data)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(result))
+
+		assert.Equal(t, RoleUser, result[0].Role)
+		textPart0, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Query", textPart0.Text)
+
+		assert.Equal(t, RoleModel, result[1].Role)
+		textPart1, ok := result[1].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Follow-up", textPart1.Text)
+	})
+
+	t.Run("should handle nil data gracefully", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:user>>>Query<<<dotprompt:history>>>Follow-up"
+		result, err := ToMessages(renderedString, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(result))
+
+		assert.Equal(t, RoleUser, result[0].Role)
+		textPart0, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Query", textPart0.Text)
+
+		assert.Equal(t, RoleModel, result[1].Role)
+		textPart1, ok := result[1].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Follow-up", textPart1.Text)
+	})
+
+	t.Run("should filter out empty messages", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:user>>> " +
+			"<<<dotprompt:role:system>>> " +
+			"<<<dotprompt:role:model>>>Response"
+		result, err := ToMessages(renderedString, nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, RoleModel, result[0].Role)
+
+		textPart, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Response", textPart.Text)
+	})
+
+	t.Run("should handle multiple history markers by treating each as a separate insertion point", func(t *testing.T) {
+		renderedString := "<<<dotprompt:history>>>First<<<dotprompt:history>>>Second"
+		historyMessages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Previous"},
+				},
+			},
+		}
+
+		data := &DataArgument{Messages: historyMessages}
+		result, err := ToMessages(renderedString, data)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 4, len(result))
+
+		assert.Contains(t, result[0].Metadata, "purpose")
+		assert.Equal(t, "history", result[0].Metadata["purpose"])
+
+		textPart1, ok := result[1].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "First", textPart1.Text)
+
+		assert.Contains(t, result[2].Metadata, "purpose")
+		assert.Equal(t, "history", result[2].Metadata["purpose"])
+
+		textPart3, ok := result[3].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Second", textPart3.Text)
+	})
+
+	t.Run("should support complex interleaving of role and history markers", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:system>>>Instructions\n" +
+			"<<<dotprompt:role:user>>>Initial Query\n" +
+			"<<<dotprompt:history>>>\n" +
+			"<<<dotprompt:role:user>>>Follow-up Question\n" +
+			"<<<dotprompt:role:model>>>Final Response"
+
+		historyMessages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Previous question"},
+				},
+			},
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Previous answer"},
+				},
+			},
+		}
+
+		data := &DataArgument{Messages: historyMessages}
+		result, err := ToMessages(renderedString, data)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 6, len(result))
+
+		assert.Equal(t, RoleSystem, result[0].Role)
+		textPart0, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Instructions\n", textPart0.Text)
+
+		assert.Equal(t, RoleUser, result[1].Role)
+		textPart1, ok := result[1].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Initial Query\n", textPart1.Text)
+
+		assert.Equal(t, RoleUser, result[2].Role)
+		assert.Contains(t, result[2].Metadata, "purpose")
+		assert.Equal(t, "history", result[2].Metadata["purpose"])
+
+		assert.Equal(t, RoleModel, result[3].Role)
+		assert.Contains(t, result[3].Metadata, "purpose")
+		assert.Equal(t, "history", result[3].Metadata["purpose"])
+
+		assert.Equal(t, RoleUser, result[4].Role)
+		textPart4, ok := result[4].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Follow-up Question\n", textPart4.Text)
+
+		assert.Equal(t, RoleModel, result[5].Role)
+		textPart5, ok := result[5].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Final Response", textPart5.Text)
+	})
+
+	t.Run("should handle an empty input string", func(t *testing.T) {
+		result, err := ToMessages("", nil)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(result))
+	})
+
+	t.Run("should properly call insertHistory with data.messages", func(t *testing.T) {
+		renderedString := "<<<dotprompt:role:user>>>Question"
+		historyMessages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Previous"},
+				},
+			},
+		}
+
+		data := &DataArgument{Messages: historyMessages}
+		result, err := ToMessages(renderedString, data)
+
+		assert.NoError(t, err)
+		// The resulting messages should have the history message inserted
+		// before the user message by the insertHistory function
+		assert.Equal(t, 2, len(result))
+
+		assert.Equal(t, RoleUser, result[0].Role)
+		textPart0, ok := result[0].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Previous", textPart0.Text)
+		assert.Nil(t, result[0].Metadata) // insertHistory shouldn't add history metadata
+
+		assert.Equal(t, RoleUser, result[1].Role)
+		textPart1, ok := result[1].Content[0].(*TextPart)
+		assert.True(t, ok)
+		assert.Equal(t, "Question", textPart1.Text)
+	})
+}
+
+func TestInsertHistory(t *testing.T) {
+	t.Run("should return original messages if history is undefined", func(t *testing.T) {
+		messages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Hello"},
+				},
+			},
+		}
+
+		result, err := insertHistory(messages, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, messages, result)
+	})
+
+	t.Run("should return original messages if history purpose already exists", func(t *testing.T) {
+		messages := []Message{
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Hello"},
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"purpose": "history",
+					},
+				},
+			},
+		}
+
+		history := []Message{
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Previous"},
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"purpose": "history",
+					},
+				},
+			},
+		}
+
+		result, err := insertHistory(messages, history)
+		assert.NoError(t, err)
+		assert.Equal(t, messages, result)
+	})
+
+	t.Run("should insert history before the last user message", func(t *testing.T) {
+		messages := []Message{
+			{
+				Role: RoleSystem,
+				Content: []Part{
+					&TextPart{Text: "System prompt"},
+				},
+			},
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Current question"},
+				},
+			},
+		}
+
+		history := []Message{
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Previous"},
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"purpose": "history",
+					},
+				},
+			},
+		}
+
+		result, err := insertHistory(messages, history)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(result))
+
+		expected := []Message{
+			{
+				Role: RoleSystem,
+				Content: []Part{
+					&TextPart{Text: "System prompt"},
+				},
+			},
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Previous"},
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"purpose": "history",
+					},
+				},
+			},
+			{
+				Role: RoleUser,
+				Content: []Part{
+					&TextPart{Text: "Current question"},
+				},
+			},
+		}
+
+		assert.Equal(t, len(expected), len(result))
+		for i := range expected {
+			assert.Equal(t, expected[i].Role, result[i].Role)
+			assert.Equal(t, expected[i].HasMetadata.Metadata, result[i].HasMetadata.Metadata)
+
+			assert.Equal(t, len(expected[i].Content), len(result[i].Content))
+			for j := range expected[i].Content {
+				expectedPart, ok := expected[i].Content[j].(*TextPart)
+				assert.True(t, ok)
+
+				resultPart, ok := result[i].Content[j].(*TextPart)
+				assert.True(t, ok)
+
+				assert.Equal(t, expectedPart.Text, resultPart.Text)
+			}
+		}
+	})
+
+	t.Run("should append history at the end if no user message is last", func(t *testing.T) {
+		messages := []Message{
+			{
+				Role: RoleSystem,
+				Content: []Part{
+					&TextPart{Text: "System prompt"},
+				},
+			},
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Model message"},
+				},
+			},
+		}
+
+		history := []Message{
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Previous"},
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"purpose": "history",
+					},
+				},
+			},
+		}
+
+		result, err := insertHistory(messages, history)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(result))
+
+		expected := []Message{
+			{
+				Role: RoleSystem,
+				Content: []Part{
+					&TextPart{Text: "System prompt"},
+				},
+			},
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Model message"},
+				},
+			},
+			{
+				Role: RoleModel,
+				Content: []Part{
+					&TextPart{Text: "Previous"},
+				},
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"purpose": "history",
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, len(expected), len(result))
+		for i := range expected {
+			assert.Equal(t, expected[i].Role, result[i].Role)
+			assert.Equal(t, expected[i].HasMetadata.Metadata, result[i].HasMetadata.Metadata)
+
+			assert.Equal(t, len(expected[i].Content), len(result[i].Content))
+			for j := range expected[i].Content {
+				expectedPart, ok := expected[i].Content[j].(*TextPart)
+				assert.True(t, ok)
+
+				resultPart, ok := result[i].Content[j].(*TextPart)
+				assert.True(t, ok)
+
+				assert.Equal(t, expectedPart.Text, resultPart.Text)
+			}
+		}
+	})
+}
+
+func TestParsePart(t *testing.T) {
+	testCases := []struct {
+		name     string
+		piece    string
+		expected Part
+		hasError bool
+	}{
+		{
+			name:     "Text part",
+			piece:    "Hello World",
+			expected: &TextPart{Text: "Hello World"},
+			hasError: false,
+		},
+		{
+			name:  "Media part",
+			piece: "<<<dotprompt:media:url>>> https://example.com/image.jpg",
+			expected: &MediaPart{
+				Media: struct {
+					URL         string `json:"url"`
+					ContentType string `json:"contentType,omitempty"`
+				}{
+					URL: "https://example.com/image.jpg",
+				},
+			},
+			hasError: false,
+		},
+		{
+			name:  "Media part with content type",
+			piece: "<<<dotprompt:media:url>>> https://example.com/image.jpg image/jpeg",
+			expected: &MediaPart{
+				Media: struct {
+					URL         string `json:"url"`
+					ContentType string `json:"contentType,omitempty"`
+				}{
+					URL:         "https://example.com/image.jpg",
+					ContentType: "image/jpeg",
+				},
+			},
+			hasError: false,
+		},
+		{
+			name:  "Section part",
+			piece: "<<<dotprompt:section>>> code",
+			expected: &PendingPart{
+				HasMetadata: HasMetadata{
+					Metadata: map[string]any{
+						"purpose": "code",
+						"pending": true,
+					},
+				},
+			},
+			hasError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parsePart(tc.piece)
+
+			if tc.hasError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				switch expected := tc.expected.(type) {
+				case *TextPart:
+					actual, ok := result.(*TextPart)
+					assert.True(t, ok)
+					assert.Equal(t, expected.Text, actual.Text)
+				case *MediaPart:
+					actual, ok := result.(*MediaPart)
+					assert.True(t, ok)
+					assert.Equal(t, expected.Media.URL, actual.Media.URL)
+					assert.Equal(t, expected.Media.ContentType, actual.Media.ContentType)
+				case *PendingPart:
+					actual, ok := result.(*PendingPart)
+					assert.True(t, ok)
+					assert.Equal(t, expected.Metadata["purpose"], actual.Metadata["purpose"])
+					assert.Equal(t, expected.Metadata["pending"], actual.Metadata["pending"])
+				}
+			}
+		})
+	}
+}
+
+func TestParseMediaPiece(t *testing.T) {
+	t.Run("parse media piece", func(t *testing.T) {
+		piece := "<<<dotprompt:media:url>>> https://example.com/image.jpg"
+		result, err := parseMediaPart(piece)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://example.com/image.jpg", result.Media.URL)
+	})
+}
+
+func TestParseDocument(t *testing.T) {
+	t.Run("parse document with frontmatter and template", func(t *testing.T) {
+		source := `---
+name: test
+description: test description
+foo.bar: value
+---
+Template content`
+
+		result, err := ParseDocument(source)
+		assert.NoError(t, err)
+		assert.Equal(t, "test", result.Name)
+		assert.Equal(t, "test description", result.Description)
+		assert.Equal(t, "Template content", result.Template)
+
+		assert.Contains(t, result.Ext, "foo")
+		assert.Equal(t, "value", result.Ext["foo"]["bar"])
+
+		assert.Equal(t, "test", result.Raw["name"])
+		assert.Equal(t, "test description", result.Raw["description"])
+		assert.Equal(t, "value", result.Raw["foo.bar"])
+	})
+
+	t.Run("handle document without frontmatter", func(t *testing.T) {
+		source := "Just template content"
+
+		result, err := ParseDocument(source)
+		assert.NoError(t, err)
+		assert.NotNil(t, result.Ext)
+		assert.Equal(t, "Just template content", result.Template)
+	})
+
+	t.Run("handle invalid yaml frontmatter", func(t *testing.T) {
+		source := `---
+invalid: : yaml
+---
+Template content`
+
+		result, err := ParseDocument(source)
+		assert.NoError(t, err)
+		assert.NotNil(t, result.Ext)
+		// When YAML is invalid, return source as template
+		assert.Equal(t, source, result.Template)
+	})
+
+	t.Run("handle empty frontmatter", func(t *testing.T) {
+		source := `---
+---
+Template content`
+
+		result, err := ParseDocument(source)
+		assert.NoError(t, err)
+		assert.NotNil(t, result.Ext)
+		assert.Equal(t, "Template content", result.Template)
+	})
+
+	t.Run("handle multiple namespaced entries", func(t *testing.T) {
+		source := `---
+foo.bar: value1
+foo.baz: value2
+qux.quux: value3
+---
+Template content`
+
+		result, err := ParseDocument(source)
+		assert.NoError(t, err)
+
+		assert.Contains(t, result.Ext, "foo")
+		assert.Contains(t, result.Ext, "qux")
+		assert.Equal(t, "value1", result.Ext["foo"]["bar"])
+		assert.Equal(t, "value2", result.Ext["foo"]["baz"])
+		assert.Equal(t, "value3", result.Ext["qux"]["quux"])
+	})
+
+	t.Run("handle reserved keywords", func(t *testing.T) {
+		// Create frontmatter with all reserved keywords except 'ext'
+		var frontmatterParts []string
+		for _, keyword := range ReservedMetadataKeywords {
+			if keyword == "ext" {
+				continue
+			}
+			frontmatterParts = append(frontmatterParts, keyword+": value-"+keyword)
+		}
+
+		// Create source with frontmatter and template
+		source := "---\n" + strings.Join(frontmatterParts, "\n") + "\n---\nTemplate content"
+
+		// Parse the document
+		result, err := ParseDocument(source)
+		assert.NoError(t, err)
+
+		// Check that the result is a ParsedPrompt with the expected template
+		assert.Equal(t, "Template content", result.Template)
+
+		// Check that each reserved keyword field has the expected value
+		// This is the equivalent of the commented-out section in the Python test
+		assert.Equal(t, "value-name", result.Name)
+		assert.Equal(t, "value-description", result.Description)
+		assert.Equal(t, "value-variant", result.Variant)
+		assert.Equal(t, "value-version", result.Version)
+
+		// Check that raw contains all the reserved keywords
+		for _, keyword := range ReservedMetadataKeywords {
+			if keyword == "ext" {
+				continue
+			}
+			assert.Contains(t, result.Raw, keyword)
+			assert.Equal(t, "value-"+keyword, result.Raw[keyword])
+		}
+	})
+}
+
+func TestIsReservedMetadataKeyword(t *testing.T) {
+	testCases := []struct {
+		name     string
+		keyword  string
+		expected bool
+	}{
+		{
+			name:     "name",
+			keyword:  "name",
+			expected: true,
+		},
+		{
+			name:     "description",
+			keyword:  "description",
+			expected: true,
+		},
+		{
+			name:     "variant",
+			keyword:  "variant",
+			expected: true,
+		},
+		{
+			name:     "version",
+			keyword:  "version",
+			expected: true,
+		},
+		{
+			name:     "ext",
+			keyword:  "ext",
+			expected: true,
+		},
+		{
+			name:     "foo",
+			keyword:  "foo",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isReservedMetadataKeyword(tc.keyword))
+		})
+	}
+}

--- a/go/dotprompt/types.go
+++ b/go/dotprompt/types.go
@@ -141,13 +141,16 @@ type DataPart struct {
 	Data map[string]any `json:"data"`
 }
 
+// Media represents a media part of a message.
+type Media struct {
+	URL         string `json:"url"`
+	ContentType string `json:"contentType,omitempty"`
+}
+
 // MediaPart represents a media part of a message.
 type MediaPart struct {
 	HasMetadata
-	Media struct {
-		URL         string `json:"url"`
-		ContentType string `json:"contentType,omitempty"`
-	} `json:"media"`
+	Media Media `json:"media"`
 }
 
 // ToolRequestPart represents a tool request part of a message.

--- a/go/dotprompt/util.go
+++ b/go/dotprompt/util.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dotprompt
+
+// stringOrEmpty returns the string value of an any or an empty string if it's not a string.
+func stringOrEmpty(value any) string {
+	if value == nil {
+		return ""
+	}
+
+	if strValue, ok := value.(string); ok {
+		return strValue
+	}
+
+	return ""
+}
+
+// getMapOrNil returns the map value of an any or nil if it's not a map.
+func getMapOrNil(m map[string]any, key string) map[string]any {
+	if value, ok := m[key]; ok {
+		if mapValue, isMap := value.(map[string]any); isMap {
+			return mapValue
+		}
+	}
+
+	return nil
+}
+
+// copyMapping copies a map.
+func copyMapping[K comparable, V any](mapping map[K]V) map[K]V {
+	newMapping := make(map[K]V)
+	for k, v := range mapping {
+		newMapping[k] = v
+	}
+	return newMapping
+}

--- a/go/dotprompt/util_test.go
+++ b/go/dotprompt/util_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dotprompt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringOrEmpty(t *testing.T) {
+	assert.Equal(t, "", stringOrEmpty(nil))
+	assert.Equal(t, "", stringOrEmpty(""))
+	assert.Equal(t, "test", stringOrEmpty("test"))
+}
+
+func TestGetMapOrNil(t *testing.T) {
+	// Create a test map with a nested map
+	testMap := map[string]any{
+		"mapKey": map[string]any{
+			"key": "value",
+		},
+		"notAMap":  "string value",
+		"nilValue": nil,
+	}
+
+	t.Run("should return nested map for existing key", func(t *testing.T) {
+		result := getMapOrNil(testMap, "mapKey")
+		assert.Equal(t, map[string]any{"key": "value"}, result)
+	})
+
+	t.Run("should return nil for nil map", func(t *testing.T) {
+		result := getMapOrNil(nil, "key")
+		assert.Nil(t, result)
+	})
+
+	t.Run("should return nil for non-existent key", func(t *testing.T) {
+		result := getMapOrNil(testMap, "nonExistentKey")
+		assert.Nil(t, result)
+	})
+
+	t.Run("should return nil for value that's not a map", func(t *testing.T) {
+		result := getMapOrNil(testMap, "notAMap")
+		assert.Nil(t, result)
+	})
+
+	t.Run("should return nil for nil value", func(t *testing.T) {
+		result := getMapOrNil(testMap, "nilValue")
+		assert.Nil(t, result)
+	})
+}
+
+func TestCopyMapping(t *testing.T) {
+	original := map[string]any{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	copy := copyMapping(original)
+
+	assert.Equal(t, original, copy)
+}

--- a/js/src/parse.ts
+++ b/js/src/parse.ts
@@ -157,12 +157,18 @@ export function convertNamespacedEntryToNestedObject(
   value: unknown,
   obj: Record<string, Record<string, unknown>> = {}
 ): Record<string, Record<string, unknown>> {
+  // NOTE: Goes only a single level deep.
+  const result = obj || {};
+
   const lastDotIndex = key.lastIndexOf('.');
   const ns = key.substring(0, lastDotIndex);
   const field = key.substring(lastDotIndex + 1);
-  obj[ns] = obj[ns] || {};
-  obj[ns][field] = value;
-  return obj;
+
+  // Ensure the namespace exists.
+  result[ns] = result[ns] || {};
+  result[ns][field] = value;
+
+  return result;
 }
 
 /**
@@ -340,12 +346,18 @@ export function insertHistory(
     return messages;
   }
 
-  // If the last message is a user message, insert the history before it.
+  // If there are no messages, return the history.
+  if (messages.length === 0) {
+    return history;
+  }
+
   const lastMessage = messages.at(-1);
   if (lastMessage?.role === 'user') {
+    // If the last message is a user message, insert the history before it.
     const messagesWithoutLast = messages.slice(0, -1);
     return [...messagesWithoutLast, ...history, lastMessage];
   }
+
   // Otherwise, append the history to the end of the messages.
   return [...messages, ...history];
 }

--- a/js/vitest.config.mts
+++ b/js/vitest.config.mts
@@ -15,10 +15,10 @@ export default defineConfig({
       reporter: ['text', 'html'],
       thresholds: {
         autoUpdate: true,
-        branches: 88.93,
+        branches: 88.61,
         functions: 95.45,
-        lines: 72.14,
-        statements: 72.14,
+        lines: 72.25,
+        statements: 72.25,
       },
     },
   },

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,7 +36,7 @@ python_files                       = ["**/*_test.py"]
 addopts = "--cov"
 
 [tool.coverage.report]
-fail_under = 70
+fail_under = 85
 
 # uv based package management.
 [tool.uv]


### PR DESCRIPTION
feat(go/parse): parse.go implementation #62
    
ISSUES:
- [x] https://github.com/google/dotprompt/issues/62

CHANGELOG:
- [ ] Add an implementation of parse.ts for Go in parse.go and
  associated tests in parse_test.go
- [ ] Add some utility functions in util.go and associated tests in util_test.go
- [ ] Small fixes here and there to the TS and Py implementations.
- [ ] Update the testing threshold for TS.