### PR TITLE
ci: decouple and parallelize building engdocs from python checks

### DIFF
--- a/.github/workflows/engdoc.yml
+++ b/.github/workflows/engdoc.yml
@@ -1,0 +1,86 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Eng Documentation Checks
+
+on:
+  push:
+    paths:
+      - "docs/**"
+      - ".github/workflows/engdoc.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/engdoc.yml"
+
+jobs:
+  engdoc-checks:
+    runs-on: ubuntu-latest
+    env:
+      PATH: ${{ github.workspace }}/go/bin:${{ github.workspace }}/.cargo/bin:${{ github.workspace }}/.local/share/pnpm:${{ github.workspace }}/.local/bin:/usr/local/bin:/usr/bin:/bin
+    strategy:
+      matrix:
+        python-version:
+          - "3.12"
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libffi-dev cmake curl ripgrep
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Set up Go
+        uses: actions/setup-go@main
+        with:
+          go-version: stable
+
+      - name: Install uv and setup Python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: |
+          cd python
+          uv pip install -e .[dev,test,docs]
+
+      - name: Install D2 diagramming tool
+        run: |
+          go install oss.terrastruct.com/d2@latest
+
+      - name: Install mkdocs
+        run: |
+          uv tool install \
+          mkdocs \
+          --with mkdocs-autorefs \
+          --with mkdocs-d2-plugin \
+          --with mkdocs-literate-nav \
+          --with mkdocs-material \
+          --with mkdocs-mermaid2-plugin \
+          --with mkdocs-minify-plugin \
+          --with mkdocstrings[python]
+
+      - name: Build documentation
+        run: uv run mkdocs build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,17 @@
 
 name: Go build, tests and other checks
 
-on: pull_request
+on:
+  push:
+    paths:
+      - "go/**"
+      - "spec/**"
+      - ".github/workflows/go.yml"
+  pull_request:
+    paths:
+      - "go/**"
+      - "spec/**"
+      - ".github/workflows/go.yml"
 
 jobs:
   tests:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,6 +21,9 @@ on:
       - main
       - master
   pull_request:
+    paths:
+      - "go/**"
+      - ".github/workflows/golangci-lint.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,10 +1,32 @@
 # Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: Python Checks
 
-on: pull_request
-
+on:
+  push:
+    paths:
+      - "python/**"
+      - "spec/**"
+      - ".github/workflows/python.yml"
+  pull_request:
+    paths:
+      - "python/**"
+      - "spec/**"
+      - ".github/workflows/python.yml"
 jobs:
   python-checks:
     runs-on: ubuntu-latest
@@ -70,24 +92,6 @@ jobs:
 
       - name: Run Rust tests for handlebarrz
         run: ./scripts/run_rust_tests
-
-      - name: Install d2lang diagramming tool
-        run: go install oss.terrastruct.com/d2@latest
-
-      - name: Install mkdocs
-        run: |
-          uv tool install \
-          mkdocs \
-          --with mkdocs-autorefs \
-          --with mkdocs-d2-plugin \
-          --with mkdocs-literate-nav \
-          --with mkdocs-material \
-          --with mkdocs-mermaid2-plugin \
-          --with mkdocs-minify-plugin \
-          --with mkdocstrings[python]
-
-      - name: Build documentation
-        run: uv run mkdocs build --strict
 
       - name: Build distributions
         run: ./scripts/build_dists

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,12 @@ on:
     paths:
       - "js/**"
       - "spec/**"
+      - ".github/workflows/test.yml"
   pull_request:
     paths:
       - "js/**"
       - "spec/**"
-
+      - ".github/workflows/test.yml"
 jobs:
   test:
     name: Run tests (Node ${{ matrix.node-version }})
@@ -47,10 +48,10 @@ jobs:
           version: 8
 
       - name: Install dependencies
-        run: cd js && pnpm install
+        run: pnpm -C js install
 
       - name: Run tests
-        run: cd js && pnpm test
+        run: pnpm -C js test
 
       - name: Build
-        run: cd js && pnpm build
+        run: pnpm -C js build


### PR DESCRIPTION
ci: decouple and parallelize building engdocs from python checks
    
CHANGELOG:
- [ ] Decouple engdoc CI checks from python checks to speed up
      CI.
- [ ] Use `pnpm -C js` rather than `cd js` in `test.yml`.
- [ ] Update CI checks to run only when relevant code has been
      modified. We don't have cross-runtime dependencies like
      genkit.