### PR TITLE
feat(releases): add release-please configuration to manage releasing multiple versions of projects

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,46 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# We follow conventional commit format for our commit messages.
+# See: https://www.conventionalcommits.org/en/v1.0.0/
+# See: https://github.com/googleapis/release-please#how-should-i-write-my-commits
+
+handlePrefix: true
+primaryBranch: main
+plugins:
+  - "@type": node
+    applyVersionLabel: false
+
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert
+
+scopes:
+  - js
+  - py
+  - go
+  - py/dotpromptz
+  - py/handlebarrz
+  - deps

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,55 @@
+{
+  "packages": {
+    "js": {
+      "release-type": "node",
+      "package-name": "dotprompt",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false
+    },
+    "python/dotpromptz": {
+      "release-type": "python",
+      "package-name": "dotpromptz",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.project.version"
+        }
+      ]
+    },
+    "python/handlebarrz": {
+      "release-type": "python",
+      "package-name": "handlebarrz",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.project.version"
+        }
+      ]
+    },
+    "go": {
+      "release-type": "go",
+      "package-name": "dotprompt-go",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "js": "1.0.1",
+  "python/dotpromptz": "0.1.0",
+  "python/handlebarrz": "0.1.0",
+  "go": "0.1.0"
+}

--- a/docs/contributing/releases.md
+++ b/docs/contributing/releases.md
@@ -1,0 +1,103 @@
+# Making Releases
+
+This repository uses
+[release-please](https://github.com/googleapis/release-please) for managing
+releases across multiple packages. Release-please automates versioning and
+changelog generation based on [Conventional
+Commits](https://www.conventionalcommits.org/).
+
+## Monorepo Structure
+
+The repository is configured to manage releases independently for the following
+packages:
+
+* `js/` - JavaScript implementation of dotprompt
+* `python/dotpromptz/` - Python implementation of dotprompt
+* `python/handlebarrz/` - Python implementation of handlebarrz
+* `go/` - Go implementation of dotprompt
+
+## How It Works
+
+1. When commits are pushed to `main`, `release-please` automatically creates or
+   updates release PRs for each package that has changes.
+2. Each package has its own release PR and will be versioned independently.
+3. When a release PR is merged, `release-please` will:
+   * Create a new release with appropriate tags.
+   * Update the package version.
+   * Generate changelog entries.
+
+## Commit Message Format
+
+To ensure proper versioning, commit messages should follow the [Conventional
+Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+* `feat`: A new feature (triggers a minor version bump)
+* `fix`: A bug fix (triggers a patch version bump)
+* `docs`: Documentation changes
+* `style`: Code style changes (formatting, etc.)
+* `refactor`: Code changes that neither fix bugs nor add features
+* `perf`: Performance improvements
+* `test`: Adding or updating tests
+* `build`: Changes to build system or dependencies
+* `ci`: Changes to CI configuration
+* `chore`: Other changes that don't modify source code
+* `revert`: Reverting a previous commit
+
+### Scopes
+
+To target specific packages, use these scopes:
+
+* `js`: For changes to the JavaScript implementation
+* `py`: For changes affecting all Python packages
+* `py/dotpromptz`: For changes to the Python dotpromptz package
+* `py/handlebarrz`: For changes to the Python handlebarrz package
+* `go`: For changes to the Go implementation
+* `deps`: For dependency updates
+
+### Examples
+
+```
+feat(js): add new template helper function
+
+fix(py/dotpromptz): resolve issue with template parsing
+
+docs(go): update API documentation
+
+build(py/handlebarrz): update build configuration
+```
+
+## Breaking Changes
+
+For breaking changes, add `BREAKING CHANGE:` in the commit message body or
+footer:
+
+```
+feat(js): change API interface
+
+BREAKING CHANGE: The `render` method now returns a Promise instead of a string
+```
+
+This will trigger a major version bump for the affected package.
+
+## Manual Release
+
+If you need to manually trigger a release, you can:
+
+1. Create a new release PR by running the release-please GitHub Action workflow
+   manually
+2. Or push a commit to main with the appropriate conventional commit message
+
+## Checking Release Status
+
+The `.release-please-manifest.json` file tracks the current version of each
+package.


### PR DESCRIPTION
feat(releases): add release-please configuration to manage releasing multiple versions of projects #125
    
ISSUE: https://github.com/google/dotprompt/issues/125

CHANGELOG:
- [ ] Add release please configuration.
- [ ] Add GitHub action to run the release-please-action.
- [ ] Add release management doc.

<img width="1402" alt="making-releases-doc" src="https://github.com/user-attachments/assets/d0849105-305e-43d5-b24f-3e0b6d7d5e14" />
