### PR TITLE
fix(py): issue with test runner script not isolating environments properly

### DIFF
--- a/scripts/run_python_tests_with_tox
+++ b/scripts/run_python_tests_with_tox
@@ -27,4 +27,4 @@ echo "Running Python tests via tox..."
 # Use uv run to execute tox, passing the --parallel flag to tox
 # The '-p auto' flag tells tox to use available CPU cores for parallelism.
 # Any arguments passed to this script ($@) are forwarded to tox (and then pytest)
-uv run --directory "$PY_DIR" tox "$@"
+uv run --active --directory "$PY_DIR" tox "$@"


### PR DESCRIPTION
```
warning: VIRTUAL_ENV=~/dotprompt/.venv does not match the project environment
path .venv and will be ignored; use --active to target the active environment instead

CHANGELOG:
- [ ] Update the `scripts/run_python_tests_with_tox` script to use the active environment
