### PR TITLE
feat(py): utility function to unquote a string literal coming from js2py handlebars helpers

### DIFF
--- a/python/dotpromptz/src/dotpromptz/util.py
+++ b/python/dotpromptz/src/dotpromptz/util.py
@@ -35,3 +35,28 @@ def remove_undefined_fields(obj: Any) -> Any:
         if value is not None:
             result[key] = remove_undefined_fields(value)
     return result
+
+
+_QUOTE_PAIRS: set[tuple[str, str]] = {('"', '"'), ("'", "'")}
+
+
+def unquote(value: str, pairs: set[tuple[str, str]] | None = None) -> str:
+    """Remove quotes from a string literal representation.
+
+    Args:
+        value: The string to remove quotes from.
+        pairs: Set of quote pairs to remove. When None, uses default pairs
+            ("", "") and ("'", "'").
+
+    Returns:
+        The string with quotes removed.
+    """
+    if pairs is None:
+        pairs = _QUOTE_PAIRS
+
+    str_value = str(value)
+    for start, end in pairs:
+        if str_value.startswith(start) and str_value.endswith(end):
+            return str_value[len(start) : -len(end)]
+
+    return str_value

--- a/python/dotpromptz/src/dotpromptz/util_test.py
+++ b/python/dotpromptz/src/dotpromptz/util_test.py
@@ -7,6 +7,7 @@ import unittest
 
 from dotpromptz.util import (
     remove_undefined_fields,
+    unquote,
 )
 
 
@@ -90,6 +91,37 @@ class TestRemoveUndefinedFields(unittest.TestCase):
         self.assertEqual(remove_undefined_fields([]), [])
         self.assertEqual(remove_undefined_fields({'a': {}}), {'a': {}})
         self.assertEqual(remove_undefined_fields({'a': []}), {'a': []})
+
+
+class TestUnquote(unittest.TestCase):
+    """Tests for unquote."""
+
+    def test_unquote(self) -> None:
+        """Test removing quotes from a string."""
+        self.assertEqual(unquote('"test"'), 'test')
+        self.assertEqual(unquote("'test'"), 'test')
+
+    def test_unquote_leaves_alone_unpaired(self) -> None:
+        """Test that unquote leaves alone strings that are not paired."""
+        self.assertEqual(unquote('test'), 'test')
+        self.assertEqual(unquote("'test"), "'test")
+        self.assertEqual(unquote('"test'), '"test')
+        self.assertEqual(unquote("test'"), "test'")
+        self.assertEqual(unquote('test"'), 'test"')
+        self.assertEqual(unquote('"test\''), '"test\'')
+        self.assertEqual(unquote('\'test"'), '\'test"')
+
+    def test_unquote_leaves_along_internal_quotes(self) -> None:
+        """Test that unquote leaves alone strings with internal quotes."""
+        self.assertEqual(unquote('"test\'test"'), "test'test")
+        self.assertEqual(unquote('\'test"'), '\'test"')
+        self.assertEqual(unquote('"test\'test""'), 'test\'test"')
+        self.assertEqual(unquote("'test\"test''"), 'test"test\'')
+
+    def test_unquote_only_unquotes_one_level(self) -> None:
+        """Test that unquote only removes one level of quotes."""
+        self.assertEqual(unquote('""test\'test""'), '"test\'test"')
+        self.assertEqual(unquote("''test\"test''"), "'test\"test'")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
CHANGELOG:
- [ ] Adds an implementation of an unquote function that
  trims from both ends paired quote characters.
