### PR TITLE
chore: Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -31,18 +31,18 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Bazel needs a JDK. Setup Java 21 as baseline.
       - name: Setup Java JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
 
       # Set up Go environment for go install
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.24.2
 
@@ -51,7 +51,7 @@ jobs:
         run: go install github.com/bazelbuild/bazelisk@latest
 
       - name: Mount Bazel repository cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/bazel/_bazel_${{ runner.os }}/repos
@@ -64,7 +64,7 @@ jobs:
       # Caching build results can significantly speed up CI.
       # Be cautious with cache size and eviction.
       - name: Mount Bazel action cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/bazel/_bazel_${{ runner.os }}/execroot/**/bazel-out
           key: bazel-action-${{ github.sha }}-${{ hashFiles('**/MODULE.bazel.lock', '**/maven_install.json', '**/pnpm-lock.yaml') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install, build, and upload your site
         uses: withastro/action@v3
         with:

--- a/.github/workflows/engdoc.yml
+++ b/.github/workflows/engdoc.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -47,7 +47,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Set up Go
-        uses: actions/setup-go@main
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,10 +35,10 @@ jobs:
     name: Go ${{ matrix.go-version }} Tests
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@main
+        uses: actions/checkout@v6
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@main
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,8 +35,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
       - name: golangci-lint

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,4 +26,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6

--- a/.github/workflows/publish_python_dotpromptz_package.yml
+++ b/.github/workflows/publish_python_dotpromptz_package.yml
@@ -50,10 +50,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -109,7 +109,7 @@ jobs:
           twine check dist/*
 
       - name: Upload dotpromptz Distributions for Python
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist-dotpromptz
           path: python/dotpromptz/dist/
@@ -127,12 +127,12 @@ jobs:
 
     steps:
       - name: Checkout code at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag_name }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist-dotpromptz
           path: dist/
@@ -157,10 +157,10 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish_python_handlebarrz_package.yml
+++ b/.github/workflows/publish_python_handlebarrz_package.yml
@@ -35,7 +35,7 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU for Multi-Arch support
         uses: docker/setup-qemu-action@v3
@@ -53,7 +53,7 @@ jobs:
           docker run -v "$PWD/python/handlebarrz":/project linux-arm64:latest sh ./generate-arm-wheels.sh "${{ matrix.python_version }}"
 
       - name: Upload build packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-arm64-${{ matrix.python_version }}
           path: python/handlebarrz/target/wheels
@@ -66,7 +66,7 @@ jobs:
         python_version:
           - "3.12"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU for Multi-Arch support
         uses: docker/setup-qemu-action@v3
@@ -84,7 +84,7 @@ jobs:
           docker run -v "$PWD/python/handlebarrz":/project linux-alpine:latest sh ./generate-alpine-wheels.sh "${{ matrix.python_version }}"
 
       - name: Upload build packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-alpine-${{ matrix.python_version }}
           path: python/handlebarrz/target/wheels
@@ -102,7 +102,7 @@ jobs:
           - "3.14"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build container
         run: |
@@ -114,7 +114,7 @@ jobs:
           docker run -v "$PWD/python/handlebarrz":/project linux-x86-64:latest sh ./generate-x86-64-wheels.sh "${{ matrix.python_version }}"
 
       - name: Upload build packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-x86-64-${{ matrix.python_version }}
           path: python/handlebarrz/target/wheels
@@ -130,11 +130,11 @@ jobs:
 #          - "3.12"
 #          - "3.13"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #
 #      - name: Set up Python
 #        id: setup_py
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: ${{ matrix.python_version }}
 #
@@ -152,7 +152,7 @@ jobs:
 #        run: maturin build --release --strip -o dist -i ${{ steps.setup_py.outputs.python-path }}
 #
 #      - name: Upload build packages
-#        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@v6
 #        with:
 #          name: wheels-windows-x86_64-${{ matrix.python_version }}
 #          path: python/handlebarrz/dist
@@ -168,15 +168,15 @@ jobs:
 #          - "3.12"
 #          - "3.13"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #
 #      - name: Set up Node.js for Actions
-#        uses: actions/setup-node@v4
+#        uses: actions/setup-node@v6
 #        with:
 #          node-version: '20'
 #
 #      - name: Set up Python
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: ${{ matrix.python_version }}
 #
@@ -197,7 +197,7 @@ jobs:
 #        run: maturin build --release --strip -o dist
 #
 #      - name: Upload build packages
-#        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@v6
 #        with:
 #          name: wheels-macos-arm64-${{ matrix.python_version }}-${{ github.job }}
 #          path: python/handlebarrz/dist
@@ -213,10 +213,10 @@ jobs:
 #          - "3.12"
 #          - "3.13"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #
 #      - name: Set up Python
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: ${{ matrix.python_version }}
 #
@@ -233,7 +233,7 @@ jobs:
 #        run: maturin build --release --strip -o dist
 #
 #      - name: Upload build packages
-#        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@v6
 #        with:
 #          name: wheels-macos-x86_64-${{ matrix.python_version }}-${{ github.job }}
 #          path: python/handlebarrz/dist
@@ -246,11 +246,11 @@ jobs:
 #        python_version:
 #          - "3.12"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #
 #      - name: Set up Python
 #        id: setup_py
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: ${{ matrix.python_version }}
 #
@@ -269,7 +269,7 @@ jobs:
 ##        run: maturin build --release --strip -o dist --target aarch64-pc-windows-msvc -i python
 #
 #      - name: Upload build packages
-#        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@v6
 #        with:
 #          name: wheels-windows-arm64-${{ matrix.python_version }}
 #          path: python/handlebarrz/dist
@@ -284,7 +284,7 @@ jobs:
       id-token: write
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           merge-multiple: true
           path: dist/
@@ -322,7 +322,7 @@ jobs:
           - "debian"
           - "fedora"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU for Multi-Arch support
         uses: docker/setup-qemu-action@v3
@@ -351,7 +351,7 @@ jobs:
         python_version:
           - "3.12"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU for Multi-Arch support
         uses: docker/setup-qemu-action@v3
@@ -386,7 +386,7 @@ jobs:
           - "debian"
           - "fedora"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build container
         run: |
@@ -413,10 +413,10 @@ jobs:
 #          - "3.12"
 #          - "3.13"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #
 #      - name: Set up Python
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: ${{ matrix.python_version }}
 #
@@ -439,10 +439,10 @@ jobs:
 #          - "3.12"
 #          - "3.13"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #
 #      - name: Set up Python
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: ${{ matrix.python_version }}
 #
@@ -466,10 +466,10 @@ jobs:
 #          - "3.12"
 #          - "3.13"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #
 #      - name: Set up Python
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: ${{ matrix.python_version }}
 #
@@ -490,10 +490,10 @@ jobs:
 #        python_version:
 #          - "3.12"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v6
 #
 #      - name: Set up Python
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: ${{ matrix.python_version }}
 #

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,10 +41,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@main
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 
@@ -54,7 +54,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
     name: Run build tasks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: pnpm/action-setup@v3
     - name: Set up node v21
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 21.x
         cache: 'pnpm'
@@ -54,7 +54,7 @@ jobs:
       working-directory: ./js
       run: pnpm test
     - name: Set up node v21
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 21.x
         cache: 'pnpm'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache Cargo registry and index
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -85,7 +85,7 @@ jobs:
   #      toolchain: [stable, nightly]
   #  steps:
   #    - name: Checkout code
-  #      uses: actions/checkout@v4
+  #      uses: actions/checkout@v6
 
   #    - name: Install musl build dependencies
   #      run: |
@@ -107,7 +107,7 @@ jobs:
   #        cargo --version --verbose
 
   #    - name: Cache Cargo registry and index (musl)
-  #      uses: actions/cache@v4
+  #      uses: actions/cache@v5
   #      with:
   #        path: |
   #          /usr/local/cargo/registry/index/

--- a/.github/workflows/smoke-test-wheels.yml
+++ b/.github/workflows/smoke-test-wheels.yml
@@ -36,7 +36,7 @@ jobs:
           - "debian"
           - "fedora"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU for Multi-Arch support
         uses: docker/setup-qemu-action@v3
@@ -64,7 +64,7 @@ jobs:
         python_version:
           - "3.12"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU for Multi-Arch support
         uses: docker/setup-qemu-action@v3
@@ -99,7 +99,7 @@ jobs:
           - "debian"
           - "fedora"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build container
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,10 @@ jobs:
       matrix:
         node-version: ["20", "21", "22", "23"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js v${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | bazel.yml, python.yml, rust.yml |
| `actions/checkout` | [`main`](https://github.com/actions/checkout/releases/tag/main), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | bazel.yml, deploy.yml, engdoc.yml, go.yml, golangci-lint.yml, publish_python_dotpromptz_package.yml, publish_python_handlebarrz_package.yml, python.yml, release.yml, rust.yml, smoke-test-wheels.yml, test.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | publish_python_dotpromptz_package.yml, publish_python_handlebarrz_package.yml |
| `actions/labeler` | [`v5`](https://github.com/actions/labeler/releases/tag/v5) | [`v6`](https://github.com/actions/labeler/releases/tag/v6) | [Release](https://github.com/actions/labeler/releases/tag/v6) | labeler.yml |
| `actions/setup-go` | [`main`](https://github.com/actions/setup-go/releases/tag/main), [`v5`](https://github.com/actions/setup-go/releases/tag/v5) | [`v6`](https://github.com/actions/setup-go/releases/tag/v6) | [Release](https://github.com/actions/setup-go/releases/tag/v6) | bazel.yml, engdoc.yml, go.yml, golangci-lint.yml, python.yml |
| `actions/setup-java` | [`v4`](https://github.com/actions/setup-java/releases/tag/v4) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | bazel.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | publish_python_handlebarrz_package.yml, release.yml, test.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | publish_python_dotpromptz_package.yml, publish_python_handlebarrz_package.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | publish_python_dotpromptz_package.yml, publish_python_handlebarrz_package.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
