### PR TITLE
fix(js): Don't escape HTML in handlebars tags.

### DIFF
--- a/js/src/dotprompt.test.ts
+++ b/js/src/dotprompt.test.ts
@@ -53,7 +53,7 @@ describe('Dotprompt', () => {
       });
 
       const template = '{{customHelper "test"}}';
-      const compiled = Handlebars.compile(template);
+      const compiled = Handlebars.compile(template, { noEscape: true });
       const result = compiled({ customHelper });
 
       expect(result).toBe('HELPER: test');

--- a/js/src/dotprompt.ts
+++ b/js/src/dotprompt.ts
@@ -400,6 +400,7 @@ export class Dotprompt {
       {
         knownHelpers: this.knownHelpers,
         knownHelpersOnly: true,
+        noEscape: true,
       }
     );
 

--- a/spec/variables.yaml
+++ b/spec/variables.yaml
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
 # Tests variable substitution in templates, including provided variables,
 # default values, and variable overriding behavior.
 - name: basic
@@ -52,10 +51,10 @@
         messages:
           - role: user
             content: [{ text: "Hello, Pavel!\n" }]
-    - desc: does not escape HTML
-      data:
-        input: {name: '<b>Pavel</b>'}
-      expect:
-        messages:
-          - role: user
-            content: [{text: "Hello, <b>Pavel</b>!\n"}]
+    # - desc: does not escape HTML
+    #   data:
+    #     input: {name: '<b>Pavel</b>'}
+    #   expect:
+    #     messages:
+    #       - role: user
+    #         content: [{text: "Hello, <b>Pavel</b>!\n"}]

--- a/spec/variables.yaml
+++ b/spec/variables.yaml
@@ -52,3 +52,10 @@
         messages:
           - role: user
             content: [{ text: "Hello, Pavel!\n" }]
+    - desc: does not escape HTML
+      data:
+        input: {name: '<b>Pavel</b>'}
+      expect:
+        messages:
+          - role: user
+            content: [{text: "Hello, <b>Pavel</b>!\n"}]


### PR DESCRIPTION
While escaping HTML in Handlebars makes sense as it was originally an HTML templating language, in Dotprompt the final render target is the Common Model Interface JSON format.

The escaping causes unexpected and unwanted behavior in Dotprompt's context, so the default behavior is changing to not escape HTML.