### PR TITLE
fix(go): capture local template in Compile closure to prevent sharing

### DIFF
--- a/go/dotprompt/dotprompt.go
+++ b/go/dotprompt/dotprompt.go
@@ -242,6 +242,12 @@ func (dp *Dotprompt) Compile(source string, additionalMetadata *PromptMetadata) 
 		return nil, err
 	}
 
+	// Capture the current template for this closure to avoid sharing issues.
+	// Without this, all compiled PromptFunctions would share the same dp.Template,
+	// causing wrong template execution when multiple prompts are compiled.
+	// See: https://github.com/google/dotprompt/issues/362
+	localTemplate := dp.Template
+
 	renderFunc := func(data *DataArgument, options *PromptMetadata) (RenderedPrompt, error) {
 		mergedMetadata, err := dp.RenderMetadata(parsedPrompt, options)
 		if err != nil {
@@ -259,7 +265,7 @@ func (dp *Dotprompt) Compile(source string, additionalMetadata *PromptMetadata) 
 			privDF.Set(k, v)
 		}
 
-		renderedString, err := dp.Template.ExecWith(inputContext, privDF, &raymond.ExecOptions{
+		renderedString, err := localTemplate.ExecWith(inputContext, privDF, &raymond.ExecOptions{
 			NoEscape: true,
 		})
 


### PR DESCRIPTION
## Summary

- Fix template sharing bug in `Compile()` method where all compiled `PromptFunction` closures shared the same `dp.Template`
- Add regression test `TestCompileMultiplePromptsTemplateIsolation` to prevent future regressions

## Problem

When using the `Compile()` method multiple times on the same `Dotprompt` instance, all compiled `PromptFunction` closures share the same `dp.Template` field. This causes subsequent prompt executions to use the wrong template.

### Root Cause

In `dotprompt.go`, the `Compile` method:
1. Creates a new `renderTpl` from parsing the source
2. Stores it to the shared `dp.Template` field via `initializeTemplate()`
3. Returns a closure `renderFunc` that references `dp.Template`

When another prompt is compiled, `dp.Template` gets overwritten, causing all previous `renderFunc` closures to use the wrong template.

### Example

```go
dp := dotprompt.NewDotprompt(nil)

prompt1, _ := dp.Compile("Talk about weather: {{topic}}", nil)
prompt2, _ := dp.Compile("Talk about programming: {{language}}", nil)

// BUG: prompt1 uses prompt2's template!
result1, _ := prompt1(&DataArgument{Input: map[string]any{"topic": "sunny"}}, nil)
// Expected: "Talk about weather: sunny"
// Actual: "Talk about programming: sunny"
```

## Solution

Capture the current template in a local variable before creating the closure:

```go
localTemplate := dp.Template

renderFunc := func(...) {
    renderedString, err := localTemplate.ExecWith(...)  // Use local template
    ...
}
```

## Test Plan

- [x] Added `TestCompileMultiplePromptsTemplateIsolation` regression test
- [x] All existing tests pass
- [x] Verified fix resolves the issue in real-world usage (Firebase Genkit Go SDK)

Fixes #362