### PR TITLE
fix(scripts/setup): update the location for the captainhook binary; minor formatting fixes for biome

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -330,7 +330,7 @@
         "bzlTransitiveDigest": "iJvsN76EW+mv1wsZWDG0aueIsNWokdUxnx51SeHZmP4=",
         "usagesDigest": "DERK4k9FbVzQIB4bXDGJ1nM+IQ2xMRKyoKFkkDE1cIk=",
         "recordedFileInputs": {
-          "@@//package.json": "ea1deeda85c6fc6798fbb2a2dc54cfe4e72ab1bf837b5d0fd71bbf12b035d6c8"
+          "@@//package.json": "3e1460e002fa008c944a34cba8d7710e2818fba0f716a3f63c79c1402f1dc79f"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/biome.json
+++ b/biome.json
@@ -1,42 +1,53 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "noParameterAssign": "error",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error",
+        "noUselessElse": "error"
+      }
     }
   },
   "files": {
     "ignoreUnknown": true,
-    "ignore": [
-      "**/.cache/**",
-      "**/.dist/**",
-      "**/.eggs/**",
-      "**/.idea/**",
-      "**/.mypy_cache/**",
-      "**/.next/**",
-      "**/.output/**",
-      "**/.pytest_cache/**",
-      "**/.ruff_cache/**",
-      "**/.venv/**",
-      "**/.wxt/**",
-      "**/__pycache__/**",
-      "**/coverage/**",
-      "**/develop-eggs/**",
-      "**/dist/**",
-      "**/manifest.*.json",
-      "**/node_modules/**",
-      ".nx/**",
-      ".trunk/**",
-      "bazel-*/**",
-      "go/**",
-      "maven_install.json",
-      "node_modules/**",
-      "python/**",
-      "third_party/**"
+    "includes": [
+      "**",
+      "!**/.cache/**",
+      "!**/.dist/**",
+      "!**/.eggs/**",
+      "!**/.idea/**",
+      "!**/.mypy_cache/**",
+      "!**/.next/**",
+      "!**/.output/**",
+      "!**/.pytest_cache/**",
+      "!**/.ruff_cache/**",
+      "!**/.venv/**",
+      "!**/.wxt/**",
+      "!**/__pycache__/**",
+      "!**/coverage/**",
+      "!**/develop-eggs/**",
+      "!**/dist/**",
+      "!**/manifest.*.json",
+      "!**/node_modules/**",
+      "!.nx/**",
+      "!.trunk/**",
+      "!bazel-*/**",
+      "!go/**",
+      "!maven_install.json",
+      "!node_modules/**",
+      "!python/**",
+      "!third_party/**"
     ]
   },
   "formatter": {

--- a/go/example/BUILD.bazel
+++ b/go/example/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "example_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/google/dotprompt/go/example",
+    visibility = ["//visibility:private"],
+    deps = ["//go/dotprompt"],
+)
+
+go_binary(
+    name = "example",
+    embed = [":example_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/go/example/main.go
+++ b/go/example/main.go
@@ -1,3 +1,19 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/js/src/dotprompt.ts
+++ b/js/src/dotprompt.ts
@@ -91,7 +91,6 @@ export class Dotprompt {
     this.registerInitialPartials(options?.partials);
   }
 
-
   /**
    * Registers a helper function for use in templates.
    *

--- a/js/src/handlebars-cjs.d.ts
+++ b/js/src/handlebars-cjs.d.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Type declarations for handlebars/dist/cjs/handlebars.js
 // This simply maps the CJS dist path to the official handlebars types
 declare module 'handlebars/dist/cjs/handlebars.js' {

--- a/js/src/helpers.ts
+++ b/js/src/helpers.ts
@@ -17,6 +17,7 @@
  */
 
 import handlebars from 'handlebars/dist/cjs/handlebars.js';
+
 const { SafeString } = handlebars;
 
 export function json(

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -17,10 +17,11 @@
  */
 
 import { Dotprompt, DotpromptOptions } from './dotprompt.js';
+
 export {
-  picoschema,
   PicoschemaOptions,
   PicoschemaParser,
+  picoschema,
 } from './picoschema.js';
 export type * from './types.js';
 export { Dotprompt, DotpromptOptions };

--- a/js/src/parse.test.ts
+++ b/js/src/parse.test.ts
@@ -19,13 +19,11 @@
 import { describe, expect, it } from 'vitest';
 import type { MessageSource } from './parse';
 import {
-  FRONTMATTER_AND_BODY_REGEX,
-  MEDIA_AND_SECTION_MARKER_REGEX,
-  RESERVED_METADATA_KEYWORDS,
-  ROLE_AND_HISTORY_MARKER_REGEX,
   convertNamespacedEntryToNestedObject,
   extractFrontmatterAndBody,
+  FRONTMATTER_AND_BODY_REGEX,
   insertHistory,
+  MEDIA_AND_SECTION_MARKER_REGEX,
   messageSourcesToMessages,
   messagesHaveHistory,
   parseDocument,
@@ -33,6 +31,8 @@ import {
   parsePart,
   parseSectionPart,
   parseTextPart,
+  RESERVED_METADATA_KEYWORDS,
+  ROLE_AND_HISTORY_MARKER_REGEX,
   splitByMediaAndSectionMarkers,
   splitByRegex,
   splitByRoleAndHistoryMarkers,

--- a/js/test/spec.test.ts
+++ b/js/test/spec.test.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { readFileSync, readdirSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { describe, expect, it, suite } from 'vitest';
 import { parse } from 'yaml';

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "packageManager": "pnpm@10.11.0",
   "scripts": {
     "build": "pnpm -C js build",
-    "format": "pnpm dlx @biomejs/biome check --formatter-enabled=true --linter-enabled=false --organize-imports-enabled=true --fix . && scripts/add_license",
-    "format:check": "pnpm dlx @biomejs/biome ci --linter-enabled=false --formatter-enabled=true --organize-imports-enabled=false . && scripts/check_license",
+    "format": "pnpm dlx @biomejs/biome check --formatter-enabled=true --linter-enabled=false --fix . && scripts/add_license",
+    "format:check": "pnpm dlx @biomejs/biome ci --linter-enabled=false --formatter-enabled=true . && scripts/check_license",
     "lint": "pnpm dlx @biomejs/biome lint --fix . && scripts/add_license",
     "test": "pnpm -C js run test"
   },
@@ -12,7 +12,7 @@
     "yaml": "^2.8.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "^2.2.6",
     "@types/node": "^22.15.20",
     "@typescript/native-preview": "7.0.0-dev.20250614.1",
     "@vitest/coverage-v8": "^3.1.4",
@@ -20,7 +20,9 @@
     "vitest": "^3.1.4"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["js"],
+    "onlyBuiltDependencies": [
+      "js"
+    ],
     "overrides": {
       "rollup@>=4.0.0 <4.22.4": ">=4.22.4",
       "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         version: 2.8.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.4
-        version: 1.9.4
+        specifier: ^2.2.6
+        version: 2.2.6
       '@types/node':
         specifier: ^22.15.20
         version: 22.15.20
@@ -340,55 +340,55 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.2.6':
+    resolution: {integrity: sha512-yKTCNGhek0rL5OEW1jbLeZX8LHaM8yk7+3JRGv08my+gkpmtb5dDE+54r2ZjZx0ediFEn1pYBOJSmOdDP9xtFw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.2.6':
+    resolution: {integrity: sha512-UZPmn3M45CjTYulgcrFJFZv7YmK3pTxTJDrFYlNElT2FNnkkX4fsxjExTSMeWKQYoZjvekpH5cvrYZZlWu3yfA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.2.6':
+    resolution: {integrity: sha512-HOUIquhHVgh/jvxyClpwlpl/oeMqntlteL89YqjuFDiZ091P0vhHccwz+8muu3nTyHWM5FQslt+4Jdcd67+xWQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.2.6':
+    resolution: {integrity: sha512-TjCenQq3N6g1C+5UT3jE1bIiJb5MWQvulpUngTIpFsL4StVAUXucWD0SL9MCW89Tm6awWfeXBbZBAhJwjyFbRQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.2.6':
+    resolution: {integrity: sha512-BpGtuMJGN+o8pQjvYsUKZ+4JEErxdSmcRD/JG3mXoWc6zrcA7OkuyGFN1mDggO0Q1n7qXxo/PcupHk8gzijt5g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.2.6':
+    resolution: {integrity: sha512-1ZcBux8zVM3JhWN2ZCPaYf0+ogxXG316uaoXJdgoPZcdK/rmRcRY7PqHdAos2ExzvjIdvhQp72UcveI98hgOog==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.2.6':
+    resolution: {integrity: sha512-1HaM/dpI/1Z68zp8ZdT6EiBq+/O/z97a2AiHMl+VAdv5/ELckFt9EvRb8hDHpk8hUMoz03gXkC7VPXOVtU7faA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.2.6':
+    resolution: {integrity: sha512-h3A88G8PGM1ryTeZyLlSdfC/gz3e95EJw9BZmA6Po412DRqwqPBa2Y9U+4ZSGUAXCsnSQE00jLV8Pyrh0d+jQw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.2.6':
+    resolution: {integrity: sha512-yx0CqeOhPjYQ5ZXgPfu8QYkgBhVJyvWe36as7jRuPrKPO5ylVDfwVtPQ+K/mooNTADW0IhxOZm3aPu16dP8yNQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -3890,39 +3890,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.2.6':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.2.6
+      '@biomejs/cli-darwin-x64': 2.2.6
+      '@biomejs/cli-linux-arm64': 2.2.6
+      '@biomejs/cli-linux-arm64-musl': 2.2.6
+      '@biomejs/cli-linux-x64': 2.2.6
+      '@biomejs/cli-linux-x64-musl': 2.2.6
+      '@biomejs/cli-win32-arm64': 2.2.6
+      '@biomejs/cli-win32-x64': 2.2.6
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.2.6':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.2.6':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.2.6':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.2.6':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.2.6':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.2.6':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.2.6':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.2.6':
     optional: true
 
   '@emmetio/abbreviation@2.3.3':

--- a/scripts/setup
+++ b/scripts/setup
@@ -213,7 +213,7 @@ function dotpromptz::install_go_cli_tools_eng() {
   go install github.com/Gelio/go-global-update@latest
   go install github.com/bazelbuild/bazelisk@latest
   go install github.com/bazelbuild/buildtools/buildifier@latest
-  go install github.com/captainhook-go/captainhook/cmd/captainhook@latest
+  go install github.com/captainhook-git/captainhook-bin/cmd/captainhook@latest
   go install github.com/google/addlicense@latest
   go install github.com/google/go-licenses@latest
   go install github.com/jesseduffield/lazygit@latest


### PR DESCRIPTION
CHANGELOG:
- [ ] Captainhook changed their repository location; we're updating it here.
- [ ] Updating biome to use the latest version of the tool and schema.
- [ ] Automatically adding license headers to some of the files that were missing them
      using https://github.com/google/addlicense.
- [ ] Fixing a few formatting issues.