### PR TITLE
feat(py): add SafeString implementation that works with js2py

### DIFF
--- a/python/dotpromptz/src/dotpromptz/safe_string.py
+++ b/python/dotpromptz/src/dotpromptz/safe_string.py
@@ -1,0 +1,68 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Safe string implementation for Handlebarz.
+
+This module provides a SafeString class that marks strings as safe for HTML
+output, meaning they will not be escaped when rendered in templates.
+"""
+
+
+class SafeString:
+    """A string that should not be escaped when rendered in templates.
+
+    It enables the user to mark a string as safe and its contents
+    will not be escaped when rendered in templates.
+    """
+
+    def __init__(self, value: str) -> None:
+        """Initialize a SafeString.
+
+        Args:
+            value: The value to wrap.
+        """
+        self._s = value
+
+    def __str__(self) -> str:
+        """Convert to string.
+
+        Returns:
+            The unescaped string content.
+        """
+        return str(self._s)
+
+    def __repr__(self) -> str:
+        """Convert to a Python string representation.
+
+        Returns:
+            The unescaped string content.
+        """
+        return f'SafeString({self._s!r})'
+
+    def to_string(self) -> str:
+        """Convert to string.
+
+        Returns:
+            The unescaped string content.
+        """
+        return str(self._s)
+
+    def to_html(self) -> str:
+        """Convert to HTML.
+
+        Returns:
+            The unescaped string content.
+        """
+        return str(self._s)
+
+    def toHTML(self) -> str:  # noqa: N802
+        """Convert to HTML.
+
+        This function is named 'toHTML' to satisfy the Handlebars.js JS2PY API
+        expectation that any type that exposes this method would be treated as a
+        safe string and not escaped by the Handlebars.js engine.
+
+        Returns:
+            The unescaped string content.
+        """
+        return str(self._s)

--- a/python/dotpromptz/src/dotpromptz/safe_string_test.py
+++ b/python/dotpromptz/src/dotpromptz/safe_string_test.py
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the SafeString class."""
+
+import unittest
+
+from dotpromptz.safe_string import SafeString
+
+
+class TestSafeString(unittest.TestCase):
+    """Test the SafeString class."""
+
+    def test_safe_string(self) -> None:
+        """Test that SafeString objects remain unescaped when passed to
+        escape_expression."""
+        safe = SafeString('<strong>Safe Content</strong>')
+        self.assertEqual(str(safe), '<strong>Safe Content</strong>')
+        self.assertEqual(safe.to_html(), '<strong>Safe Content</strong>')
+        self.assertEqual(safe.toHTML(), '<strong>Safe Content</strong>')
+        self.assertEqual(safe.to_string(), '<strong>Safe Content</strong>')
+
+    def test_safe_string_repr(self) -> None:
+        """Test that SafeString objects have a correct string representation."""
+        safe = SafeString('<strong>Safe Content</strong>')
+        self.assertEqual(
+            repr(safe), "SafeString('<strong>Safe Content</strong>')"
+        )


### PR DESCRIPTION
feat(py): add SafeString implementation that works with js2py
    
The `SafeString` js2py implementation in handlebars-py doesn't
appear to be functional and results in runtime type errors/
missing functionality.

I've implemented a `SafeString` class that implements the same
interface as expected by the JS library based on these files:

- [ ] Escape expression function: https://github.com/yesudeep/handlebars.js/blob/master/lib/handlebars/utils.js#L61
- [ ] JS implementation: https://github.com/yesudeep/handlebars.js/blob/master/lib/handlebars/safe-string.js

CHANGELOG:
- [ ] Add Python implementation for the SafeString class.