### PR TITLE
feat(py): add support for python 3.14

### DIFF
--- a/.github/workflows/publish_python_dotpromptz_package.yml
+++ b/.github/workflows/publish_python_dotpromptz_package.yml
@@ -155,6 +155,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish_python_handlebarrz_package.yml
+++ b/.github/workflows/publish_python_handlebarrz_package.yml
@@ -33,6 +33,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
     steps:
       - uses: actions/checkout@v4
 
@@ -98,6 +99,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - uses: actions/checkout@v4
@@ -315,6 +317,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         linux_platform:
           - "debian"
           - "fedora"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PATH: ${{ github.workspace }}/go/bin:${{ github.workspace }}/.cargo/bin:${{ github.workspace }}/.local/share/pnpm:${{ github.workspace }}/.local/bin:/usr/local/bin:/usr/bin:/bin
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
     strategy:
       matrix:
         python-version:
@@ -36,7 +37,7 @@ jobs:
           - "3.13"
           #- "pypy-3.10" Remove it as pypy 3.10 being lower than the minimum supported by PyO3 (3.11):
           - "pypy-3.11"
-          #- "3.14" # This still fails.
+          - "3.14"
       fail-fast: false
 
     steps:

--- a/.github/workflows/smoke-test-wheels.yml
+++ b/.github/workflows/smoke-test-wheels.yml
@@ -31,6 +31,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         linux_platform:
           - "debian"
           - "fedora"
@@ -93,6 +94,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         linux_platform:
           - "debian"
           - "fedora"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -772,6 +772,168 @@
   },
   "facts": {
     "@@rules_go+//go:extensions.bzl%go_sdk": {
+      "1.24.11": {
+        "aix_ppc64": [
+          "go1.24.11.aix-ppc64.tar.gz",
+          "45513664b53269d46f413d8c99b14d0295f1d753c2e56ceebd20b4c3951c653f"
+        ],
+        "darwin_amd64": [
+          "go1.24.11.darwin-amd64.tar.gz",
+          "c45566cf265e2083cd0324e88648a9c28d0edede7b5fd12f8dc6932155a344c5"
+        ],
+        "darwin_arm64": [
+          "go1.24.11.darwin-arm64.tar.gz",
+          "a9c90c786e75d5d1da0547de2d1199034df6a4b163af2fa91b9168c65f229c12"
+        ],
+        "dragonfly_amd64": [
+          "go1.24.11.dragonfly-amd64.tar.gz",
+          "20b0c49a64e5d6366c38685fa2ea96c1cdd05312d056e45a460b283c03a78df4"
+        ],
+        "freebsd_386": [
+          "go1.24.11.freebsd-386.tar.gz",
+          "99229da13fd74d5cdcb81fae844bf48574c64eae0d2821137f45c848f1453771"
+        ],
+        "freebsd_amd64": [
+          "go1.24.11.freebsd-amd64.tar.gz",
+          "de6fdd4eefa06dbb2531ed601ef5f2b88e73f49f89c10bc1078f51a96a7ae88f"
+        ],
+        "freebsd_arm": [
+          "go1.24.11.freebsd-arm.tar.gz",
+          "fd7a01515c09ad190c969bd9cd277803c05acfaa7b03c496d3a9d1b8cad72d03"
+        ],
+        "freebsd_arm64": [
+          "go1.24.11.freebsd-arm64.tar.gz",
+          "eead4408b88557228fe4b30ee90aa33062d338fa5647c046a5aaca4237839f5a"
+        ],
+        "freebsd_riscv64": [
+          "go1.24.11.freebsd-riscv64.tar.gz",
+          "3c192d96d57c6330e6a92d70235a4e938345c9b3a50d37cfce60c92dd7240d04"
+        ],
+        "illumos_amd64": [
+          "go1.24.11.illumos-amd64.tar.gz",
+          "52985c554c3078eb550acd1b0ae497c620d50e4f22096c845ef5a6fffdade367"
+        ],
+        "linux_386": [
+          "go1.24.11.linux-386.tar.gz",
+          "bb702d0b67759724dccee1825828e8bae0b5199e3295cac5a98a81f3098fa64a"
+        ],
+        "linux_amd64": [
+          "go1.24.11.linux-amd64.tar.gz",
+          "bceca00afaac856bc48b4cc33db7cd9eb383c81811379faed3bdbc80edb0af65"
+        ],
+        "linux_arm64": [
+          "go1.24.11.linux-arm64.tar.gz",
+          "beaf0f51cbe0bd71b8289b2b6fa96c0b11cd86aa58672691ef2f1de88eb621de"
+        ],
+        "linux_armv6l": [
+          "go1.24.11.linux-armv6l.tar.gz",
+          "24d712a7e8ea2f429c05bc67287249e0291f2fe0ea6d6ff268f11b7343ad0f47"
+        ],
+        "linux_loong64": [
+          "go1.24.11.linux-loong64.tar.gz",
+          "45c3cbec9e30071ea1f3323fc30fb1b8497007c992f00ba48fcdcb729f06467c"
+        ],
+        "linux_mips": [
+          "go1.24.11.linux-mips.tar.gz",
+          "c006942d74a348af080aac3930c3772148761cf1de5d97c3879c30d17b72ccf5"
+        ],
+        "linux_mips64": [
+          "go1.24.11.linux-mips64.tar.gz",
+          "d054e2fb0873ac1d5502c4a860090bfff130b8fabdeeea311adda658fbc45ac5"
+        ],
+        "linux_mips64le": [
+          "go1.24.11.linux-mips64le.tar.gz",
+          "c0274255613b85e2ba45e210e8f07995d51a048f11c7f0b9128dc177472692b3"
+        ],
+        "linux_mipsle": [
+          "go1.24.11.linux-mipsle.tar.gz",
+          "5c787fc3ac04c4ebeaa0a6602c8a69eae557fe15d033a07cf22ac44e2489285f"
+        ],
+        "linux_ppc64": [
+          "go1.24.11.linux-ppc64.tar.gz",
+          "3fceb9492469f2155134a834c12b4bf9c1126fbb3cbf5a5ae660648897b8076d"
+        ],
+        "linux_ppc64le": [
+          "go1.24.11.linux-ppc64le.tar.gz",
+          "f770d0c5d7e7e2edb030133ac7854d9204f4e954e79a176e81362ffedf6ea34c"
+        ],
+        "linux_riscv64": [
+          "go1.24.11.linux-riscv64.tar.gz",
+          "9db9ba8e6b60f3662f55ed78b128175edbe8b9480e657126a5b8f5043ee1e38c"
+        ],
+        "linux_s390x": [
+          "go1.24.11.linux-s390x.tar.gz",
+          "5955ddda3445b2cbfd81b8772044084911f55d0baeb32414da0411f6a377a2d4"
+        ],
+        "netbsd_386": [
+          "go1.24.11.netbsd-386.tar.gz",
+          "804344f1051f2d00fda808627431374036d1774b43f18da4eb4bbb36b45608d0"
+        ],
+        "netbsd_amd64": [
+          "go1.24.11.netbsd-amd64.tar.gz",
+          "d79e74c466c25ae5e2537e5121efa9f378e94da77a2874d0aee0503ee5db4f43"
+        ],
+        "netbsd_arm": [
+          "go1.24.11.netbsd-arm.tar.gz",
+          "c031fccb5d1c77235639a25219d9e029a6025aca26d92cca343cbfaad311a232"
+        ],
+        "netbsd_arm64": [
+          "go1.24.11.netbsd-arm64.tar.gz",
+          "3ad222d8c6e4a91340afbab241a04ac3dd34a19363755f22589c7ed7e4e5b6e0"
+        ],
+        "openbsd_386": [
+          "go1.24.11.openbsd-386.tar.gz",
+          "f43e20c857403ae55f94b1edaa459c58c0a399549c7c63b02c9000c4710f3071"
+        ],
+        "openbsd_amd64": [
+          "go1.24.11.openbsd-amd64.tar.gz",
+          "a15b059d170ab7fac5695b889116f9c84cb9bf9a1378ad3aa2c510ead0188e01"
+        ],
+        "openbsd_arm": [
+          "go1.24.11.openbsd-arm.tar.gz",
+          "41961a46c9661390faeec21cd1f6082e04a6456075649c59c115aa8ba659a337"
+        ],
+        "openbsd_arm64": [
+          "go1.24.11.openbsd-arm64.tar.gz",
+          "bb25b24233a79f4b0fbf56e84f13002d201002734277d18178418cdb3bfce3f6"
+        ],
+        "openbsd_ppc64": [
+          "go1.24.11.openbsd-ppc64.tar.gz",
+          "fa83fc7399dc6cbd070260eaa20122b574cbae44aacef1c6b46306b20e4dcf89"
+        ],
+        "openbsd_riscv64": [
+          "go1.24.11.openbsd-riscv64.tar.gz",
+          "a62488fbc56b2d3327e6e708f667299fd988c22ac5a4fa82407a21ca1ca9d13c"
+        ],
+        "plan9_386": [
+          "go1.24.11.plan9-386.tar.gz",
+          "6e260b5e708526124e8330f8a81ff3cf1e432d7195e85c3e2ae701a044a355e0"
+        ],
+        "plan9_amd64": [
+          "go1.24.11.plan9-amd64.tar.gz",
+          "2959658c6867109e5c1ccf954e4e72dd2aa53e69613608ce4c9d30c8816ac4ac"
+        ],
+        "plan9_arm": [
+          "go1.24.11.plan9-arm.tar.gz",
+          "e546632e520ba84e78cd35b8e2d0ddb68fa9649022c8c705de7575275b72754d"
+        ],
+        "solaris_amd64": [
+          "go1.24.11.solaris-amd64.tar.gz",
+          "13c11b81e8ae61bcfec3fd673364fbfff0f32a1d84cce9c5012a89f3d50aa109"
+        ],
+        "windows_386": [
+          "go1.24.11.windows-386.zip",
+          "ecf6d24b20964acfe4603d7706793a770004003fae6fccae530f93b0e46ab446"
+        ],
+        "windows_amd64": [
+          "go1.24.11.windows-amd64.zip",
+          "39f6267b6bb2a1c0daa83f563b3bf0a1a3e49925ecf6da854f7ff7d5e78d6968"
+        ],
+        "windows_arm64": [
+          "go1.24.11.windows-arm64.zip",
+          "1bafb42190b67fba93fbf1a236a193b0f6058db65d7406965374ce7af2ca3917"
+        ]
+      },
       "1.25.0": {
         "aix_ppc64": [
           "go1.25.0.aix-ppc64.tar.gz",
@@ -932,168 +1094,6 @@
         "windows_arm64": [
           "go1.25.0.windows-arm64.zip",
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
-        ]
-      },
-      "1.25.5": {
-        "aix_ppc64": [
-          "go1.25.5.aix-ppc64.tar.gz",
-          "89d3300aeb8a49354c04d43abf2a0dca6a75ac772b3bc2edaac52de513041572"
-        ],
-        "darwin_amd64": [
-          "go1.25.5.darwin-amd64.tar.gz",
-          "b69d51bce599e5381a94ce15263ae644ec84667a5ce23d58dc2e63e2c12a9f56"
-        ],
-        "darwin_arm64": [
-          "go1.25.5.darwin-arm64.tar.gz",
-          "bed8ebe824e3d3b27e8471d1307f803fc6ab8e1d0eb7a4ae196979bd9b801dd3"
-        ],
-        "dragonfly_amd64": [
-          "go1.25.5.dragonfly-amd64.tar.gz",
-          "51478a265f45b68ce761aa303c1ecf185949f6eb0b2106e3066ec4d32361b38a"
-        ],
-        "freebsd_386": [
-          "go1.25.5.freebsd-386.tar.gz",
-          "f8ff9fa5309fbbbd7d52f5d3f7181feb830dfd044d23c38746a2ada091f751b5"
-        ],
-        "freebsd_amd64": [
-          "go1.25.5.freebsd-amd64.tar.gz",
-          "a2d2b2aeb218bd646fd8708bacc96c9d4de1b6c9ea48ceb9171e9e784f676650"
-        ],
-        "freebsd_arm": [
-          "go1.25.5.freebsd-arm.tar.gz",
-          "b83a5cb1695c7185a13840661aef6aa1b46202d41a72528ecde51735765c6641"
-        ],
-        "freebsd_arm64": [
-          "go1.25.5.freebsd-arm64.tar.gz",
-          "938fc0204f853c24ab03967105146af6590903dd14f869fe912db7a735f654f6"
-        ],
-        "freebsd_riscv64": [
-          "go1.25.5.freebsd-riscv64.tar.gz",
-          "7b0cc61246cf6fc9e576135cfcd2b95e870b0f2ee5bf057325b2d76119001e4e"
-        ],
-        "illumos_amd64": [
-          "go1.25.5.illumos-amd64.tar.gz",
-          "ea5cafcf995ef4a82ced5a7134f18bbc5ca554c345075d18f37d2e192fe2c1ff"
-        ],
-        "linux_386": [
-          "go1.25.5.linux-386.tar.gz",
-          "db908a86e888574ed3432355ba5372ad3ef2c0821ba9b91ceaa0f6634620c40c"
-        ],
-        "linux_amd64": [
-          "go1.25.5.linux-amd64.tar.gz",
-          "9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b"
-        ],
-        "linux_arm64": [
-          "go1.25.5.linux-arm64.tar.gz",
-          "b00b694903d126c588c378e72d3545549935d3982635ba3f7a964c9fa23fe3b9"
-        ],
-        "linux_armv6l": [
-          "go1.25.5.linux-armv6l.tar.gz",
-          "0b27e3dec8d04899d6941586d2aa2721c3dee67c739c1fc1b528188f3f6e8ab5"
-        ],
-        "linux_loong64": [
-          "go1.25.5.linux-loong64.tar.gz",
-          "0be2f27172a85de1b9c0c7f324832023b177d07cfa04a55dc67a3cc965fe969e"
-        ],
-        "linux_mips": [
-          "go1.25.5.linux-mips.tar.gz",
-          "0e7c387a6914c81b53278f023da2004e17d8d8e851749cdb5df15ad59e54ff3e"
-        ],
-        "linux_mips64": [
-          "go1.25.5.linux-mips64.tar.gz",
-          "32ef8f4c4896c1e88dcbbf79c353d3e46dc38410e649327ee47e073e3326b06f"
-        ],
-        "linux_mips64le": [
-          "go1.25.5.linux-mips64le.tar.gz",
-          "437dc493b3ce97a65e7abc7e8ecb935f504b4805aff749baba219841bd970335"
-        ],
-        "linux_mipsle": [
-          "go1.25.5.linux-mipsle.tar.gz",
-          "675cd3e0cb7d9131602a0de06f5471ce969fd95d388baf1ec05106a1cdeb20b6"
-        ],
-        "linux_ppc64": [
-          "go1.25.5.linux-ppc64.tar.gz",
-          "a2159b254b025a816673365db565b3bd64f99fb185eb3f4cedabbf992097304d"
-        ],
-        "linux_ppc64le": [
-          "go1.25.5.linux-ppc64le.tar.gz",
-          "f0904b647b5b8561efc5d48bb59a34f2b7996afab83ccd41c93b1aeb2c0067e4"
-        ],
-        "linux_riscv64": [
-          "go1.25.5.linux-riscv64.tar.gz",
-          "05de84b319bc91b9cecbc6bf8eb5fcd814cf8a9d16c248d293dbd96f6cc0151b"
-        ],
-        "linux_s390x": [
-          "go1.25.5.linux-s390x.tar.gz",
-          "a5d0a72b0dfd57f9c2c0cdd8b7e0f401e0afb9e8c304d3410f9b0982ce0953da"
-        ],
-        "netbsd_386": [
-          "go1.25.5.netbsd-386.tar.gz",
-          "57e79e72d1110954c6567082137f0228c46eb4d612211b3bf48dadb6a27eeaa2"
-        ],
-        "netbsd_amd64": [
-          "go1.25.5.netbsd-amd64.tar.gz",
-          "d6062fa06c33613be60436b3e6422f2de43c28350bb30dbbc459782985eea7bd"
-        ],
-        "netbsd_arm": [
-          "go1.25.5.netbsd-arm.tar.gz",
-          "457d844df4aa6cd51616b2334e378cc295ee7bcca1cb21869adfc16f5f379bfd"
-        ],
-        "netbsd_arm64": [
-          "go1.25.5.netbsd-arm64.tar.gz",
-          "5030511891f670dba65a6d8f15e687f623030ac5b63661a423a7dad53990b634"
-        ],
-        "openbsd_386": [
-          "go1.25.5.openbsd-386.tar.gz",
-          "27cba5feeedfb08dea2770420c6024d7ea72eedad08132a9759c0f05f66f2486"
-        ],
-        "openbsd_amd64": [
-          "go1.25.5.openbsd-amd64.tar.gz",
-          "c873e93f6bd125a23b359914ba34d62e6af21111b06c14ce344b724aa1ef933b"
-        ],
-        "openbsd_arm": [
-          "go1.25.5.openbsd-arm.tar.gz",
-          "e5a8cc469c66248bc2031327e66a4ad48a8f379435677386db52ef1aa7b2b0e2"
-        ],
-        "openbsd_arm64": [
-          "go1.25.5.openbsd-arm64.tar.gz",
-          "cdd655fa0e15bc839d0c353bfb728b8d22a8012e54a11e297be919c3cf7ad866"
-        ],
-        "openbsd_ppc64": [
-          "go1.25.5.openbsd-ppc64.tar.gz",
-          "a149370fda34ce27fa78a452248f6f2040fe5ab955dce246d4d92de2c2d511c1"
-        ],
-        "openbsd_riscv64": [
-          "go1.25.5.openbsd-riscv64.tar.gz",
-          "be96cf8460011088cb75b330357796ecf1ac2ffffac77a3d1f798cbd7e6a2bc0"
-        ],
-        "plan9_386": [
-          "go1.25.5.plan9-386.tar.gz",
-          "a3926108324c4b161080b03cd941db58090fba1194610093ee5716ee98997287"
-        ],
-        "plan9_amd64": [
-          "go1.25.5.plan9-amd64.tar.gz",
-          "f171e529236b850ed4a1e714c317dddcf46855b575d9d018c654cf78b3ea1a2e"
-        ],
-        "plan9_arm": [
-          "go1.25.5.plan9-arm.tar.gz",
-          "aaf285e49f39717029f4759c0f9b2860dbf23c20fb659122006ba1e145643721"
-        ],
-        "solaris_amd64": [
-          "go1.25.5.solaris-amd64.tar.gz",
-          "fb61c56ca80a2e1e5f74609ded64546166a5ab431c0d581ce718310cf27f6b9f"
-        ],
-        "windows_386": [
-          "go1.25.5.windows-386.zip",
-          "a593393ea7715ffd315158f622a76226c3a4c4a0a6f92b1aeae03d7380cc06a3"
-        ],
-        "windows_amd64": [
-          "go1.25.5.windows-amd64.zip",
-          "ae756cce1cb80c819b4fe01b0353807178f532211b47f72d7fa77949de054ebb"
-        ],
-        "windows_arm64": [
-          "go1.25.5.windows-arm64.zip",
-          "55a94a423a6b8f3ac2ac4d05a6e44d7760c6520a2c6dcef7425f6bac79c4eece"
         ]
       }
     }

--- a/python/dotpromptz/pyproject.toml
+++ b/python/dotpromptz/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries",

--- a/python/dotpromptz/src/dotpromptz/adapters/openai.py
+++ b/python/dotpromptz/src/dotpromptz/adapters/openai.py
@@ -62,6 +62,8 @@ class ContentItem(BaseModel):
 
 
 class ToolFunction(BaseModel):
+    """Tool function."""
+
     name: str
     arguments: str
 
@@ -73,13 +75,15 @@ class ToolCallType(StrEnum):
 
 
 class ToolCall(BaseModel):
+    """Tool Call."""
+
     id: str
     type: ToolCallType
     function: ToolFunction
 
 
 class OpenAIMessage(BaseModel):
-    """Open AI Message"""
+    """Open AI Message."""
 
     role: Role
     content: str | list[ContentItem] | None = None
@@ -89,22 +93,28 @@ class OpenAIMessage(BaseModel):
 
 
 class OpenAIToolFunction(BaseModel):
+    """OpenAI Tool Function."""
+
     name: str
     description: str | None = None
     parameters: dict[str, Any] | None = None
 
 
 class OpenAIToolDefinition(BaseModel):
+    """OpenAI Tool Definition."""
+
     type: ToolCallType
     function: OpenAIToolFunction
 
 
 class ToolChoiceFunction(BaseModel):
+    """Tool Choice Function."""
+
     name: str
 
 
 class ToolChoice(BaseModel):
-    """Tool Choice"""
+    """Tool Choice."""
 
     type: ToolCallType
     function: ToolChoiceFunction
@@ -118,7 +128,7 @@ class ResponseFormatType(StrEnum):
 
 
 class ResponseFormat(BaseModel):
-    """Expected Response Format"""
+    """Expected Response Format."""
 
     type: ResponseFormatType
 
@@ -127,7 +137,7 @@ ToolChoiceOptions = Literal['none', 'auto']
 
 
 class OpenAIRequest(BaseModel):
-    """Open AI Request"""
+    """Open AI Request."""
 
     messages: list[OpenAIMessage]
     model: str

--- a/python/dotpromptz/src/dotpromptz/dotprompt.py
+++ b/python/dotpromptz/src/dotpromptz/dotprompt.py
@@ -45,7 +45,6 @@ from typing import Any
 import anyio
 
 from dotpromptz.helpers import BUILTIN_HELPERS
-from dotpromptz.models import dump_models
 from dotpromptz.parse import parse_document, to_messages
 from dotpromptz.picoschema import picoschema_to_json_schema
 from dotpromptz.resolvers import resolve_json_schema, resolve_partial, resolve_tool

--- a/python/dotpromptz/tests/dotpromptz/parse_test.py
+++ b/python/dotpromptz/tests/dotpromptz/parse_test.py
@@ -351,7 +351,6 @@ class TestExtractFrontmatterAndBody(unittest.TestCase):
         Both the frontmatter and body are empty strings, when there
         is no frontmatter marker.
         """
-
         input_str = 'Hello World'
         frontmatter, body = extract_frontmatter_and_body(input_str)
         assert frontmatter == ''

--- a/python/dotpromptz/tests/dotpromptz/spec_test.py
+++ b/python/dotpromptz/tests/dotpromptz/spec_test.py
@@ -99,12 +99,11 @@ spec/
 
 from __future__ import annotations
 
-import asyncio
 import re
 import unittest
 from collections.abc import Callable, Coroutine
 from pathlib import Path
-from typing import Any, Generic, TypedDict
+from typing import Any, Generic
 
 import structlog
 import yaml
@@ -296,7 +295,7 @@ class TestSpecFiles(unittest.IsolatedAsyncioTestCase):
                 self.assertIsNotNone(data)
 
 
-class YamlSpecTestBase(unittest.IsolatedAsyncioTestCase, Generic[ModelConfigT]):
+class YamlSpecTestBase(Generic[ModelConfigT], unittest.IsolatedAsyncioTestCase):
     """A base class that is used as a template for all YAML spec test suites."""
 
     async def run_yaml_test(

--- a/python/dotpromptz/tests/dotpromptz/stores/dir_async_test.py
+++ b/python/dotpromptz/tests/dotpromptz/stores/dir_async_test.py
@@ -38,10 +38,7 @@ store, and verifies the correct behavior through assertions.
 
 from __future__ import annotations
 
-import asyncio
 import os
-import shutil
-from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import aiofiles

--- a/python/dotpromptz/tests/dotpromptz/stores/dir_sync_test.py
+++ b/python/dotpromptz/tests/dotpromptz/stores/dir_sync_test.py
@@ -37,9 +37,6 @@ version but uses standard blocking I/O operations, making it suitable for
 simpler applications or those that don't require async operations.
 """
 
-import os
-import shutil
-from collections.abc import Generator
 from pathlib import Path
 
 import pytest

--- a/python/handlebarrz/generate-alpine-wheels.sh
+++ b/python/handlebarrz/generate-alpine-wheels.sh
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 export UV_LINK_MODE=copy
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 
 PYTHON_VERSION="python$1"
 

--- a/python/handlebarrz/generate-arm-wheels.sh
+++ b/python/handlebarrz/generate-arm-wheels.sh
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 export UV_LINK_MODE=copy
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 
 PYTHON_VERSION="python$1"
 

--- a/python/handlebarrz/generate-x86-64-wheels.sh
+++ b/python/handlebarrz/generate-x86-64-wheels.sh
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 export UV_LINK_MODE=copy
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 
 PYTHON_VERSION="python$1"
 

--- a/python/handlebarrz/pyproject.toml
+++ b/python/handlebarrz/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Rust",
   "Topic :: Text Processing :: Markup",
   "License :: OSI Approved :: Apache Software License",

--- a/python/handlebarrz/smoke_tests/handlebarrz_test.py
+++ b/python/handlebarrz/smoke_tests/handlebarrz_test.py
@@ -16,8 +16,6 @@
 
 """Test code for smoke tests."""
 
-from typing import Any
-
 from handlebarrz import HelperOptions, Template
 
 

--- a/python/handlebarrz/src/handlebarrz/_native.pyi
+++ b/python/handlebarrz/src/handlebarrz/_native.pyi
@@ -17,7 +17,6 @@
 """Stub type annotations for native Handlebars."""
 
 from collections.abc import Callable
-from typing import Any
 
 def html_escape(text: str) -> str: ...
 def no_escape(text: str) -> str: ...

--- a/python/handlebarrz/tests/advanced_features_test.py
+++ b/python/handlebarrz/tests/advanced_features_test.py
@@ -17,7 +17,6 @@
 """Tests for advanced Handlebars features."""
 
 import unittest
-from typing import Any
 
 from handlebarrz import HelperOptions, Template
 

--- a/python/handlebarrz/tests/escape_test.py
+++ b/python/handlebarrz/tests/escape_test.py
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from typing import Any
 
 from handlebarrz import EscapeFunction, HelperOptions, Template
 

--- a/python/handlebarrz/tests/helpers_test.py
+++ b/python/handlebarrz/tests/helpers_test.py
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from typing import Any
 
 from handlebarrz import HelperOptions, Template
 

--- a/python/handlebarrz/tests/subexpression_test.py
+++ b/python/handlebarrz/tests/subexpression_test.py
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from typing import Any
 
 from handlebarrz import HelperOptions, Template
 

--- a/python/handlebarrz/tests/template_core_test.py
+++ b/python/handlebarrz/tests/template_core_test.py
@@ -15,7 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from typing import Any
 
 import pytest
 

--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -22,13 +22,12 @@ import nox
 nox.options.default_venv_backend = 'uv|virtualenv'
 
 PYTHON_VERSIONS = [
-    'pypy-3.10',
     'pypy-3.11',
     '3.10',
     '3.11',
     '3.12',
     '3.13',
-    #'3.14', # This still fails.
+    '3.14',
 ]
 
 
@@ -53,6 +52,7 @@ def tests(session: nox.Session) -> None:
         'handlebarrz',
         'maturin',
         'develop',
+        env={'PYO3_USE_ABI3_FORWARD_COMPATIBILITY': '1'},
     )
 
     session.run(
@@ -64,8 +64,8 @@ def tests(session: nox.Session) -> None:
         '--isolated',
         'pytest',
         '-v',
-        #'-vv',
-        #'--log-level=DEBUG',
+        # '-vv',
+        # '--log-level=DEBUG',
         '.',
         *session.posargs,
         external=True,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -136,6 +136,10 @@ section-order = [
   "local-folder",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"**/*_test.py" = ["D"]
+"**/tests/*"   = ["D"]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -3,7 +3,8 @@ envlist =
   py310,
   py311,
   py312,
-  py313
+  py313,
+  py314
 isolated_build = True
 skipsdist = True # We install editable, so don't build sdist.
 

--- a/scripts/run_handlebarrz_checks
+++ b/scripts/run_handlebarrz_checks
@@ -42,6 +42,7 @@ for arg in "$@"; do
 done
 
 export RUST_BACKTRACE=1
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 
 if [ "$VERBOSE" = true ]; then
   echo "Running tests in verbose mode..."

--- a/scripts/run_python_checks
+++ b/scripts/run_python_checks
@@ -25,14 +25,12 @@ fi
 TOP_DIR=$(git rev-parse --show-toplevel)
 PY_DIR="${TOP_DIR}/python"
 PYTHON_VERSIONS=(
-  "pypy3.10"
   "pypy3.11"
   "python3.10"
   "python3.11"
   "python3.12"
   "python3.13"
-  # TODO: Wait for https://github.com/PyO3/pyo3/issues/5000 to be fixed.
-  #"python3.14" # Next version to catch breakages early.
+  "python3.14" 
 )
 
 echo "=== Running Python lint ==="
@@ -64,7 +62,7 @@ for VERSION in "${PYTHON_VERSIONS[@]}"; do
   # NOTE: Build the Rust extension for a specific Python version in an isolated
   # virtual environment; otherwise we see weird missing import errors.
   echo "Creating virtual environment for ${VERSION}..."
-  uv venv --python "${VERSION}"
+  uv venv --allow-existing --python "${VERSION}"
   uv run --python "${VERSION}" --active --isolated --directory handlebarrz maturin develop
   echo "Running tests with Python ${VERSION}..."
   uv run \


### PR DESCRIPTION
CHANGELOG:
- [ ] Use PYO3_USE_ABI3_FORWARD_COMPATIBILITY to enable python 3.14
  support
- [ ] Update Github actions to support Python 3.14.
- [ ] Update test configuration add support for Python 3.14.
- [ ] Fix some lint.