### PR TITLE
chore: upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/publish_python_dotpromptz_package.yml
+++ b/.github/workflows/publish_python_dotpromptz_package.yml
@@ -138,7 +138,7 @@ jobs:
           path: dist/
 
       - name: Publish Distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
         with:
           verbose: true
           packages-dir: dist/

--- a/.github/workflows/publish_python_handlebarrz_package.yml
+++ b/.github/workflows/publish_python_handlebarrz_package.yml
@@ -298,7 +298,7 @@ jobs:
           fi
 
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
         with:
           verbose: true
           packages-dir: dist/


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Files |
|--------|---------------|-------------|-------|
| `pypa/gh-action-pypi-publish` | `release/v1` | [`ed0c539`](https://github.com/pypa/gh-action-pypi-publish/commit/ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e) | workflow files |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Note on pypa/gh-action-pypi-publish

This action uses **branch-based versioning** (`release/v1.x`) rather than tags. The `v1` tag does not exist in this repository. 

This PR pins to the SHA of `release/v1.13` for security best practices:
```yaml
uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
```

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality.
