### PR TITLE
fix(go/dotprompt): format require sections

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -6,21 +6,17 @@ require (
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/goccy/go-yaml v1.16.0
-	github.com/stretchr/testify v1.10.0
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/invopop/jsonschema v0.13.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0
+	github.com/wk8/go-ordered-map/v2 v2.1.8
 )
-
-require github.com/wk8/go-ordered-map/v2 v2.1.8
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Same as title, format `require` section on `go.mod`.