### PR TITLE
ci(py): add a convenience script to run python tests with nox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 /js/dist
 /third_party/docsite/src/content/refdocs
 bazel-*
-node_modules
-site/
 go/coverage.out
+node_modules
+python/.nox
+python/.tox
 python/handlebarrz/target
+site/

--- a/captainhook.json
+++ b/captainhook.json
@@ -46,7 +46,7 @@
           "run": "scripts/run_rust_tests"
         },
         {
-          "run": "uv run --active --directory python nox -s tests"
+          "run": "scripts/run_python_tests_with_nox -s tests"
         },
         {
           "run": "scripts/run_js_tests"
@@ -98,7 +98,7 @@
           "run": "scripts/run_rust_tests --verbose"
         },
         {
-          "run": "uv run --active --directory python nox -s tests"
+          "run": "scripts/run_python_tests_with_nox -s tests"
         },
         {
           "run": "scripts/run_js_tests"

--- a/scripts/run_python_tests_with_nox
+++ b/scripts/run_python_tests_with_nox
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Run tests for all supported Python versions using tox
+
+set -euo pipefail
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+PY_DIR="$TOP_DIR/python"
+
+echo "Running Python tests via nox..."
+
+uv run --active --directory "$PY_DIR" nox "$@"


### PR DESCRIPTION
CHANGELOG:
- [ ] Update ignore rules to exclude tox and nox output.
- [ ] Add a convenience script to run python tests with nox.
- [ ] Update captainhook.json
