### PR TITLE
bug: migrate to the release version of dotpromptz and handlebarzz

### DIFF
--- a/python/handlebarrz/pyproject.toml
+++ b/python/handlebarrz/pyproject.toml
@@ -32,10 +32,10 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "Handlebars library for Python based on handlebars-rust."
-name = "dotprompt_handlebars"
+name = "handlebarrz"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.0.1"
+version = "0.1.0"
 
 [build-system]
 build-backend = "maturin"


### PR DESCRIPTION
[Fixes #123](https://github.com/google/dotprompt/issues/329)

dotpromptz: Version 0.1.0 - already released to PyPI 
handlebarrz: Version 0.0.1.dev1 - changed to 0.0.1
