### PR TITLE
fix(py/dotpromptz): pyyaml is a runtime dependency; also update dotpromptz-handlebars to 0.1.3

### DIFF
--- a/python/dotpromptz/pyproject.toml
+++ b/python/dotpromptz/pyproject.toml
@@ -35,12 +35,14 @@ classifiers = [
 ]
 dependencies = [
   "aiofiles>=24.1.0",
-  "dotpromptz-handlebars>=0.1.2",
+  "anyio>=4.9.0",
+  "dotpromptz-handlebars>=0.1.3",
   "pydantic[email]>=2.10.6",
+  "pyyaml>=6.0.2",
+  "strenum>=0.4.15 ; python_version < '3.11'",
   "structlog>=25.2.0",
   "types-aiofiles>=24.1.0.20250326",
-  "strenum>=0.4.15 ; python_version < '3.11'",
-  "anyio>=4.9.0",
+  "types-pyyaml>=6.0.12.20241230",
 ]
 description = "Dotpromptz is a language-neutral executable prompt template file format for Generative AI."
 license = { text = "Apache-2.0" }
@@ -61,8 +63,6 @@ dev = [
   "pytest>=8.3.5",
   "pytest-asyncio>=0.25.3",
   "pytest-cov>=6.0.0",
-  "pyyaml>=6.0.2",
-  "types-pyyaml>=6.0.12.20241230",
 ]
 
 [tool.pytest.ini_options]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -837,9 +837,11 @@ dependencies = [
     { name = "anyio" },
     { name = "dotpromptz-handlebars" },
     { name = "pydantic", extra = ["email"] },
+    { name = "pyyaml" },
     { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog" },
     { name = "types-aiofiles" },
+    { name = "types-pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -847,8 +849,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
-    { name = "pyyaml" },
-    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -857,9 +857,11 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "dotpromptz-handlebars", editable = "handlebarrz" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.6" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
     { name = "structlog", specifier = ">=25.2.0" },
     { name = "types-aiofiles", specifier = ">=24.1.0.20250326" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
 ]
 
 [package.metadata.requires-dev]
@@ -867,8 +869,6 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
 ]
 
 [[package]]


### PR DESCRIPTION
`pyyaml` is a runtime dependency since the parser uses it. This fixes the dependency breakage for samples when we attempt to run them.