### PR TITLE
fix(go): lint errors reported in #176

### DIFF
--- a/go/dotprompt/dotprompt.go
+++ b/go/dotprompt/dotprompt.go
@@ -274,10 +274,10 @@ func (dp *Dotprompt) resolvePartials(template string, tpl *raymond.Template) err
 func mergeMetadata(parsedPrompt ParsedPrompt, additionalMetadata *PromptMetadata) ParsedPrompt {
 	if additionalMetadata != nil {
 		if additionalMetadata.Model != "" {
-			parsedPrompt.PromptMetadata.Model = additionalMetadata.Model
+			parsedPrompt.Model = additionalMetadata.Model
 		}
 		if additionalMetadata.Config != nil {
-			parsedPrompt.PromptMetadata.Config = additionalMetadata.Config
+			parsedPrompt.Config = additionalMetadata.Config
 		}
 	}
 	return parsedPrompt
@@ -304,7 +304,7 @@ func (dp *Dotprompt) RenderMetadata(source any, additionalMetadata *PromptMetada
 	}
 	selectedModel := additionalMetadata.Model
 	if selectedModel == "" {
-		selectedModel = parsedSource.PromptMetadata.Model
+		selectedModel = parsedSource.Model
 	}
 	if selectedModel == "" {
 		selectedModel = dp.defaultModel

--- a/go/dotprompt/parse.go
+++ b/go/dotprompt/parse.go
@@ -593,11 +593,12 @@ func parseMediaPart(piece string) (*MediaPart, error) {
 	n := len(fields)
 
 	var url, contentType string
-	if n == 3 {
+	switch n {
+	case 3:
 		url, contentType = fields[1], fields[2]
-	} else if n == 2 {
+	case 2:
 		url = fields[1]
-	} else {
+	default:
 		return nil, fmt.Errorf(
 			"invalid media piece: %s; expected 2 or 3 fields, found %d",
 			piece, n)

--- a/go/dotprompt/parse_test.go
+++ b/go/dotprompt/parse_test.go
@@ -973,7 +973,7 @@ func TestInsertHistory(t *testing.T) {
 		assert.Equal(t, len(expected), len(result))
 		for i := range expected {
 			assert.Equal(t, expected[i].Role, result[i].Role)
-			assert.Equal(t, expected[i].HasMetadata.Metadata, result[i].HasMetadata.Metadata)
+			assert.Equal(t, expected[i].Metadata, result[i].Metadata)
 
 			assert.Equal(t, len(expected[i].Content), len(result[i].Content))
 			for j := range expected[i].Content {
@@ -1051,7 +1051,7 @@ func TestInsertHistory(t *testing.T) {
 		assert.Equal(t, len(expected), len(result))
 		for i := range expected {
 			assert.Equal(t, expected[i].Role, result[i].Role)
-			assert.Equal(t, expected[i].HasMetadata.Metadata, result[i].HasMetadata.Metadata)
+			assert.Equal(t, expected[i].Metadata, result[i].Metadata)
 
 			assert.Equal(t, len(expected[i].Content), len(result[i].Content))
 			for j := range expected[i].Content {

--- a/go/dotprompt/test/spec_test.go
+++ b/go/dotprompt/test/spec_test.go
@@ -238,8 +238,8 @@ func pruneResult(t *testing.T, result PromptMetadata) map[string]any {
 		}
 		pruned["output"] = outputMap
 	}
-	if len(result.HasMetadata.Metadata) > 0 {
-		pruned["metadata"] = result.HasMetadata.Metadata
+	if len(result.Metadata) > 0 {
+		pruned["metadata"] = result.Metadata
 	}
 	return pruned
 }
@@ -276,8 +276,8 @@ func pruneMessages(messages []Message) []map[string]any {
 		if len(message.Content) > 0 {
 			prunedMessage["content"] = pruneContent(message.Content)
 		}
-		if len(message.HasMetadata.Metadata) > 0 {
-			prunedMessage["metadata"] = message.HasMetadata.Metadata
+		if len(message.Metadata) > 0 {
+			prunedMessage["metadata"] = message.Metadata
 		}
 		if len(message.Role) > 0 {
 			prunedMessage["role"] = message.Role


### PR DESCRIPTION
CHANGELOG:
- [ ] Fixes lint across `dotprompt.go`, `parse.go`, `parse_test.go`, and `spec_test.go`
