### PR TITLE
docs: add table about the scopes to use for conventional commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,18 @@ All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
+
+### Commit Messages
+
+We use [Conventional Commits](https://conventionalcommits.org) for our
+commit message format. The following scopes must be used whenever submitting
+PRs to ensure they get included in our release notes:
+
+| Scope           | Description                                  |
+|-----------------|----------------------------------------------|
+| `deps`          | For dependency updates                       |
+| `go`            | For changes to the Go implementation         |
+| `js`            | For changes to the JavaScript implementation |
+| `py/dotpromptz` | For changes to the Python dotpromptz package |
+| `py/handlebarrz`| For changes to the Python handlebarrz package|
+| `py`            | For changes affecting all Python packages    |


### PR DESCRIPTION
CHANGELOG:
- [ ] Add table of common scopes to the `CONTRIBUTING.md` file.
