### PR TITLE
feat(py/dotpromptz): python implementations of if_equals and unless_equals

### DIFF
--- a/python/dotpromptz/README.md
+++ b/python/dotpromptz/README.md
@@ -43,10 +43,20 @@ consistency across different uses of the same prompt.
 Here's an example of a Dotprompt file that extracts structured data from provided text:
 
 ```handlebars
---- model: googleai/gemini-1.5-pro input: schema: text: string output: format: json schema: name?:
-string, the full name of the person age?: number, the age of the person occupation?: string, the
-person's occupation --- Extract the requested information from the given text. If a piece of
-information is not present, omit that field from the output. Text:
+---
+model: googleai/gemini-1.5-pro
+input:
+  schema:
+    text: string
+output:
+  format: json
+  schema:
+    name?: string, the full name of the person
+    age?: number, the age of the person
+    occupation?: string, the person's occupation
+---
+Extract the requested information from the given text. If a piece of information is not
+present, omit that field from the output. Text:
 {{text}}
 ```
 

--- a/python/dotpromptz/src/dotpromptz/helpers.py
+++ b/python/dotpromptz/src/dotpromptz/helpers.py
@@ -1,7 +1,27 @@
 # Copyright 2025 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Custom helpers for the Handlebars template engine."""
+"""Custom helpers for the Handlebars template engine.
+
+Example:
+
+    ```handlebars
+    {{json value}}
+    ```
+
+## Key helpers:
+
+| Helper         | Description                                         |
+|----------------|-----------------------------------------------------|
+| `history`      | Create a dotprompt history marker.                  |
+| `ifEquals`     | Compare two values and return content if equal.     |
+| `json`         | Convert a value to a JSON string.                   |
+| `media`        | Create a dotprompt media marker.                    |
+| `role`         | Create a dotprompt role marker.                     |
+| `section`      | Create a dotprompt section marker.                  |
+| `unlessEquals` | Compare two values and return content unless equal. |
+
+"""
 
 import json
 from typing import Any
@@ -146,10 +166,66 @@ def media_helper(
         return f'<<<dotprompt:media:url {url}>>>'
 
 
+def if_equals_helper(
+    params: list[Any], hash: dict[str, Any], ctx: dict[str, Any]
+) -> str:
+    """ifEquals compares two values and returns appropriate content.
+
+    Args:
+        params: List containing the two values to compare.
+        hash: Hash arguments - provides access to fn and inverse.
+        ctx: Current context.
+
+    Returns:
+        Rendered content based on equality check.
+    """
+    if len(params) < 2:
+        return ''
+
+    arg1, arg2 = params[0], params[1]
+    fn = hash.get('fn')
+    if arg1 == arg2 and fn is not None:
+        return str(fn(ctx))
+    else:
+        inverse = hash.get('inverse')
+        if inverse is not None:
+            return str(inverse(ctx))
+    return ''
+
+
+def unless_equals_helper(
+    params: list[Any], hash: dict[str, Any], ctx: dict[str, Any]
+) -> str:
+    """unlessEquals compares two values and returns appropriate content.
+
+    Args:
+        params: List containing the two values to compare.
+        hash: Hash arguments - provides access to fn and inverse.
+        ctx: Current context.
+
+    Returns:
+        Rendered content based on inequality check.
+    """
+    if len(params) < 2:
+        return ''
+
+    arg1, arg2 = params[0], params[1]
+    fn = hash.get('fn')
+    if arg1 != arg2 and fn is not None:
+        return str(fn(ctx))
+    else:
+        inverse = hash.get('inverse')
+        if inverse is not None:
+            return str(inverse(ctx))
+    return ''
+
+
 def register_all_helpers(handlebars: Handlebars) -> None:
     """Register all custom helpers with the handlebars instance."""
     handlebars.register_helper('history', history_helper)
+    handlebars.register_helper('ifEquals', if_equals_helper)
     handlebars.register_helper('json', json_helper)
     handlebars.register_helper('media', media_helper)
     handlebars.register_helper('role', role_helper)
     handlebars.register_helper('section', section_helper)
+    handlebars.register_helper('unlessEquals', unless_equals_helper)

--- a/python/dotpromptz/src/dotpromptz/helpers_test.py
+++ b/python/dotpromptz/src/dotpromptz/helpers_test.py
@@ -177,3 +177,103 @@ class TestDotpromptHelpers(unittest.TestCase):
             '<<<dotprompt:media:url https://example.com/img.png image/png>>>'
         )
         self.assertEqual(result, expected)
+
+
+class TestIfEqualsHelper(unittest.TestCase):
+    def setUp(self) -> None:
+        self.handlebars = Handlebars()
+        self.handlebars.register_extra_helpers()
+
+    def test_if_equals_helper_equal_values(self) -> None:
+        """Test ifEquals helper with equal integer values."""
+        self.handlebars.register_template(
+            'if_equals_test',
+            '{{#ifEquals arg1 arg2}}yes{{else}}no{{/ifEquals}}',
+        )
+        result = self.handlebars.render(
+            'if_equals_test', {'arg1': 1, 'arg2': 1}
+        )
+        self.assertEqual(result, 'yes')
+
+    def test_if_equals_helper_unequal_values(self) -> None:
+        """Test ifEquals helper with unequal integer values."""
+        self.handlebars.register_template(
+            'if_equals_test',
+            '{{#ifEquals arg1 arg2}}yes{{else}}no{{/ifEquals}}',
+        )
+        result = self.handlebars.render(
+            'if_equals_test', {'arg1': 1, 'arg2': 2}
+        )
+        self.assertEqual(result, 'no')
+
+    def test_if_equals_helper_string_equal_values(self) -> None:
+        """Test ifEquals helper with equal string values."""
+        self.handlebars.register_template(
+            'if_equals_test',
+            '{{#ifEquals arg1 arg2}}yes{{else}}no{{/ifEquals}}',
+        )
+        result = self.handlebars.render(
+            'if_equals_test', {'arg1': 'test', 'arg2': 'test'}
+        )
+        self.assertEqual(result, 'yes')
+
+    def test_if_equals_helper_string_unequal_values(self) -> None:
+        """Test ifEquals helper with unequal string values."""
+        self.handlebars.register_template(
+            'if_equals_test',
+            '{{#ifEquals arg1 arg2}}yes{{else}}no{{/ifEquals}}',
+        )
+        result = self.handlebars.render(
+            'if_equals_test', {'arg1': 'test', 'arg2': 'diff'}
+        )
+        self.assertEqual(result, 'no')
+
+
+class TestUnlessEqualsHelper(unittest.TestCase):
+    def setUp(self) -> None:
+        self.handlebars = Handlebars()
+        self.handlebars.register_extra_helpers()
+
+    def test_unless_equals_helper_unequal_values(self) -> None:
+        """Test unlessEquals helper with unequal integer values."""
+        self.handlebars.register_template(
+            'unless_equals_test',
+            '{{#unlessEquals arg1 arg2}}yes{{else}}no{{/unlessEquals}}',
+        )
+        result = self.handlebars.render(
+            'unless_equals_test', {'arg1': 1, 'arg2': 2}
+        )
+        self.assertEqual(result, 'yes')
+
+    def test_unless_equals_helper_equal_values(self) -> None:
+        """Test unlessEquals helper with equal integer values."""
+        self.handlebars.register_template(
+            'unless_equals_test',
+            '{{#unlessEquals arg1 arg2}}yes{{else}}no{{/unlessEquals}}',
+        )
+        result = self.handlebars.render(
+            'unless_equals_test', {'arg1': 1, 'arg2': 1}
+        )
+        self.assertEqual(result, 'no')
+
+    def test_unless_equals_helper_string_unequal_values(self) -> None:
+        """Test unlessEquals helper with unequal string values."""
+        self.handlebars.register_template(
+            'unless_equals_test',
+            '{{#unlessEquals arg1 arg2}}yes{{else}}no{{/unlessEquals}}',
+        )
+        result = self.handlebars.render(
+            'unless_equals_test', {'arg1': 'test', 'arg2': 'diff'}
+        )
+        self.assertEqual(result, 'yes')
+
+    def test_unless_equals_helper_string_equal_values(self) -> None:
+        """Test unlessEquals helper with equal string values."""
+        self.handlebars.register_template(
+            'unless_equals_test',
+            '{{#unlessEquals arg1 arg2}}yes{{else}}no{{/unlessEquals}}',
+        )
+        result = self.handlebars.render(
+            'unless_equals_test', {'arg1': 'test', 'arg2': 'test'}
+        )
+        self.assertEqual(result, 'no')

--- a/python/handlebarrz/src/handlebarrz/__init__.py
+++ b/python/handlebarrz/src/handlebarrz/__init__.py
@@ -60,9 +60,7 @@ from typing import Any
 import structlog
 
 from ._native import (
-    HandlebarrzTemplate as _HandlebarrzTemplate,
-)
-from ._native import (
+    HandlebarrzTemplate,
     html_escape,
     no_escape,
 )
@@ -114,12 +112,13 @@ class Template:
 
     Attributes:
         strict_mode: Whether to raise errors for missing fields in templates.
-        dev_mode: Whether to enable development mode features for auto-reloading.
+        dev_mode: Whether to enable development mode features for
+            auto-reloading.
     """
 
     def __init__(self) -> None:
         """Create a new Handlebars template engine."""
-        self._template = _HandlebarrzTemplate()
+        self._template = HandlebarrzTemplate()
 
     @property
     def strict_mode(self) -> bool:

--- a/python/handlebarrz/tests/extra_helpers_test.py
+++ b/python/handlebarrz/tests/extra_helpers_test.py
@@ -8,7 +8,7 @@ from typing import Any
 from handlebarrz import Template
 
 
-class TestExtraHelpers(unittest.TestCase):
+class TestIfEqualsHelper(unittest.TestCase):
     def setUp(self) -> None:
         self.template = Template()
         self.template.register_extra_helpers()

--- a/scripts/run_python_tests
+++ b/scripts/run_python_tests
@@ -10,8 +10,8 @@ set -euo pipefail
 TOP_DIR=$(git rev-parse --show-toplevel)
 PYTHON_DIR="${TOP_DIR}/python"
 PYTHON_VERSIONS=(
-  "3.12"
-  "3.13"
+  "python3.12"
+  "python3.13"
 )
 
 echo "=== Running Python tests ==="
@@ -22,9 +22,11 @@ echo ""
 pushd "${PYTHON_DIR}"
 for VERSION in "${PYTHON_VERSIONS[@]}"; do
   echo "Running tests with Python ${VERSION}..."
-  uv run --directory handlebarrz maturin build
+  # NOTE: Build the Rust extension for a specific Python version; otherwise we
+  # see weird missing import errors.
+  uv run --python "${VERSION}" --directory handlebarrz maturin develop
   uv run \
-    --python "python${VERSION}" \
+    --python "${VERSION}" \
     pytest -vv --log-level=DEBUG .
 done
 popd

--- a/scripts/setup
+++ b/scripts/setup
@@ -63,7 +63,7 @@ function dotpromptz::update_path() {
 
   # Check if path is already in PATH
   if [[ ":$PATH:" != *":$new_path:"* ]]; then
-    if [ -n "${ZSH_VERSION:-}" ]; then
+    if [ -n "${ZSH_VERSION-}" ]; then
       echo "export PATH=\"$new_path:\$PATH\"" >>"$HOME/.zshrc"
     else
       echo "export PATH=\"$new_path:\$PATH\"" >>"$HOME/.bashrc"
@@ -119,7 +119,6 @@ function dotpromptz::install_prerequisites() {
       python3 \
       ripgrep
 
-
   elif [[ -x "$(command -v dnf)" ]]; then
     # Fedora-based systems.
     sudo dnf install -y \
@@ -142,8 +141,8 @@ function dotpromptz::install_prerequisites() {
 }
 
 function dotpromptz::install_golangci_lint() {
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
-    | sh -s -- -b $(go env GOPATH)/bin "v${GOLANGCI_LINT_VERSION}"
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh |
+    sh -s -- -b $(go env GOPATH)/bin "v${GOLANGCI_LINT_VERSION}"
 }
 
 function dotpromptz::install_rust() {


### PR DESCRIPTION
feat(py/dotpromptz): python implementations of `if_equals` and `unless_equals`

CHANGELOG:
- [ ] Add helper implementations for `if_equals` and `unless_equals`.
- [ ] Fix formatting in README.md
- [ ] Add documentation to the helpers module.
- [ ] Fix issue with `scripts/run_python_tests` where maturin
      wasn't building the Python-Rust implementation of handlebars
      for a specific version of Python under test.
- [ ] Fix some formatting in `scripts/setup`.
- [ ] Fix typo in `extra_helpers_test.py`