### PR TITLE
fix(docs): correct type for tags in getting-started.mdx

### DIFF
--- a/third_party/docsite/src/content/docs/getting-started.mdx
+++ b/third_party/docsite/src/content/docs/getting-started.mdx
@@ -39,7 +39,7 @@ output:
   schema:
     title?: string, the title of the article if it has one
     summary: string, a 3-sentence summary of the text
-    tags?(array, a list of string tag category for the text): String, 
+    tags?(array, a list of string tag category for the text): string, 
 ---
 
 Extract the requested information from the given text. If a piece of information is not present, omit that field from the output.


### PR DESCRIPTION
In Handlebars templates, the capitalized `String` is not the correct type name; lowercase `string` is the proper type notation. This PR fixes the type name in `getting-started.mdx`
