### PR TITLE
fix(ci): warnings when running tests/linters with uv

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -65,13 +65,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Format check
-        run: uv run --directory python ruff format --check --preview .
+        run: uv run --active --directory python ruff format --check --preview .
 
       - name: Lint with ruff
-        run: uv run --directory python ruff check --select I .
+        run: uv run --active --directory python ruff check --select I .
 
       - name: Static type check
-        run: uv run --directory python mypy .
+        run: uv run --active --directory python mypy .
 
       - name: Check licenses
         run: ./scripts/check_license


### PR DESCRIPTION
`warning: `VIRTUAL_ENV=/home/runner/work/dotprompt/dotprompt/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead`
