### PR TITLE
feat(py/dotpromptz): implement helpers in terms of the rust implementation of handlebars-rust

### DIFF
--- a/go/dotprompt/picoschema.go
+++ b/go/dotprompt/picoschema.go
@@ -86,10 +86,11 @@ func (p *PicoschemaParser) Parse(schema any) (*jsonschema.Schema, error) {
 		if err != nil {
 			return nil, err
 		}
+		resolvedSchemaCopy := createCopy(resolvedSchema)
 		if typeDesc[1] != "" {
-			resolvedSchema.Description = typeDesc[1]
+			resolvedSchemaCopy.Description = typeDesc[1]
 		}
-		return resolvedSchema, nil
+		return resolvedSchemaCopy, nil
 	}
 
 	// if there's a JSON schema-ish type at the top level, treat as JSON schema
@@ -156,10 +157,12 @@ func (p *PicoschemaParser) parsePico(obj any, path ...string) (*jsonschema.Schem
 			if err != nil {
 				return nil, err
 			}
+			// Create a deep copy to prevent shared references.
+			resolvedSchemaCopy := createCopy(resolvedSchema)
 			if typeDesc[1] != "" {
-				resolvedSchema.Description = typeDesc[1]
+				resolvedSchemaCopy.Description = typeDesc[1]
 			}
-			return resolvedSchema, nil
+			return resolvedSchemaCopy, nil
 		}
 
 		// Handle the special case for "any" type

--- a/python/dotpromptz/pyproject.toml
+++ b/python/dotpromptz/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["handlebars", "pydantic[email]>=2.10.6"]
+dependencies = ["handlebarrz", "pydantic[email]>=2.10.6"]
 description = "Dotpromptz is a language-neutral executable prompt template file format for Generative AI."
 license = { text = "Apache-2.0" }
 name = "dotpromptz"

--- a/python/handlebarrz/Cargo.toml
+++ b/python/handlebarrz/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
-authors     = ["Yesudeep Mangalapilly <yesudeep@google.com>"]
-description = "Python bindings for handlebars-rust"
-edition     = "2021"
-license     = "Apache-2.0"
-name        = "handlebarrz"
-version     = "0.1.0"
+authors       = ["Yesudeep Mangalapilly <yesudeep@google.com>"]
+description   = "Handlebars library for Python based on handlebars-rust"
+documentation = "https://github.com/google/dotprompt"
+edition       = "2021"
+homepage      = "https://github.com/google/dotprompt"
+license       = "Apache-2.0"
+name          = "handlebarrz"
+repository    = "https://github.com/google/dotprompt"
+version       = "0.1.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/python/handlebarrz/src/lib.rs
+++ b/python/handlebarrz/src/lib.rs
@@ -93,7 +93,7 @@ impl HelperDef for PyHelperDef {
                 Ok(json) => json,
                 Err(e) => {
                     let desc = format!("Failed to serialize params: {}", e);
-                    return Err(RenderError::new(desc));
+                    return Err(RenderError::from(RenderErrorReason::Other(desc.into())));
                 }
             };
 
@@ -107,7 +107,7 @@ impl HelperDef for PyHelperDef {
                 Ok(json) => json,
                 Err(e) => {
                     let desc = format!("Failed to serialize hash: {}", e);
-                    return Err(RenderError::new(desc));
+                    return Err(RenderError::from(RenderErrorReason::Other(desc.into())));
                 }
             };
 
@@ -116,7 +116,7 @@ impl HelperDef for PyHelperDef {
                 Ok(json) => json,
                 Err(e) => {
                     let desc = format!("Failed to serialize context: {}", e);
-                    return Err(RenderError::new(desc));
+                    return Err(RenderError::from(RenderErrorReason::Other(desc.into())));
                 }
             };
 
@@ -129,7 +129,7 @@ impl HelperDef for PyHelperDef {
                         Ok(s) => s,
                         Err(e) => {
                             let desc = format!("Failed to extract result: {}", e);
-                            return Err(RenderError::new(desc));
+                            return Err(RenderError::from(RenderErrorReason::Other(desc.into())));
                         }
                     };
                     out.write(&result_str)?;
@@ -137,7 +137,7 @@ impl HelperDef for PyHelperDef {
                 }
                 Err(e) => {
                     let desc = format!("Helper execution failed: {}", e);
-                    Err(RenderError::new(desc))
+                    Err(RenderError::from(RenderErrorReason::Other(desc.into())))
                 }
             }
         })

--- a/python/tests/smoke/package_test.py
+++ b/python/tests/smoke/package_test.py
@@ -3,11 +3,6 @@
 
 """Smoke tests for package structure."""
 
-import unittest
-
-import js2py
-from handlebars import Handlebars  # type:ignore
-
 # TODO: Replace this with proper imports once we have a proper implementation.
 from dotpromptz import package_name as dotpromptz_package_name
 
@@ -30,83 +25,3 @@ def test_square() -> None:
     assert square(2) == 4
     assert square(3) == 9
     assert square(4) == 16
-
-
-class TestDependencies(unittest.TestCase):
-    def test_js2py_basic_functionality(self) -> None:
-        """Test basic functionality of js2py."""
-        # Simple JavaScript code to be executed
-        js_code = 'function add(a, b) { return a + b; }'
-        # Create a JavaScript context
-        context = js2py.EvalJs()
-        # Execute the JavaScript code
-        context.execute(js_code)
-        # Call the JavaScript function and check the output
-        result = context.add(3, 4)
-        assert result == 7, 'Expected result is 7'
-
-    def test_js2py_variable_handling(self) -> None:
-        """Test JavaScript variable assignment and access."""
-        js_code = 'let greeting = "Hello, World!";'
-        context = js2py.EvalJs()
-        context.execute(js_code)
-        assert context.greeting == 'Hello, World!', 'Variable value mismatch'
-
-    def test_template_rendering(self) -> None:
-        template = Handlebars.compile('Name: {{name}}')
-        result = template({'name': 'Jane'})
-        assert result == 'Name: Jane'
-
-    def test_template_nested_data(self) -> None:
-        """Test template rendering with nested data structures."""
-        template = Handlebars.compile(
-            'User: {{profile.first}} {{profile.last}}'
-        )
-        data = {'profile': {'first': 'Alice', 'last': 'Smith'}}
-        result = template(data)
-        assert result == 'User: Alice Smith', 'Nested data rendering failed'
-
-    def test_handlebars_helpers(self) -> None:
-        """Test custom helper functions."""
-        # Create JS helper using arguments to capture options
-        helper_js = js2py.eval_js(
-            """
-            function() {
-                // Get options from last argument
-                var options = arguments[arguments.length - 1];
-                // Use current context (this) and options.fn
-                return options.fn(this).toUpperCase() + '!!!';
-            }
-        """
-        )
-
-        # Register helper
-        Handlebars.registerHelper('shout', helper_js)
-
-        # Compile and test template
-        template = Handlebars.compile(
-            '{{#shout}}Important: {{message}}{{/shout}}'
-        )
-        result = template({'message': 'hello world'})
-        self.assertEqual(result, 'IMPORTANT: HELLO WORLD!!!')
-
-    def test_handlebars_partials(self) -> None:
-        """Test template partials inclusion."""
-        # Register the partial directly using the Handlebars JS object
-        Handlebars.registerPartial('bio', 'Age: {{age}} | Country: {{country}}')
-
-        # Compile and test the template
-        template = Handlebars.compile('{{> bio}}')
-        result = template({'age': 30, 'country': 'Canada'})
-        self.assertEqual(result, 'Age: 30 | Country: Canada')
-
-    def test_handlebars_comments(self) -> None:
-        """Test template comments handling."""
-        template = Handlebars.compile('Hello {{! This is a comment }}World!')
-        assert template({}) == 'Hello World!'
-
-    def test_handlebars_html_escape(self) -> None:
-        """Test automatic HTML escaping."""
-        template = Handlebars.compile('{{content}}')
-        result = template({'content': '<script>alert()</script>'})
-        assert result == '&lt;script&gt;alert()&lt;/script&gt;'

--- a/python/tests/smoke/pyproject.toml
+++ b/python/tests/smoke/pyproject.toml
@@ -15,8 +15,8 @@ classifiers = [
 ]
 dependencies = [
   "dotpromptz",
-  "handlebars@git+https://github.com/Manurajbharath/handlebars-py.git",
-  "js2py@git+https://github.com/a-j-albert/Js2Py---supports-python-3.13.git",
+  #"handlebars@git+https://github.com/Manurajbharath/handlebars-py.git",
+  #"js2py@git+https://github.com/a-j-albert/Js2Py---supports-python-3.13.git",
 ]
 description = "Packaging smoke test"
 license = { text = "Apache-2.0" }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -462,13 +462,13 @@ name = "dotpromptz"
 version = "0.1.0"
 source = { editable = "dotpromptz" }
 dependencies = [
-    { name = "handlebars" },
+    { name = "handlebarrz" },
     { name = "pydantic", extra = ["email"] },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "handlebars" },
+    { name = "handlebarrz", editable = "handlebarrz" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.6" },
 ]
 
@@ -579,14 +579,6 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
-]
-
-[[package]]
-name = "handlebars"
-version = "0.1.dev12+g5b6ecb1"
-source = { git = "https://github.com/Manurajbharath/handlebars-py.git#5b6ecb1f6dd0ace62d5caf3f70b3ebae33fb53cf" }
-dependencies = [
-    { name = "js2py" },
 ]
 
 [[package]]
@@ -754,16 +746,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/e3/0e0014d6ab159d48189e92044ace13b1e1fe9aa3024ba9f4e8cf172aa7c2/jinxed-1.3.0-py2.py3-none-any.whl", hash = "sha256:b993189f39dc2d7504d802152671535b06d380b26d78070559551cbf92df4fc5", size = 33085 },
-]
-
-[[package]]
-name = "js2py"
-version = "0.74"
-source = { git = "https://github.com/a-j-albert/Js2Py---supports-python-3.13.git#cc64a715727f110b79310b8031e0ade9c501d5d3" }
-dependencies = [
-    { name = "pyjsparser" },
-    { name = "six" },
-    { name = "tzlocal" },
 ]
 
 [[package]]
@@ -1425,12 +1407,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyjsparser"
-version = "2.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/ef/c72abcfa2c6accd03e7c89c400790fc3d908c5804d50a7c4e9ceabd74d23/pyjsparser-2.7.1.tar.gz", hash = "sha256:be60da6b778cc5a5296a69d8e7d614f1f870faf94e1b1b6ac591f2ad5d729579", size = 24196 }
-
-[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1758,16 +1734,10 @@ version = "0.1.0"
 source = { virtual = "tests/smoke" }
 dependencies = [
     { name = "dotpromptz" },
-    { name = "handlebars" },
-    { name = "js2py" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "dotpromptz", editable = "dotpromptz" },
-    { name = "handlebars", git = "https://github.com/Manurajbharath/handlebars-py.git" },
-    { name = "js2py", git = "https://github.com/a-j-albert/Js2Py---supports-python-3.13.git" },
-]
+requires-dist = [{ name = "dotpromptz", editable = "dotpromptz" }]
 
 [[package]]
 name = "sniffio"
@@ -1888,27 +1858,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
-]
-
-[[package]]
-name = "tzdata"
-version = "2025.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/0f/fa4723f22942480be4ca9527bbde8d43f6c3f2fe8412f00e7f5f6746bc8b/tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694", size = 194950 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639", size = 346762 },
-]
-
-[[package]]
-name = "tzlocal"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026 },
 ]
 
 [[package]]

--- a/scripts/build_dists
+++ b/scripts/build_dists
@@ -14,13 +14,15 @@ fi
 
 TOP_DIR=$(git rev-parse --show-toplevel)
 
+# NOTE: Order matters.
 PROJECT_DIRS=(
-  "dotpromptz"
+  "python/handlebarrz"
+  "python/dotpromptz"
 )
 
 for PROJECT_DIR in "${PROJECT_DIRS[@]}"; do
   uv \
-    --directory=${TOP_DIR}/python \
+    --directory="${TOP_DIR}" \
     --project "$PROJECT_DIR" \
     build
 done

--- a/scripts/run_python_tests
+++ b/scripts/run_python_tests
@@ -13,12 +13,14 @@ PYTHON_VERSIONS=(
   "3.13"
 )
 
+pushd "${TOP_DIR}/python"
 for VERSION in "${PYTHON_VERSIONS[@]}"; do
   echo "Running tests with Python ${VERSION}..."
+  uv run --directory handlebarrz maturin build
   uv run \
     --python "python${VERSION}" \
-    --directory "${TOP_DIR}/python" \
     pytest -vv --log-level=DEBUG .
 done
+popd
 
 exit $?


### PR DESCRIPTION
feat(py/dotpromptz): implement helpers in terms of the rust implementation of handlebars-rust and fix go flakiness

1. Fixes flaky tests in the Go picoschema parser by ensuring proper deep
   copying of resolved schemas before description modifications, preventing
   shared references from causing side effects. This ensures consistent behavior
   across different Go versions.

2. Implements some of the handlebars helpers in terms of the
   handlebars-rust wrapper python package handlebarrz.

CHANGELOG:
- [x] Fix flaky tests in Go picoschema parser when working with nested named schemas
- [x] Implement some helpers in helpers.py and tests in helpers_test.py
- [x] Update build and test scripts to build the cargo package before
  running tests.