### PR TITLE
ci(py/dotpromptz): add smoke test to verify dotpromptz usability from pypi

### DIFF
--- a/.github/workflows/publish_python_dotpromptz_package.yml
+++ b/.github/workflows/publish_python_dotpromptz_package.yml
@@ -151,7 +151,10 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.10"
+          - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
CHANGELOG:
1. After publishing dotpromptz to pypi, a smoke test added to verify its usability. 
2. Add supported Python version test in smoke test( Single run of build job can create a universal wheel (py3-none-any.whl) and 3.10, 3.11, 3.12, 3.13 (Full Matrix) were tested)