### PR TITLE
chore(js): Bump version to 1.1.0

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotprompt",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Dotprompt: Executable GenAI Prompt Templates",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Going to cut a release to get the default escaping changed in the next JS release of Genkit.