### PR TITLE
feat(py): fix picoschema spec test

### DIFF
--- a/python/dotpromptz/src/dotpromptz/parse.py
+++ b/python/dotpromptz/src/dotpromptz/parse.py
@@ -261,7 +261,8 @@ def parse_document(source: str) -> ParsedPrompt[T]:
                 raw=raw,
                 template=body.strip(),
             )
-        except Exception:
+        except Exception as e:
+            print(f'Dotprompt: Error building a parsed prompt object: {e}')
             # Return a basic ParsedPrompt with just the template
             return ParsedPrompt(
                 ext={},

--- a/python/dotpromptz/src/dotpromptz/typing.py
+++ b/python/dotpromptz/src/dotpromptz/typing.py
@@ -157,8 +157,8 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, Field
 
-Schema = dict[str, Any]
-"""Type alias for a generic schema, represented as a dictionary."""
+Schema = Any
+"""Type alias for a generic schema."""
 
 JsonSchema = Any
 """Type alias for a JSON schema definition. 'Any' allows flexibility."""

--- a/python/dotpromptz/tests/dotpromptz/spec_test.py
+++ b/python/dotpromptz/tests/dotpromptz/spec_test.py
@@ -118,6 +118,7 @@ from dotpromptz.typing import (
     ModelConfigT,
     PromptInputConfig,
     PromptMetadata,
+    PromptOutputConfig,
     ToolDefinition,
 )
 
@@ -140,8 +141,8 @@ ALLOWLISTED_FILES = [
     'spec/helpers/section.yaml',
     'spec/variables.yaml',
     'spec/partials.yaml',
+    'spec/picoschema.yaml',
     # 'spec/metadata.yaml',
-    # 'spec/picoschema.yaml',
 ]
 
 # Counters for test class and test method names.
@@ -155,6 +156,7 @@ class Expect(BaseModel):
     config: dict[Any, Any] = Field(default_factory=dict)
     ext: dict[str, dict[str, Any]] = Field(default_factory=dict)
     input: PromptInputConfig | None = None
+    output: PromptOutputConfig | None = None
     messages: list[Message] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
     raw: dict[str, Any] | None = None
@@ -319,6 +321,13 @@ class YamlSpecTestBase(unittest.IsolatedAsyncioTestCase, Generic[ModelConfigT]):
         data = self._merge_data(suite.data or DataArgument[Any](), test_case.data or DataArgument[Any]())
         result = await dotprompt.render(suite.template, data, test_case.options)
         pruned_res: Expect = Expect(**result.model_dump())
+
+        # Only compare raw if the spec demands it.
+        if test_case.expect.raw is None:
+            pruned_res.raw = None
+
+        print('----- R', pruned_res)
+        print('----- E', test_case.expect)
         self.assertEqual(pruned_res, test_case.expect)
 
     def _merge_data(self, data1: DataArgument[Any], data2: DataArgument[Any]) -> DataArgument[Any]:

--- a/python/dotpromptz/tests/dotpromptz/spec_test.py
+++ b/python/dotpromptz/tests/dotpromptz/spec_test.py
@@ -326,8 +326,6 @@ class YamlSpecTestBase(unittest.IsolatedAsyncioTestCase, Generic[ModelConfigT]):
         if test_case.expect.raw is None:
             pruned_res.raw = None
 
-        print('----- R', pruned_res)
-        print('----- E', test_case.expect)
         self.assertEqual(pruned_res, test_case.expect)
 
     def _merge_data(self, data1: DataArgument[Any], data2: DataArgument[Any]) -> DataArgument[Any]:


### PR DESCRIPTION
ISSUE: 293

CHANGELOG:
- [x] Add a missing output field to the Expect spec test model
- [x] Fix schema type (schema can be anything, not necessary a dict)
- [x] Fix spec test result validation to be aligned with the current JS/Go spec test logic