### PR TITLE
feat(go): add examples for dotprompt library usage

### DIFF
--- a/go/example/doc.md
+++ b/go/example/doc.md
@@ -1,0 +1,44 @@
+# Go Dotprompt Library Usage Example
+
+This directory contains sample code demonstrating how to use the `dotprompt` library in Go.
+
+## File Structure
+
+- `example.prompt`: The prompt definition file. It defines metadata with YAML front matter and the template in the body.
+- `main.go`: An executable program that reads, parses, and renders `example.prompt` and outputs the result.
+
+## How to Run
+
+1.  Change the current directory to `go/example`.
+    ```bash
+    cd go/example
+    ```
+
+2.  Tidy the dependencies.
+    ```bash
+    go mod tidy
+    ```
+
+3.  Run the program.
+    ```bash
+    go run main.go
+    ```
+
+## Output
+
+When you run the program, the metadata from the `.prompt` file and the messages after applying the data will be displayed on standard output.
+
+```text
+--- Metadata ---
+Model: gemini-1.5-flash
+Description: Summarize the input text.
+
+--- Messages ---
+Role: user
+Content: Please summarize the following text.
+
+dotprompt is a library and toolset for managing and executing prompts. It defines metadata with YAML front matter and describes the prompt body with Handlebars templates. This makes it easy to reuse, maintain, and version control prompts.
+----------
+Role: model
+Content: Yes, I understand. I will summarize it.
+----------

--- a/go/example/example.prompt
+++ b/go/example/example.prompt
@@ -1,0 +1,22 @@
+---
+model: "gemini-1.5-flash"
+description: "Summarize the input text."
+input:
+  schema:
+    type: object
+    properties:
+      text:
+        type: string
+        description: "The text to summarize"
+    required:
+      - text
+output:
+  format: "text"
+---
+<<<dotprompt:role:user>>>
+Please summarize the following text.
+
+{{text}}
+
+<<<dotprompt:role:model>>>
+Yes, I understand. I will summarize it.

--- a/go/example/main.go
+++ b/go/example/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/dotprompt/go/dotprompt"
+)
+
+func main() {
+	// Read the .prompt file
+	source, err := os.ReadFile("example.prompt")
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a Dotprompt instance
+	dp := dotprompt.NewDotprompt(nil)
+
+	// Compile the prompt
+	// Compile calls Parse internally
+	promptFunc, err := dp.Compile(string(source), nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Data to pass during rendering
+	data := &dotprompt.DataArgument{
+		Input: map[string]any{
+			"text": "dotprompt is a library and toolset for managing and executing prompts. It defines metadata with YAML front matter and describes the prompt body with Handlebars templates. This makes it easy to reuse, maintain, and version control prompts.",
+		},
+	}
+
+	// Render the prompt
+	renderedPrompt, err := promptFunc(data, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Display the results
+	fmt.Println("--- Metadata ---")
+	fmt.Printf("Model: %s\n", renderedPrompt.Model)
+	fmt.Printf("Description: %s\n", renderedPrompt.Description)
+
+	fmt.Println("\n--- Messages ---")
+	for _, msg := range renderedPrompt.Messages {
+		fmt.Printf("Role: %s\n", msg.Role)
+		for _, part := range msg.Content {
+			if textPart, ok := part.(*dotprompt.TextPart); ok {
+				fmt.Printf("Content: %s\n", textPart.Text)
+			}
+		}
+		fmt.Println("----------")
+	}
+}


### PR DESCRIPTION
## ✨ What's new

This pull request introduces a new `example` directory within the Go package (`go/example`) to demonstrate how to use the `dotprompt` library.

It includes:
- A sample `.prompt` file (`example.prompt`) that defines metadata and a template.
- A `main.go` file that reads the `.prompt` file, compiles it, and renders the final prompt with sample data.
- A `doc.md` providing instructions on how to run the example.

This will help new users understand the basic functionality of parsing `.prompt` files and generating prompts with the Go library.
