### PR TITLE
fix(js): line-separator matching

### DIFF
--- a/js/src/parse.test.ts
+++ b/js/src/parse.test.ts
@@ -17,6 +17,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { Dotprompt } from './dotprompt';
+import type { MessageSource } from './parse';
 import {
   FRONTMATTER_AND_BODY_REGEX,
   MEDIA_AND_SECTION_MARKER_REGEX,
@@ -38,7 +40,6 @@ import {
   toMessages,
   transformMessagesToHistory,
 } from './parse';
-import type { MessageSource } from './parse';
 import type { DataArgument, Message } from './types';
 
 describe('ROLE_AND_HISTORY_MARKER_REGEX', () => {
@@ -865,5 +866,26 @@ Template content`;
       ext: {},
       template: 'Template content',
     });
+  });
+});
+
+describe('parseDocumentWithCRLF', () => {
+  it('should parse document with CRLF line separators', async () => {
+    const source =
+      '---\r\ninput:\r\n  schema:\r\n    scope: string\r\noutput:\r\n  schema:\r\n    result: string\r\n---\r\n';
+    const prompt = new Dotprompt();
+    await expect(prompt.render(source)).resolves.toEqual(expect.anything());
+  });
+  it('should parse document with LF line separators', async () => {
+    const source =
+      '---\ninput:\n  schema:\n    scope: string\noutput:\n  schema:\n    result: string\n---\n';
+    const prompt = new Dotprompt();
+    await expect(prompt.render(source)).resolves.toEqual(expect.anything());
+  });
+  it('should parse document with CR line separators', async () => {
+    const source =
+      '---\rinput:\r  schema:\r    scope: string\routput:\r  schema:\r    result: string\r---\r';
+    const prompt = new Dotprompt();
+    await expect(prompt.render(source)).resolves.toEqual(expect.anything());
   });
 });

--- a/js/src/parse.ts
+++ b/js/src/parse.ts
@@ -65,7 +65,7 @@ export const SECTION_MARKER_PREFIX = '<<<dotprompt:section';
  * the start of a .prompt content block.
  */
 export const FRONTMATTER_AND_BODY_REGEX =
-  /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+  /^---\s*(?:\r\n|\r|\n)([\s\S]*?)(?:\r\n|\r|\n)---\s*(?:\r\n|\r|\n)([\s\S]*)$/;
 
 /**
  * Regular expression to match <<<dotprompt:role:xxx>>> and


### PR DESCRIPTION
## Description of the Issue

When a `.prompt` file uses **CRLF** (`\r\n`) as the line separator—which is standard on Windows—the parser fails to render the content. This issue is critical for the **Genkit** project, as it prevents startup when loading such prompt files.

## Expected Behavior

The parser should handle all common line endings—CRLF (`\r\n`), LF (`\n`), and CR (`\r`)—consistently and without error. A new test case, `parseDocumentWithCRLF`, demonstrates the expected behavior across the three scenarios.

## Proposed Solution

Update the `FRONTMATTER_AND_BODY_REGEX` to support all standard line endings by replacing `\n` with a non-capturing group:

```regex
^---\s*(?:\r\n|\r|\n)([\s\S]*?)(?:\r\n|\r|\n)---\s*(?:\r\n|\r|\n)([\s\S]*)$
```

## Note for maintainers
This issue may also exist in the Go and Python variants, as they appear to use similar regular expressions. However, those implementations might rely on YAML parsers that are more tolerant of line-ending styles. It would be worth porting the new test cases to those codebases to confirm consistent behavior across implementations.
