### PR TITLE
feat(py): switch to using ty for type checking

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -75,7 +75,7 @@ jobs:
         run: uv run --active --directory python ruff check --select I .
 
       - name: Static type check
-        run: uv run --active --directory python mypy .
+        run: uv run --active --directory python ty check
 
       # TODO: Move this to a rust workflow once we have one.
       - name: Run rust lint

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -13,7 +13,7 @@ Target: Python >= 3.10
   from `collections.abc` instead.
 - Apply type hints strictly, including `-> None` for functions returning nothing.
 - Use the `type` keyword for type aliases.
-- Use enum types like `StrEnum` instead of `(str, Enum)` for string-based enums.
+- Use enum types like `StrEnum` instead of `(str, Enum)` for string-based enums when we drop support for Python 3.10 at its EOL.
 - Code against interfaces, not implementations.
 - Use the adapter pattern for optional implementations.
 - Use proper punctuation in comments.
@@ -53,7 +53,7 @@ functions.
 ### Tooling & Environment
 
 - Use `uv` for packaging and environment management.
-- Use `mypy` for static type checking.
+- Use `ty` for static type checking.
 - Target Python 3.12 or newer. Aim for PyPy compatibility (optional).
 
 ### Logging

--- a/python/dotpromptz/pyproject.toml
+++ b/python/dotpromptz/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
   "dotpromptz-handlebars>=0.1.3",
   "pydantic[email]>=2.10.6",
   "pyyaml>=6.0.2",
-  "strenum>=0.4.15 ; python_version < '3.11'",
   "structlog>=25.2.0",
   "types-aiofiles>=24.1.0.20250326",
   "types-pyyaml>=6.0.12.20241230",

--- a/python/dotpromptz/src/dotpromptz/adapters/openai.py
+++ b/python/dotpromptz/src/dotpromptz/adapters/openai.py
@@ -16,21 +16,15 @@
 
 """Data models and interfaces type definitions using Pydantic v2."""
 
-import sys  # noqa
-
+from enum import Enum
 from typing import Any, Literal
 
 from pydantic import BaseModel
 
 from dotpromptz.typing import Role
 
-if sys.version_info < (3, 11):  # noqa
-    from strenum import StrEnum  # noqa
-else:  # noqa
-    from enum import StrEnum  # noqa
 
-
-class DetailKind(StrEnum):
+class DetailKind(str, Enum):
     """The kind of Image URL detail."""
 
     AUTO = 'auto'
@@ -46,7 +40,7 @@ class ImageURLDetail(BaseModel):
     detail: DetailKind | None = None
 
 
-class ContentItemType(StrEnum):
+class ContentItemType(str, Enum):
     """Enumveration variants for content item type."""
 
     TEXT = 'text'
@@ -68,7 +62,7 @@ class ToolFunction(BaseModel):
     arguments: str
 
 
-class ToolCallType(StrEnum):
+class ToolCallType(str, Enum):
     """Enumeration variants for tool call type."""
 
     FUNCTION = 'function'
@@ -120,7 +114,7 @@ class ToolChoice(BaseModel):
     function: ToolChoiceFunction
 
 
-class ResponseFormatType(StrEnum):
+class ResponseFormatType(str, Enum):
     """Enum variants for response format type."""
 
     TEXT = 'text'

--- a/python/dotpromptz/src/dotpromptz/parse.py
+++ b/python/dotpromptz/src/dotpromptz/parse.py
@@ -227,7 +227,7 @@ def parse_document(source: str) -> ParsedPrompt[T]:
     frontmatter, body = extract_frontmatter_and_body(source)
     if not frontmatter:
         # No frontmatter, return a basic ParsedPrompt with just the template
-        return ParsedPrompt(ext={}, config=None, metadata={}, toolDefs=None, template=source)
+        return ParsedPrompt(ext={}, config=None, metadata={}, tool_defs=None, template=source)
 
     try:
         parsed_metadata = yaml.safe_load(frontmatter)
@@ -253,7 +253,7 @@ def parse_document(source: str) -> ParsedPrompt[T]:
                 version=raw.get('version'),
                 input=raw.get('input'),
                 output=raw.get('output'),
-                toolDefs=raw.get('toolDefs'),
+                tool_defs=raw.get('toolDefs'),
                 tools=raw.get('tools'),
                 ext=ext,
                 config=pruned.get('config'),
@@ -268,7 +268,7 @@ def parse_document(source: str) -> ParsedPrompt[T]:
                 ext={},
                 config=None,
                 metadata={},
-                toolDefs=None,
+                tool_defs=None,
                 template=body.strip(),
             )
     except Exception as e:
@@ -279,7 +279,7 @@ def parse_document(source: str) -> ParsedPrompt[T]:
             ext={},
             config=None,
             metadata={},
-            toolDefs=None,
+            tool_defs=None,
             template=source.strip(),
         )
 
@@ -502,7 +502,7 @@ def parse_media_part(piece: str) -> MediaPart:
 
     media_content = MediaContent(
         url=url,
-        contentType=(content_type if content_type and content_type.strip() else None),
+        content_type=(content_type if content_type and content_type.strip() else None),
     )
     return MediaPart(media=media_content)
 

--- a/python/dotpromptz/src/dotpromptz/picoschema.py
+++ b/python/dotpromptz/src/dotpromptz/picoschema.py
@@ -310,7 +310,7 @@ class PicoschemaParser:
         elif not isinstance(obj, dict):
             raise ValueError(f'Picoschema: only consists of objects and strings. Got: {obj}')
 
-        schema: JsonSchema = {
+        schema: dict[str, Any] = {
             'type': 'object',
             'properties': {},
             'required': [],

--- a/python/dotpromptz/src/dotpromptz/resolvers.py
+++ b/python/dotpromptz/src/dotpromptz/resolvers.py
@@ -42,7 +42,7 @@ import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
 
-import anyio
+from anyio.to_thread import run_sync
 
 from dotpromptz.errors import ResolverFailedError
 from dotpromptz.typing import (
@@ -133,7 +133,7 @@ async def resolve(name: str, kind: str, resolver: ResolverT | None) -> Definitio
             # type after calling, as we don't know it yet. It might still return
             # an awaitable (e.g. sync function returning `asyncio.Future`) but
             # calling it sync first is necessary to check.
-            result_or_awaitable = await anyio.to_thread.run_sync(resolver, name)
+            result_or_awaitable = await run_sync(resolver, name)
             if inspect.isawaitable(result_or_awaitable):
                 obj = await result_or_awaitable
             else:

--- a/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
+++ b/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
@@ -147,7 +147,7 @@ def test_define_tool(mock_handlebars: Mock) -> None:
 @patch('dotpromptz.dotprompt.parse_document')
 def test_parse(mock_parse_document: Mock, mock_handlebars: Mock) -> None:
     """Test parsing a prompt."""
-    mock_parse_document.return_value = ParsedPrompt(template='Hello {{name}}', toolDefs=None)
+    mock_parse_document.return_value = ParsedPrompt(template='Hello {{name}}', tool_defs=None)
 
     dotprompt = Dotprompt()
     result: ParsedPrompt[dict[str, Any]] = dotprompt.parse('source string')
@@ -155,7 +155,7 @@ def test_parse(mock_parse_document: Mock, mock_handlebars: Mock) -> None:
     mock_parse_document.assert_called_once_with('source string')
 
     # Ensure chaining works.
-    assert result == ParsedPrompt(template='Hello {{name}}', toolDefs=None)
+    assert result == ParsedPrompt(template='Hello {{name}}', tool_defs=None)
 
 
 def test_chainable_interface(mock_handlebars: Mock) -> None:

--- a/python/dotpromptz/tests/dotpromptz/parse_test.py
+++ b/python/dotpromptz/tests/dotpromptz/parse_test.py
@@ -603,7 +603,7 @@ class TestInsertHistory(unittest.TestCase):
             MediaPart(
                 media=MediaContent(
                     url='https://example.com/image.jpg',
-                    contentType='image/jpeg',
+                    content_type='image/jpeg',
                 ),
             ),
         ),

--- a/python/handlebarrz/pyproject.toml
+++ b/python/handlebarrz/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-  "strenum>=0.4.15 ; python_version < '3.11'",
   "structlog>=25.2.0",
 ]
 description = "Handlebars library for Python based on handlebars-rust."

--- a/python/handlebarrz/src/handlebarrz/__init__.py
+++ b/python/handlebarrz/src/handlebarrz/__init__.py
@@ -73,15 +73,11 @@ import json
 import re
 import sys  # noqa
 from collections.abc import Callable
+from enum import Enum
 from pathlib import Path
 from typing import Any, TypedDict
 
 import structlog
-
-if sys.version_info < (3, 11):  # noqa
-    from strenum import StrEnum  # noqa
-else:  # noqa
-    from enum import StrEnum  # noqa
 
 from ._native import (
     HandlebarrzHelperOptions,
@@ -112,7 +108,7 @@ class RuntimeOptions(TypedDict):
 CompiledRenderer = Callable[[Context, RuntimeOptions | None], str]
 
 
-class EscapeFunction(StrEnum):
+class EscapeFunction(str, Enum):
     """Enumeration of built-in escape functions for Handlebars templates.
 
     These constants define how content is escaped when rendered in templates.

--- a/python/noxfile.py
+++ b/python/noxfile.py
@@ -84,8 +84,13 @@ def lint(session: nox.Session) -> None:
     """
     session.log('Running linters')
     session.log('Running ruff format check')
-    session.run('uv', 'run', 'ruff', 'format', '--check', '.', external=True)
+    session.run(
+        'uv', 'run', 'ruff', 'check', '--select', 'I', '--fix', '--preview', '--unsafe-fixes', '.', external=True
+    )
+    session.run('uv', 'run', 'ruff', 'format', '--check', '--preview', '.', external=True)
     session.log('Running ruff checks')
     session.run('uv', 'run', 'ruff', 'check', '--preview', '--unsafe-fixes', '--fix', '.', external=True)
+    session.log('Running ty checks')
+    session.run('uv', 'run', 'ty', 'check', '.', external=True)
     # session.log("Running mypy checks") # mypy has many errors currently
     # session.run("mypy", external=True)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,8 +38,9 @@ dev = [
   "nox>=2025.2.9",
   "nox-uv>=0.2.1",
   "pyrefly>=0.16.1",
+  "ty>=0.0.5",
 ]
-lint = ["mypy>=1.14.1", "ruff>=0.9.2"]
+lint = ["ruff>=0.9.2"]
 
 [tool.hatch.build.targets.wheel]
 packages = []
@@ -106,7 +107,7 @@ exclude = [
 ]
 indent-width = 4
 line-length = 120
-target-version = "py312"
+target-version = "py310"
 
 [tool.ruff.lint]
 fixable = ["ALL"]
@@ -152,11 +153,6 @@ quote-style                = "single"
 skip-magic-trailing-comma  = false
 
 # Static type checking.
-[tool.mypy]
-disallow_incomplete_defs = true
-disallow_untyped_defs    = true
-strict                   = true
-warn_unused_configs      = true
 
 [tool.pyrefly]
 project_excludes = [

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -794,10 +794,10 @@ dev = [
     { name = "pytest-watcher" },
     { name = "tox" },
     { name = "tox-uv" },
+    { name = "ty" },
     { name = "types-pyyaml" },
 ]
 lint = [
-    { name = "mypy" },
     { name = "ruff" },
 ]
 
@@ -821,12 +821,10 @@ dev = [
     { name = "pytest-watcher", specifier = ">=0.4.3" },
     { name = "tox", specifier = ">=4.25.0" },
     { name = "tox-uv", specifier = ">=1.25.0" },
+    { name = "ty", specifier = ">=0.0.5" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
 ]
-lint = [
-    { name = "mypy", specifier = ">=1.14.1" },
-    { name = "ruff", specifier = ">=0.9.2" },
-]
+lint = [{ name = "ruff", specifier = ">=0.9.2" }]
 
 [[package]]
 name = "dotpromptz"
@@ -838,7 +836,6 @@ dependencies = [
     { name = "dotpromptz-handlebars" },
     { name = "pydantic", extra = ["email"] },
     { name = "pyyaml" },
-    { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog" },
     { name = "types-aiofiles" },
     { name = "types-pyyaml" },
@@ -858,7 +855,6 @@ requires-dist = [
     { name = "dotpromptz-handlebars", editable = "handlebarrz" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.6" },
     { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
     { name = "structlog", specifier = ">=25.2.0" },
     { name = "types-aiofiles", specifier = ">=24.1.0.20250326" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
@@ -876,7 +872,6 @@ name = "dotpromptz-handlebars"
 version = "0.1.3"
 source = { editable = "handlebarrz" }
 dependencies = [
-    { name = "strenum", marker = "python_full_version < '3.11'" },
     { name = "structlog" },
 ]
 
@@ -889,10 +884,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "strenum", marker = "python_full_version < '3.11'", specifier = ">=0.4.15" },
-    { name = "structlog", specifier = ">=25.2.0" },
-]
+requires-dist = [{ name = "structlog", specifier = ">=25.2.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1648,60 +1640,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/6f/657961a0743cff32e6c0611b63ff1c1970a0b482ace35b069203bf705187/mypy-1.18.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eab0cf6294dafe397c261a75f96dc2c31bffe3b944faa24db5def4e2b0f77c", size = 12807973, upload-time = "2025-09-19T00:10:35.282Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e9/420822d4f661f13ca8900f5fa239b40ee3be8b62b32f3357df9a3045a08b/mypy-1.18.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a780ca61fc239e4865968ebc5240bb3bf610ef59ac398de9a7421b54e4a207e", size = 11896527, upload-time = "2025-09-19T00:10:55.791Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/73/a05b2bbaa7005f4642fcfe40fb73f2b4fb6bb44229bd585b5878e9a87ef8/mypy-1.18.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448acd386266989ef11662ce3c8011fd2a7b632e0ec7d61a98edd8e27472225b", size = 12507004, upload-time = "2025-09-19T00:11:05.411Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/01/f6e4b9f0d031c11ccbd6f17da26564f3a0f3c4155af344006434b0a05a9d/mypy-1.18.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9e171c465ad3901dc652643ee4bffa8e9fef4d7d0eece23b428908c77a76a66", size = 13245947, upload-time = "2025-09-19T00:10:46.923Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/97/19727e7499bfa1ae0773d06afd30ac66a58ed7437d940c70548634b24185/mypy-1.18.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:592ec214750bc00741af1f80cbf96b5013d81486b7bb24cb052382c19e40b428", size = 13499217, upload-time = "2025-09-19T00:09:39.472Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/4f/90dc8c15c1441bf31cf0f9918bb077e452618708199e530f4cbd5cede6ff/mypy-1.18.2-cp310-cp310-win_amd64.whl", hash = "sha256:7fb95f97199ea11769ebe3638c29b550b5221e997c63b14ef93d2e971606ebed", size = 9766753, upload-time = "2025-09-19T00:10:49.161Z" },
-    { url = "https://files.pythonhosted.org/packages/88/87/cafd3ae563f88f94eec33f35ff722d043e09832ea8530ef149ec1efbaf08/mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:807d9315ab9d464125aa9fcf6d84fde6e1dc67da0b6f80e7405506b8ac72bc7f", size = 12731198, upload-time = "2025-09-19T00:09:44.857Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e0/1e96c3d4266a06d4b0197ace5356d67d937d8358e2ee3ffac71faa843724/mypy-1.18.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bb00de1778caf4db739c6e83919c1d85a448f71979b6a0edd774ea8399341", size = 11817879, upload-time = "2025-09-19T00:09:47.131Z" },
-    { url = "https://files.pythonhosted.org/packages/72/ef/0c9ba89eb03453e76bdac5a78b08260a848c7bfc5d6603634774d9cd9525/mypy-1.18.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1379451880512ffce14505493bd9fe469e0697543717298242574882cf8cdb8d", size = 12427292, upload-time = "2025-09-19T00:10:22.472Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/52/ec4a061dd599eb8179d5411d99775bec2a20542505988f40fc2fee781068/mypy-1.18.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1331eb7fd110d60c24999893320967594ff84c38ac6d19e0a76c5fd809a84c86", size = 13163750, upload-time = "2025-09-19T00:09:51.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5f/2cf2ceb3b36372d51568f2208c021870fe7834cf3186b653ac6446511839/mypy-1.18.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ca30b50a51e7ba93b00422e486cbb124f1c56a535e20eff7b2d6ab72b3b2e37", size = 13351827, upload-time = "2025-09-19T00:09:58.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/7d/2697b930179e7277529eaaec1513f8de622818696857f689e4a5432e5e27/mypy-1.18.2-cp311-cp311-win_amd64.whl", hash = "sha256:664dc726e67fa54e14536f6e1224bcfce1d9e5ac02426d2326e2bb4e081d1ce8", size = 9757983, upload-time = "2025-09-19T00:10:09.071Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273, upload-time = "2025-09-19T00:10:58.321Z" },
-    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910, upload-time = "2025-09-19T00:10:20.043Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585, upload-time = "2025-09-19T00:10:33.005Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562, upload-time = "2025-09-19T00:10:11.51Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296, upload-time = "2025-09-19T00:10:06.568Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828, upload-time = "2025-09-19T00:10:28.203Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/04/7f462e6fbba87a72bc8097b93f6842499c428a6ff0c81dd46948d175afe8/mypy-1.18.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:07b8b0f580ca6d289e69209ec9d3911b4a26e5abfde32228a288eb79df129fcc", size = 12898728, upload-time = "2025-09-19T00:10:01.33Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5b/61ed4efb64f1871b41fd0b82d29a64640f3516078f6c7905b68ab1ad8b13/mypy-1.18.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ed4482847168439651d3feee5833ccedbf6657e964572706a2adb1f7fa4dfe2e", size = 11910758, upload-time = "2025-09-19T00:10:42.607Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/46/d297d4b683cc89a6e4108c4250a6a6b717f5fa96e1a30a7944a6da44da35/mypy-1.18.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3ad2afadd1e9fea5cf99a45a822346971ede8685cc581ed9cd4d42eaf940986", size = 12475342, upload-time = "2025-09-19T00:11:00.371Z" },
-    { url = "https://files.pythonhosted.org/packages/83/45/4798f4d00df13eae3bfdf726c9244bcb495ab5bd588c0eed93a2f2dd67f3/mypy-1.18.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a431a6f1ef14cf8c144c6b14793a23ec4eae3db28277c358136e79d7d062f62d", size = 13338709, upload-time = "2025-09-19T00:11:03.358Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/09/479f7358d9625172521a87a9271ddd2441e1dab16a09708f056e97007207/mypy-1.18.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7ab28cc197f1dd77a67e1c6f35cd1f8e8b73ed2217e4fc005f9e6a504e46e7ba", size = 13529806, upload-time = "2025-09-19T00:10:26.073Z" },
-    { url = "https://files.pythonhosted.org/packages/71/cf/ac0f2c7e9d0ea3c75cd99dff7aec1c9df4a1376537cb90e4c882267ee7e9/mypy-1.18.2-cp313-cp313-win_amd64.whl", hash = "sha256:0e2785a84b34a72ba55fb5daf079a1003a34c05b22238da94fcae2bbe46f3544", size = 9833262, upload-time = "2025-09-19T00:10:40.035Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0c/7d5300883da16f0063ae53996358758b2a2df2a09c72a5061fa79a1f5006/mypy-1.18.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:62f0e1e988ad41c2a110edde6c398383a889d95b36b3e60bcf155f5164c4fdce", size = 12893775, upload-time = "2025-09-19T00:10:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/50/df/2cffbf25737bdb236f60c973edf62e3e7b4ee1c25b6878629e88e2cde967/mypy-1.18.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8795a039bab805ff0c1dfdb8cd3344642c2b99b8e439d057aba30850b8d3423d", size = 11936852, upload-time = "2025-09-19T00:10:51.631Z" },
-    { url = "https://files.pythonhosted.org/packages/be/50/34059de13dd269227fb4a03be1faee6e2a4b04a2051c82ac0a0b5a773c9a/mypy-1.18.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ca1e64b24a700ab5ce10133f7ccd956a04715463d30498e64ea8715236f9c9c", size = 12480242, upload-time = "2025-09-19T00:11:07.955Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/040983fad5132d85914c874a2836252bbc57832065548885b5bb5b0d4359/mypy-1.18.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d924eef3795cc89fecf6bedc6ed32b33ac13e8321344f6ddbf8ee89f706c05cb", size = 13326683, upload-time = "2025-09-19T00:09:55.572Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/ba/89b2901dd77414dd7a8c8729985832a5735053be15b744c18e4586e506ef/mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075", size = 13514749, upload-time = "2025-09-19T00:10:44.827Z" },
-    { url = "https://files.pythonhosted.org/packages/25/bc/cc98767cffd6b2928ba680f3e5bc969c4152bf7c2d83f92f5a504b92b0eb/mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf", size = 9982959, upload-time = "2025-09-19T00:10:37.344Z" },
-    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "nbclient"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1874,15 +1812,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/87/93/897d612f6df7cfd987bdf668425127efeff8d8e4ad8bfbab1c69d2a0d861/patchelf-0.17.2.4-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:680a266a70f60a7a4f4c448482c5bdba80cc8e6bb155a49dcc24238ba49927b0", size = 540276, upload-time = "2025-07-23T21:16:27.983Z" },
     { url = "https://files.pythonhosted.org/packages/5d/b8/2b92d11533482bac9ee989081d6880845287751b5f528adbd6bb27667fbd/patchelf-0.17.2.4-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.musllinux_1_1_s390x.whl", hash = "sha256:d842b51f0401460f3b1f3a3a67d2c266a8f515a5adfbfa6e7b656cb3ac2ed8bc", size = 596632, upload-time = "2025-07-23T21:16:29.253Z" },
     { url = "https://files.pythonhosted.org/packages/14/e2/975d4bdb418f942b53e6187b95bd9e0d5e0488b7bc214685a1e43e2c2751/patchelf-0.17.2.4-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:7076d9e127230982e20a81a6e2358d3343004667ba510d9f822d4fdee29b0d71", size = 508281, upload-time = "2025-07-23T21:16:30.865Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
@@ -2691,15 +2620,6 @@ wheels = [
 ]
 
 [[package]]
-name = "strenum"
-version = "0.4.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
-]
-
-[[package]]
 name = "structlog"
 version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2849,6 +2769,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/db/6299d478000f4f1c6f9bf2af749359381610ffc4cbe6713b66e436ecf6e7/ty-0.0.5.tar.gz", hash = "sha256:983da6330773ff71e2b249810a19c689f9a0372f6e21bbf7cde37839d05b4346", size = 4806218, upload-time = "2025-12-20T21:19:17.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/98/c1f61ba378b4191e641bb36c07b7fcc70ff844d61be7a4bf2fea7472b4a9/ty-0.0.5-py3-none-linux_armv6l.whl", hash = "sha256:1594cd9bb68015eb2f5a3c68a040860f3c9306dc6667d7a0e5f4df9967b460e2", size = 9785554, upload-time = "2025-12-20T21:19:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f9/b37b77c03396bd779c1397dae4279b7ad79315e005b3412feed8812a4256/ty-0.0.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7c0140ba980233d28699d9ddfe8f43d0b3535d6a3bbff9935df625a78332a3cf", size = 9603995, upload-time = "2025-12-20T21:19:15.256Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/70/4e75c11903b0e986c0203040472627cb61d6a709e1797fb08cdf9d565743/ty-0.0.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:15de414712cde92048ae4b1a77c4dc22920bd23653fe42acaf73028bad88f6b9", size = 9145815, upload-time = "2025-12-20T21:19:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/89/05/93983dfcf871a41dfe58e5511d28e6aa332a1f826cc67333f77ae41a2f8a/ty-0.0.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:438aa51ad6c5fae64191f8d58876266e26f9250cf09f6624b6af47a22fa88618", size = 9619849, upload-time = "2025-12-20T21:19:19.084Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b6/896ab3aad59f846823f202e94be6016fb3f72434d999d2ae9bd0f28b3af9/ty-0.0.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b3d373fd96af1564380caf153600481c676f5002ee76ba8a7c3508cdff82ee0", size = 9606611, upload-time = "2025-12-20T21:19:24.583Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ae/098e33fc92330285ed843e2750127e896140c4ebd2d73df7732ea496f588/ty-0.0.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8453692503212ad316cf8b99efbe85a91e5f63769c43be5345e435a1b16cba5a", size = 10029523, upload-time = "2025-12-20T21:19:07.055Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5a/f4b4c33758b9295e9aca0de9645deca0f4addd21d38847228723a6e780fc/ty-0.0.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2e4c454139473abbd529767b0df7a795ed828f780aef8d0d4b144558c0dc4446", size = 10870892, upload-time = "2025-12-20T21:19:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c5/4e3e7e88389365aa1e631c99378711cf0c9d35a67478cb4720584314cf44/ty-0.0.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:426d4f3b82475b1ec75f3cc9ee5a667c8a4ae8441a09fcd8e823a53b706d00c7", size = 10599291, upload-time = "2025-12-20T21:19:26.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/5d/138f859ea87bd95e17b9818e386ae25a910e46521c41d516bf230ed83ffc/ty-0.0.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5710817b67c6b2e4c0224e4f319b7decdff550886e9020f6d46aa1ce8f89a609", size = 10413515, upload-time = "2025-12-20T21:19:11.094Z" },
+    { url = "https://files.pythonhosted.org/packages/27/21/1cbcd0d3b1182172f099e88218137943e0970603492fb10c7c9342369d9a/ty-0.0.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e23c55ef08882c7c5ced1ccb90b4eeefa97f690aea254f58ac0987896c590f76", size = 10144992, upload-time = "2025-12-20T21:19:13.225Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/30/fdac06a5470c09ad2659a0806497b71f338b395d59e92611f71b623d05a0/ty-0.0.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b9e4c1a28a23b14cf8f4f793f4da396939f16c30bfa7323477c8cc234e352ac4", size = 9606408, upload-time = "2025-12-20T21:19:09.212Z" },
+    { url = "https://files.pythonhosted.org/packages/09/93/e99dcd7f53295192d03efd9cbcec089a916f49cad4935c0160ea9adbd53d/ty-0.0.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4e9ebb61529b9745af662e37c37a01ad743cdd2c95f0d1421705672874d806cd", size = 9630040, upload-time = "2025-12-20T21:19:38.165Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f8/6d1e87186e4c35eb64f28000c1df8fd5f73167ce126c5e3dd21fd1204a23/ty-0.0.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5eb191a8e332f50f56dfe45391bdd7d43dd4ef6e60884710fd7ce84c5d8c1eb5", size = 9754016, upload-time = "2025-12-20T21:19:32.79Z" },
+    { url = "https://files.pythonhosted.org/packages/28/e6/20f989342cb3115852dda404f1d89a10a3ce93f14f42b23f095a3d1a00c9/ty-0.0.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:92ed7451a1e82ee134a2c24ca43b74dd31e946dff2b08e5c34473e6b051de542", size = 10252877, upload-time = "2025-12-20T21:19:20.787Z" },
+    { url = "https://files.pythonhosted.org/packages/57/9d/fc66fa557443233dfad9ae197ff3deb70ae0efcfb71d11b30ef62f5cdcc3/ty-0.0.5-py3-none-win32.whl", hash = "sha256:71f6707e4c1c010c158029a688a498220f28bb22fdb6707e5c20e09f11a5e4f2", size = 9212640, upload-time = "2025-12-20T21:19:30.817Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b6/05c35f6dea29122e54af0e9f8dfedd0a100c721affc8cc801ebe2bc2ed13/ty-0.0.5-py3-none-win_amd64.whl", hash = "sha256:2b8b754a0d7191e94acdf0c322747fec34371a4d0669f5b4e89549aef28814ae", size = 10034701, upload-time = "2025-12-20T21:19:28.311Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ca/4201ed5cb2af73912663d0c6ded927c28c28b3c921c9348aa8d2cfef4853/ty-0.0.5-py3-none-win_arm64.whl", hash = "sha256:83bea5a5296caac20d52b790ded2b830a7ff91c4ed9f36730fe1f393ceed6654", size = 9566474, upload-time = "2025-12-20T21:19:22.518Z" },
 ]
 
 [[package]]

--- a/scripts/lint
+++ b/scripts/lint
@@ -26,9 +26,9 @@ TOP_DIR=$(git rev-parse --show-toplevel)
 PY_DIR="${TOP_DIR}/python"
 
 uv run --directory "${PY_DIR}" ruff check --select I --fix --preview --unsafe-fixes .
-uv run --directory "${PY_DIR}" mypy .
+# uv run --directory "${PY_DIR}" mypy .
 
 # Add pylyzer, ty, and pyrefly
 #uv run --directory "${PY_DIR}" pylyzer --check .
-#uv run --directory "${PY_DIR}" ty check
+uv run --directory "${PY_DIR}" ty check
 #uv run --directory "${PY_DIR}" pyrefly check

--- a/scripts/run_python_checks_with_nox
+++ b/scripts/run_python_checks_with_nox
@@ -29,7 +29,7 @@ PY_DIR="$TOP_DIR/python"
 
 echo "=== Running Python lint ==="
 uv run --directory "${PY_DIR}" ruff check --select I --fix --preview --unsafe-fixes .
-uv run --directory "${PY_DIR}" mypy .
+uv run --directory "${PY_DIR}" ty check
 
 echo "=== Running Python tests (nox) ==="
 echo "Project root: ${TOP_DIR}"

--- a/scripts/run_python_checks_with_tox
+++ b/scripts/run_python_checks_with_tox
@@ -29,7 +29,7 @@ PY_DIR="$TOP_DIR/python"
 
 echo "=== Running Python lint ==="
 uv run --directory "${PY_DIR}" ruff check --select I --fix --preview --unsafe-fixes .
-uv run --directory "${PY_DIR}" mypy .
+uv run --directory "${PY_DIR}" ty check
 
 echo "=== Running Python tests ==="
 


### PR DESCRIPTION
CHANGELOG:
- [ ] Replace mypy with ty for faster and more accurate lint checks.
- [ ] Remove the use of strenum since (str, Enum) also works.
- [ ] Fix some field names.
- [ ] Update github rules and test runners to use ty.