### PR TITLE
fix(docs): add documentation explaining yaml spec test format and revert typo

### DIFF
--- a/python/dotpromptz/tests/dotpromptz/spec_test.py
+++ b/python/dotpromptz/tests/dotpromptz/spec_test.py
@@ -14,6 +14,89 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Runs specification tests defined in YAML files located in the `spec` directory.
+
+These YAML files define test suites for Dotprompt templates.
+The general structure of each YAML file is a list of test suites.
+
+- Each YAML file is a set of test suites.
+- Each test suite is a set of tests.
+- Each test is a set of expectations.
+
+Each test suite object in the list typically contains the following keys:
+
+| Key                | Type   | Description                                                                          |
+|--------------------|--------|--------------------------------------------------------------------------------------|
+| `name`             | string | An identifier for this group of tests.                                               |
+| `template`         | string | The Dotprompt template content (often multi-line, and may include YAML frontmatter). |
+| `tests`            | list   | A list of individual test scenarios. Each scenario object has keys: `desc` (string), |
+|                    |        | `data` (object, optional), `expect` (object).                                        |
+| `partials`         | object | (Optional) A mapping where keys are partial names and values are the string content  |
+|                    |        | of those partials. (e.g., see `partials.yaml`)                                       |
+| `resolverPartials` | object | (Optional) Similar to `partials`, but for partials                                   |
+|                    |        | that are expected to be provided by a resolver function. (e.g., see `partials.yaml`) |
+
+Each test scenario object (i.e., an item in the `tests` list) has the following keys:
+
+| Key      | Type   | Description                                                         |
+|----------|--------|---------------------------------------------------------------------|
+| `desc`   | string | A description of the specific test case.                            |
+| `data`   | object | (Optional) Input data for the template. This can include `context`, |
+|          |        | `input`, or other variables relevant to the template.               |
+| `expect` | object | Defines the expected outcome. Common keys include                   |
+|          |        | (list), and others corresponding to parsed frontmatter (`config`,   |
+|          |        | `model`, `output.schema`, `input.schema`, `ext`, `raw`).            |
+
+The YAML files located in the `spec/helpers` subdirectory also follow this
+general structure, but are specifically focused on testing individual helper
+functions available within the Dotprompt templating environment.
+
+The structure of the YAML files is as follows:
+
+```
+spec/
+├── *.yaml (e.g., metadata.yaml, partials.yaml, picoschema.yaml, etc.)
+│   └── List of Test Suites
+│       └── Test Suite 1
+│           ├── name: "suite_name_1"
+│           ├── template: "..."
+│           ├── partials: { ... } (optional)
+│           ├── resolverPartials: { ... } (optional)
+│           └── tests:
+│               ├── Test Case 1.1
+│               │   ├── desc: "description_1.1"
+│               │   ├── data: { ... } (optional)
+│               │   └── expect: { ... }
+│               ├── Test Case 1.2
+│               │   ├── desc: "description_1.2"
+│               │   ├── data: { ... } (optional)
+│               │   └── expect: { ... }
+│               └── ... (more test cases)
+│       └── Test Suite 2
+│           ├── name: "suite_name_2"
+│           ├── template: "..."
+│           └── tests:
+│               ├── Test Case 2.1
+│               │   ├── desc: "description_2.1"
+│               │   └── expect: { ... }
+│               └── ... (more test cases)
+│       └── ... (more test suites)
+│
+└── helpers/
+    ├── *.yaml (e.g., history.yaml, json.yaml, ifEquals.yaml, etc.)
+    │   └── List of Test Suites (same structure as above)
+    │       └── Test Suite H1
+    │           ├── name: "helper_suite_name_1"
+    │           ├── template: "..."
+    │           └── tests:
+    │               ├── Test Case H1.1
+    │               │   ├── desc: "description_H1.1"
+    │               │   └── expect: { ... }
+    │               └── ...
+    └── ... (more helper spec files)
+```
+"""
+
 from __future__ import annotations
 
 import unittest
@@ -23,7 +106,7 @@ from typing import Any, TypedDict, cast
 import structlog
 import yaml
 
-from dotpromptz.typing import DataArgument
+from dotpromptz.typing import DataArgument, JsonSchema, ToolDefinition
 
 logger = structlog.get_logger(__name__)
 
@@ -54,8 +137,8 @@ class SpecSuite(TypedDict, total=False):
     name: str
     template: str
     data: DataArgument[Any]
-    schemas: dict[str, Any]
-    tools: list[Any]
+    schemas: dict[str, JsonSchema]
+    tools: dict[str, ToolDefinition]
     partials: dict[str, str]
     resolver_partials: dict[str, str]
     tests: list[SpecTest]


### PR DESCRIPTION
CHANGELOG:
- [ ] Document the YAML spec test format.
