### PR TITLE
docs: Update Dart implementations list with latest links

### DIFF
--- a/third_party/docsite/src/content/docs/implementations.mdx
+++ b/third_party/docsite/src/content/docs/implementations.mdx
@@ -20,6 +20,5 @@ The following is a community-curated list of Dotprompt implementations in variou
 
 | Name | Description | Links |
 | --- | --- | --- |
-| [ShipFlutter](https://shipflutter.com/) | A customizable Flutter starter kit. | [Docs](https://shipflutter.com/docs/ai/vertex/) |
-| [dartantic_ai](https://pub.dev/packages/dartantic_ai) | A Dart Agent framework inspired by pydantic-ai. | [Docs](https://pub.dev/packages/dartantic_ai) [GitHub](https://github.com/csells/dartantic_ai) |
-| [dotprompt_dart](https://pub.dev/packages/dotprompt_dart) | A dotprompt-client parser and validator for Dart; relies on [dartantic_ai](https://pub.dev/packages/dartantic_ai) for execution. | [Docs](https://pub.dev/packages/dotprompt_dart) [GitHub](https://github.com/csells/dotprompt_dart) |
+| [dartantic_ai](https://pub.dev/packages/dartantic_ai) | A Dart Agent framework inspired by pydantic-ai. | [Docs](https://docs.dartantic.ai/) [Pub](https://pub.dev/packages/dartantic_ai) [GitHub](https://github.com/csells/dartantic)  |
+| [dotprompt_dart](https://pub.dev/packages/dotprompt_dart) | A dotprompt-client parser and validator for Dart; relies on [dartantic_ai](https://pub.dev/packages/dartantic_ai) for execution. | [Pub](https://pub.dev/packages/dotprompt_dart) [GitHub](https://github.com/csells/dotprompt_dart)                                |


### PR DESCRIPTION
- Removes ShipFlutter entry as it doesn't seem to have any special support for dotprompt and the linked doc no longer exists.
- Updates the docs link for `dartantic_ai` to point to its hosted docs at https://docs.dartantic.ai/
- Adds an explicit "Pub" link for both `dartantic_ai` and `dotprompt_dart` for discoverability and consistent with the Node.js entry which has a NPM link.

\cc @csells 