### PR TITLE
fix: remove spurious role type `assistant`

### DIFF
--- a/go/dotprompt/parse.go
+++ b/go/dotprompt/parse.go
@@ -66,7 +66,6 @@ var (
 	//
 	// Examples of matching patterns:
 	// - <<<dotprompt:role:user>>>
-	// - <<<dotprompt:role:assistant>>>
 	// - <<<dotprompt:role:system>>>
 	// - <<<dotprompt:history>>>
 	RoleAndHistoryMarkerRegex = regexp.MustCompile(

--- a/go/dotprompt/types.go
+++ b/go/dotprompt/types.go
@@ -224,11 +224,10 @@ type Role string
 
 // Predefined roles.
 const (
-	RoleAssistant Role = "assistant"
-	RoleModel     Role = "model"
-	RoleSystem    Role = "system"
-	RoleTool      Role = "tool"
-	RoleUser      Role = "user"
+	RoleModel  Role = "model"
+	RoleSystem Role = "system"
+	RoleTool   Role = "tool"
+	RoleUser   Role = "user"
 )
 
 // Message represents a message in a conversation.

--- a/js/src/parse.ts
+++ b/js/src/parse.ts
@@ -73,7 +73,6 @@ export const FRONTMATTER_AND_BODY_REGEX =
  *
  * Examples of matching patterns:
  * - <<<dotprompt:role:user>>>
- * - <<<dotprompt:role:assistant>>>
  * - <<<dotprompt:role:system>>>
  * - <<<dotprompt:history>>>
  *

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -128,9 +128,7 @@ export type Part =
   | ToolResponsePart
   | PendingPart;
 
-// TODO: Check with mbleigh whether it is okay to add 'assistant' here.
-// TODO: Also update typing.py depending on what is decided.
-export type Role = 'user' | 'model' | 'tool' | 'system' | 'assistant';
+export type Role = 'user' | 'model' | 'tool' | 'system';
 
 export interface Message extends HasMetadata {
   role: Role;
@@ -167,7 +165,7 @@ export type JSONSchema = any;
  * provided by an external tool.
  **/
 export type SchemaResolver = (
-  schemaName: string,
+  schemaName: string
 ) => JSONSchema | null | Promise<JSONSchema | null>;
 
 /**
@@ -176,7 +174,7 @@ export type SchemaResolver = (
  * provided by an external library.
  **/
 export type ToolResolver = (
-  toolName: string,
+  toolName: string
 ) => ToolDefinition | null | Promise<ToolDefinition | null>;
 
 /**
@@ -197,7 +195,7 @@ export interface RenderedPrompt<ModelConfig = Record<string, any>>
 export interface PromptFunction<ModelConfig = Record<string, any>> {
   (
     data: DataArgument,
-    options?: PromptMetadata<ModelConfig>,
+    options?: PromptMetadata<ModelConfig>
   ): Promise<RenderedPrompt<ModelConfig>>;
   prompt: ParsedPrompt<ModelConfig>;
 }
@@ -209,7 +207,7 @@ export interface PromptFunction<ModelConfig = Record<string, any>> {
 export interface PromptRefFunction<ModelConfig = Record<string, any>> {
   (
     data: DataArgument,
-    options?: PromptMetadata<ModelConfig>,
+    options?: PromptMetadata<ModelConfig>
   ): Promise<RenderedPrompt<ModelConfig>>;
   promptRef: PromptRef;
 }

--- a/python/dotpromptz/src/dotpromptz/parse.py
+++ b/python/dotpromptz/src/dotpromptz/parse.py
@@ -71,7 +71,6 @@ FRONTMATTER_AND_BODY_REGEX = re.compile(
 #
 # Examples of matching patterns:
 # - <<<dotprompt:role:user>>>
-# - <<<dotprompt:role:assistant>>>
 # - <<<dotprompt:role:system>>>
 # - <<<dotprompt:history>>>
 #

--- a/python/dotpromptz/src/dotpromptz/typing.py
+++ b/python/dotpromptz/src/dotpromptz/typing.py
@@ -367,7 +367,6 @@ class Role(str, Enum):
     MODEL = 'model'
     TOOL = 'tool'
     SYSTEM = 'system'
-    ASSISTANT = 'assistant'
 
 
 # Role constants with ROLE_ prefix for explicit imports
@@ -375,7 +374,6 @@ ROLE_USER = Role.USER
 ROLE_MODEL = Role.MODEL
 ROLE_TOOL = Role.TOOL
 ROLE_SYSTEM = Role.SYSTEM
-ROLE_ASSISTANT = Role.ASSISTANT
 
 
 class Message(HasMetadata):


### PR DESCRIPTION
fix: remove spurious role type `assistant`

CHANGELOG:
- [ ] Remove spurious role type `assistant` throughout type defs
      in Python, JS and Go.