### PR TITLE
feat(py/dotpromptz): translate render_metadata for dotprompt.py from ts

### DIFF
--- a/js/src/dotprompt.ts
+++ b/js/src/dotprompt.ts
@@ -275,6 +275,7 @@ export class Dotprompt {
     out = outWithoutTemplate as PromptMetadata<ModelConfig>;
 
     out = removeUndefinedFields(out);
+    // TODO: Can this be done concurrently?
     out = await this.resolveTools(out);
     out = await this.renderPicoschema(out);
 
@@ -485,12 +486,12 @@ export class Dotprompt {
       parsedSource = source;
     }
 
-    const selectedModel =
+    const model =
       additionalMetadata?.model || parsedSource.model || this.defaultModel;
 
     let modelConfig: ModelConfig | undefined;
-    if (selectedModel && this.modelConfigs[selectedModel]) {
-      modelConfig = this.modelConfigs[selectedModel] as ModelConfig;
+    if (model && this.modelConfigs[model]) {
+      modelConfig = this.modelConfigs[model] as ModelConfig;
     }
 
     return this.resolveMetadata<ModelConfig>(


### PR DESCRIPTION
CHANGELOG:
- [ ] Adds a verbatim translation of the renderMetadta function from TS
  for Python.
