### PR TITLE
build(py): update pyproject.toml license config to fix deprecation warnings

### DIFF
--- a/python/dotpromptz/pyproject.toml
+++ b/python/dotpromptz/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
+
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -44,7 +44,7 @@ dependencies = [
   "types-pyyaml>=6.0.12.20241230",
 ]
 description = "Dotpromptz is a language-neutral executable prompt template file format for Generative AI."
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "dotpromptz"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/handlebarrz/pyproject.toml
+++ b/python/handlebarrz/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Rust",
   "Topic :: Text Processing :: Markup",
-  "License :: OSI Approved :: Apache Software License",
+
 ]
 dependencies = [
   "structlog>=25.2.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@
 [project]
 dependencies    = ["dotpromptz", "dotpromptz-handlebars"]
 description     = "Workspace for Dotprompt packages"
-license         = { text = "Apache-2.0" }
+license         = "Apache-2.0"
 name            = "dotprompt-workspace"
 readme          = "README.md"
 requires-python = ">=3.10"

--- a/python/tests/smoke/pyproject.toml
+++ b/python/tests/smoke/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: Apache Software License",
+
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -38,7 +38,7 @@ dependencies = [
   #"js2py@git+https://github.com/a-j-albert/Js2Py---supports-python-3.13.git",
 ]
 description = "Packaging smoke test"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 name = "smoke"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Updates the license configuration in `pyproject.toml` files to use SPDX license expression strings instead of the deprecated table format. Also removes deprecated license classifiers to resolve `SetuptoolsDeprecationWarning`.

CHANGELOG:
- [ ] Update pyproject.toml license configuration to SPDX format
