### PR TITLE
ci(py): change handlebars name in pyproject.toml files

### DIFF
--- a/python/dotpromptz/pyproject.toml
+++ b/python/dotpromptz/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
   "aiofiles>=24.1.0",
-  "dotprompt-handlebars",
+  "dotpromptz-handlebars",
   "pydantic[email]>=2.10.6",
   "structlog>=25.2.0",
   "types-aiofiles>=24.1.0.20250326",

--- a/python/handlebarrz/pyproject.toml
+++ b/python/handlebarrz/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "structlog>=25.2.0",
 ]
 description = "Handlebars library for Python based on handlebars-rust."
-name = "dotprompt_handlebars"
+name = "dotpromptz-handlebars"
 readme = "README.md"
 requires-python = ">=3.10"
 version = "0.1.2"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
-dependencies    = ["dotpromptz", "dotprompt-handlebars"]
+dependencies    = ["dotpromptz", "dotpromptz-handlebars"]
 description     = "Workspace for Dotprompt packages"
 license         = { text = "Apache-2.0" }
 name            = "dotprompt-workspace"
@@ -68,7 +68,7 @@ fail_under = 85
 default-groups = ["dev", "lint"]
 
 [tool.uv.sources]
-dotprompt-handlebars = { workspace = true }
+dotpromptz-handlebars = { workspace = true }
 dotpromptz           = { workspace = true }
 
 [tool.uv.workspace]
@@ -127,7 +127,7 @@ select = [
 [tool.ruff.lint.isort]
 combine-as-imports = true
 force-single-line = false
-known-first-party = ["dotpromptz", "aioia", "dotprompt-handlebars"]
+known-first-party = ["dotpromptz", "dotpromptz-handlebars"]
 section-order = [
   "future",
   "standard-library",


### PR DESCRIPTION
Link to issue #344 

Refactoring dotprompt-handlebars into dotpromptz-handlebars in relevant pyproject.toml files. 