### PR TITLE
feat(py/dotpromptz): configure handlebars to not escape by default

### DIFF
--- a/python/dotpromptz/src/dotpromptz/dotprompt.py
+++ b/python/dotpromptz/src/dotpromptz/dotprompt.py
@@ -19,22 +19,20 @@
 from __future__ import annotations
 
 import re
-from typing import Any, TypedDict, TypeVar
+from typing import Any, TypedDict
 
 from dotpromptz.helpers import register_all_helpers
 from dotpromptz.parse import parse_document
 from dotpromptz.typing import (
-    DataArgument,
     JsonSchema,
     ParsedPrompt,
     PartialResolver,
-    PromptMetadata,
     PromptStore,
     SchemaResolver,
     ToolDefinition,
     ToolResolver,
 )
-from handlebarrz import Handlebars, HelperFn
+from handlebarrz import EscapeFunction, Handlebars, HelperFn
 
 # Pre-compiled regex for finding partial references in handlebars templates
 
@@ -74,14 +72,19 @@ class Options(TypedDict, total=False):
 class Dotprompt:
     """Dotprompt extends a Handlebars template for use with Gen AI prompts."""
 
-    def __init__(self, options: Options | None = None) -> None:
+    def __init__(
+        self,
+        options: Options | None = None,
+        escape_fn: EscapeFunction = EscapeFunction.NO_ESCAPE,
+    ) -> None:
         """Initialize Dotprompt with a Handlebars template.
 
         Args:
             options: Options for Dotprompt.
         """
         self._options: Options = options or {}
-        self._handlebars: Handlebars = Handlebars()
+        self._handlebars: Handlebars = Handlebars(escape_fn=escape_fn)
+
         self._known_helpers: dict[str, bool] = {}
         self._default_model: str | None = self._options.get('default_model')
         self._model_configs: dict[str, Any] | None = self._options.get(

--- a/python/dotpromptz/tests/dotpromptz/helpers_test.py
+++ b/python/dotpromptz/tests/dotpromptz/helpers_test.py
@@ -30,6 +30,8 @@ from handlebarrz import Handlebars
 
 
 class TestJsonHelper(unittest.TestCase):
+    """Tests for the JSON helper function."""
+
     def test_json_helper_direct(self) -> None:
         """Test the JSON helper function directly."""
         # Basic object
@@ -86,6 +88,8 @@ class TestJsonHelper(unittest.TestCase):
 
 
 class TestRoleHelper(unittest.TestCase):
+    """Tests for the role helper function."""
+
     def test_role_helper_direct(self) -> None:
         """Test role helper function directly."""
         result = role_helper(['system'], {}, {})
@@ -100,6 +104,8 @@ class TestRoleHelper(unittest.TestCase):
 
 
 class TestHistoryHelper(unittest.TestCase):
+    """Tests for the history helper function."""
+
     def test_history_helper_direct(self) -> None:
         """Test history helper function directly."""
         result = history_helper([], {}, {})
@@ -107,6 +113,8 @@ class TestHistoryHelper(unittest.TestCase):
 
 
 class TestSectionHelper(unittest.TestCase):
+    """Tests for the section helper function."""
+
     def test_section_helper_direct(self) -> None:
         """Test section helper function directly."""
         result = section_helper(['test'], {}, {})
@@ -119,6 +127,8 @@ class TestSectionHelper(unittest.TestCase):
 
 
 class TestMediaHelper(unittest.TestCase):
+    """Tests for the media helper function."""
+
     def test_media_helper_direct(self) -> None:
         """Test media helper function directly."""
         # With URL only.
@@ -147,6 +157,8 @@ class TestMediaHelper(unittest.TestCase):
 
 
 class TestDotpromptHelpers(unittest.TestCase):
+    """Tests for the dotprompt helpers."""
+
     def test_dotprompt_helpers_in_template(self) -> None:
         """Test dotprompt helpers in templates."""
         handlebars = Handlebars()
@@ -192,7 +204,10 @@ class TestDotpromptHelpers(unittest.TestCase):
 
 
 class TestIfEqualsHelper(unittest.TestCase):
+    """Tests for the ifEquals helper function."""
+
     def setUp(self) -> None:
+        """Set up the test environment."""
         self.handlebars = Handlebars()
         self.handlebars.register_extra_helpers()
 
@@ -242,7 +257,10 @@ class TestIfEqualsHelper(unittest.TestCase):
 
 
 class TestUnlessEqualsHelper(unittest.TestCase):
+    """Tests for the unlessEquals helper function."""
+
     def setUp(self) -> None:
+        """Set up the test environment."""
         self.handlebars = Handlebars()
         self.handlebars.register_extra_helpers()
 
@@ -289,3 +307,7 @@ class TestUnlessEqualsHelper(unittest.TestCase):
             'unless_equals_test', {'arg1': 'test', 'arg2': 'test'}
         )
         self.assertEqual(result, 'no')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/dotpromptz/tests/dotpromptz/util_test.py
+++ b/python/dotpromptz/tests/dotpromptz/util_test.py
@@ -25,6 +25,8 @@ from dotpromptz.util import (
 
 
 class TestRemoveUndefinedFields(unittest.TestCase):
+    """Tests for remove_undefined_fields."""
+
     def test_remove_undefined_fields_recursively(self) -> None:
         """Test removing undefined fields from dictionaries."""
         input_dict = {

--- a/python/handlebarrz/src/handlebarrz/__init__.py
+++ b/python/handlebarrz/src/handlebarrz/__init__.py
@@ -136,9 +136,24 @@ class Template:
             auto-reloading.
     """
 
-    def __init__(self) -> None:
-        """Create a new Handlebars template engine."""
+    def __init__(
+        self,
+        escape_fn: EscapeFunction = EscapeFunction.HTML_ESCAPE,
+        strict_mode: bool = False,
+        dev_mode: bool = False,
+    ) -> None:
+        """Create a new Handlebars template engine.
+
+        Args:
+            escape_fn: The escape function to use for HTML escaping.
+            strict_mode: Whether to raise errors for missing fields in templates.
+            dev_mode: Whether to enable development mode features for
+                auto-reloading.
+        """
         self._template: HandlebarrzTemplate = HandlebarrzTemplate()
+        self._template.set_escape_fn(escape_fn)
+        self._template.set_strict_mode(strict_mode)
+        self._template.set_dev_mode(dev_mode)
 
     @property
     def strict_mode(self) -> bool:


### PR DESCRIPTION
CHANGELOG:
- [ ] Configure Handlebars for dotpromptz to not escape HTML by default.
