### PR TITLE
fix(go/genkit): Reset knownpartials and helpers array for every new template

### DIFF
--- a/go/dotprompt/dotprompt.go
+++ b/go/dotprompt/dotprompt.go
@@ -23,9 +23,10 @@ import (
 	"regexp"
 	"strings"
 
+	"maps"
+
 	"github.com/invopop/jsonschema"
 	"github.com/mbleigh/raymond"
-	"maps"
 )
 
 // PartialResolver is a function to resolve partial names to their content.
@@ -161,6 +162,12 @@ func (dp *Dotprompt) RegisterPartials(tpl *raymond.Template, template string) er
 	return nil
 }
 
+func (dp *Dotprompt) initializeTemplate(tpl *raymond.Template) {
+	dp.Template = tpl
+	dp.knownHelpers = make(map[string]bool)
+	dp.knownPartials = make(map[string]bool)
+}
+
 // DefineTool registers a tool definition.
 func (dp *Dotprompt) DefineTool(def ToolDefinition) *Dotprompt {
 	dp.tools[def.Name] = def
@@ -195,7 +202,7 @@ func (dp *Dotprompt) Compile(source string, additionalMetadata *PromptMetadata) 
 	if err != nil {
 		return nil, err
 	}
-	dp.Template = renderTpl
+	dp.initializeTemplate(renderTpl)
 
 	// RegisterHelpers()
 	if err = dp.RegisterHelpers(dp.Template); err != nil {


### PR DESCRIPTION
fix(go/genkit): Reset knownpartials and helpers array for every new template [#312]
ISSUES:
[ ] [#3019](https://github.com/firebase/genkit/issues/3019)

CHANGELOG:
[ ] Add initialize method for template, knownpartials and knownhelpers fields in the dotprompt instance. This is done because every time a new prompt is compiled a new template is created using handlebars and then partials and helpers are registered for this template. Earlier only the template was created new but the knownhelpers and knownpartials arrays were not initialized again. This led to using knownhelpers and knownpartials for older template with the current template. And instead of registering the helpers and partials for the new template, error was thrown saying partials and helpers are already registered because they were already present in the knownpartials and knownhelpers arrays.
 