### PR TITLE
feat(go/dotprompt): Add template as a parameter for dotprompt type

### DIFF
--- a/go/dotprompt/dotprompt.go
+++ b/go/dotprompt/dotprompt.go
@@ -41,6 +41,7 @@ type Dotprompt struct {
 	schemaResolver  SchemaResolver
 	partialResolver PartialResolver
 	knownPartials   map[string]bool
+	Template        *raymond.Template
 }
 
 // NewDotprompt creates a new Dotprompt instance with the given options.
@@ -142,10 +143,11 @@ func (dp *Dotprompt) Compile(source string, additionalMetadata *PromptMetadata, 
 	if err != nil {
 		return nil, err
 	}
+	dp.Template = renderTpl
 
 	// RegisterHelpers()
-	dp.RegisterHelpers(dotpromptOptions, renderTpl)
-	err = dp.RegisterPartials(dotpromptOptions, renderTpl, parsedPrompt.Template)
+	dp.RegisterHelpers(dotpromptOptions, dp.Template)
+	err = dp.RegisterPartials(dotpromptOptions, dp.Template, parsedPrompt.Template)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +168,7 @@ func (dp *Dotprompt) Compile(source string, additionalMetadata *PromptMetadata, 
 		inputContext = MergeMaps(defaultInput, data.Input)
 		inputContext = MergeMaps(inputContext, data.Context)
 
-		renderedString, err := renderTpl.Exec(inputContext)
+		renderedString, err := dp.Template.Exec(inputContext)
 
 		if err != nil {
 			return RenderedPrompt{}, err


### PR DESCRIPTION
[ ] Add template as a field for the dotprompt type so that this field can be reference in future using the dotprompt instance if any further operations are required to be done using the template.