### PR TITLE
fix: Ensure helper behavior parity across all runtimes

### DIFF
--- a/go/dotprompt/helper.go
+++ b/go/dotprompt/helper.go
@@ -36,6 +36,7 @@ var templateHelpers = map[string]any{
 
 // TODO: Add pending: true for section helper
 // JSON serializes the given data to a JSON string with optional indentation.
+// Panics on serialization errors to match JavaScript's JSON.stringify fail-fast behavior.
 func JSON(serializable any, options *raymond.Options) raymond.SafeString {
 	var jsonData []byte
 	var err error
@@ -51,7 +52,7 @@ func JSON(serializable any, options *raymond.Options) raymond.SafeString {
 	}
 
 	if err != nil {
-		return ""
+		panic(fmt.Sprintf("json helper: serialization failed: %v", err))
 	}
 	return raymond.SafeString(string(jsonData))
 }

--- a/go/dotprompt/helper_test.go
+++ b/go/dotprompt/helper_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// JSON, Media, IfEquals and UnlessEquals functions cannot be tested directly.
-// These functions are tested as part of spec tests present under go/test dir.
+// Tests for role helper
+
 func TestRoleFn(t *testing.T) {
 	role := "admin"
 	expected := "<<<dotprompt:role:admin>>>"
@@ -32,11 +32,30 @@ func TestRoleFn(t *testing.T) {
 	assert.Equal(t, raymond.SafeString(expected), result)
 }
 
+func TestRoleFn_system(t *testing.T) {
+	result := RoleFn("system")
+	assert.Equal(t, raymond.SafeString("<<<dotprompt:role:system>>>"), result)
+}
+
+func TestRoleFn_user(t *testing.T) {
+	result := RoleFn("user")
+	assert.Equal(t, raymond.SafeString("<<<dotprompt:role:user>>>"), result)
+}
+
+func TestRoleFn_model(t *testing.T) {
+	result := RoleFn("model")
+	assert.Equal(t, raymond.SafeString("<<<dotprompt:role:model>>>"), result)
+}
+
+// Tests for history helper
+
 func TestHistory(t *testing.T) {
 	expected := "<<<dotprompt:history>>>"
 	result := History()
 	assert.Equal(t, raymond.SafeString(expected), result)
 }
+
+// Tests for section helper
 
 func TestSection(t *testing.T) {
 	name := "Introduction"
@@ -44,3 +63,18 @@ func TestSection(t *testing.T) {
 	result := Section(name)
 	assert.Equal(t, raymond.SafeString(expected), result)
 }
+
+func TestSection_examples(t *testing.T) {
+	result := Section("examples")
+	assert.Equal(t, raymond.SafeString("<<<dotprompt:section examples>>>"), result)
+}
+
+// Note: JSON, Media, IfEquals, UnlessEquals helpers require raymond.Options
+// which is complex to mock in unit tests. These functions are thoroughly tested
+// via the spec tests in go/test/spec_test.go which exercise them through the
+// full template rendering pipeline.
+//
+// The spec tests cover:
+// - json: basic objects, arrays, indent variations, nested objects, empty values
+// - media: url only, url + contentType
+// - ifEquals/unlessEquals: int/string equality, boolean, null comparisons, type safety

--- a/go/dotprompt/parse.go
+++ b/go/dotprompt/parse.go
@@ -611,12 +611,12 @@ func parseMediaPart(piece string) (*MediaPart, error) {
 
 	mediaPart := &MediaPart{
 		Media: Media{
-			URL:         url,
-			ContentType: contentType,
+			URL: url,
 		},
 		HasMetadata: HasMetadata{},
 	}
 
+	// Only set ContentType if it's not empty (for JSON omitempty to work)
 	if contentType != "" && strings.TrimSpace(contentType) != "" {
 		mediaPart.Media.ContentType = contentType
 	}

--- a/go/dotprompt/test/spec_test.go
+++ b/go/dotprompt/test/spec_test.go
@@ -24,10 +24,11 @@ import (
 	"reflect"
 	"testing"
 
+	"maps"
+
 	"github.com/go-viper/mapstructure/v2"
 	. "github.com/google/dotprompt/go/dotprompt"
 	"github.com/invopop/jsonschema"
-	"maps"
 )
 
 const SpecDir = "../../../spec"
@@ -300,10 +301,14 @@ func pruneContent(content []Part) []map[string]any {
 			}
 		case *MediaPart:
 			if p.Media.URL != "" || p.Media.ContentType != "" {
-				prunedPart["media"] = map[string]any{
-					"url":         p.Media.URL,
-					"contentType": p.Media.ContentType,
+				mediaMap := map[string]any{
+					"url": p.Media.URL,
 				}
+				// Only include contentType if it's not empty (matches JSON omitempty behavior)
+				if p.Media.ContentType != "" {
+					mediaMap["contentType"] = p.Media.ContentType
+				}
+				prunedPart["media"] = mediaMap
 			}
 		case *ToolRequestPart:
 			if len(p.ToolRequest) > 0 {

--- a/js/src/helpers.test.ts
+++ b/js/src/helpers.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  history,
+  ifEquals,
+  json,
+  media,
+  role,
+  section,
+  unlessEquals,
+} from './helpers';
+
+describe('helpers', () => {
+  describe('json', () => {
+    it('should serialize an object to JSON', () => {
+      const result = json({ foo: 'bar' }, { hash: {} });
+      expect(result.toString()).toBe('{"foo":"bar"}');
+    });
+
+    it('should serialize with indent when specified', () => {
+      const result = json({ foo: 'bar' }, { hash: { indent: 2 } });
+      expect(result.toString()).toBe('{\n  "foo": "bar"\n}');
+    });
+
+    it('should serialize with 4-space indent when specified', () => {
+      const result = json({ test: true }, { hash: { indent: 4 } });
+      expect(result.toString()).toBe('{\n    "test": true\n}');
+    });
+
+    it('should serialize nested objects', () => {
+      const result = json({ outer: { inner: { value: 42 } } }, { hash: {} });
+      expect(result.toString()).toBe('{"outer":{"inner":{"value":42}}}');
+    });
+
+    it('should serialize arrays', () => {
+      const result = json([1, 2, 3], { hash: {} });
+      expect(result.toString()).toBe('[1,2,3]');
+    });
+
+    it('should serialize empty objects', () => {
+      const result = json({}, { hash: {} });
+      expect(result.toString()).toBe('{}');
+    });
+
+    it('should serialize empty arrays', () => {
+      const result = json([], { hash: {} });
+      expect(result.toString()).toBe('[]');
+    });
+
+    it('should throw on circular references (fail-fast behavior)', () => {
+      const circular: Record<string, unknown> = { foo: 'bar' };
+      circular.self = circular;
+
+      expect(() => json(circular, { hash: {} })).toThrow(TypeError);
+    });
+
+    it('should throw on BigInt values (fail-fast behavior)', () => {
+      // BigInt is not serializable to JSON
+      expect(() => json({ value: BigInt(123) }, { hash: {} })).toThrow(
+        TypeError
+      );
+    });
+  });
+
+  describe('role', () => {
+    it('should return a role marker for system', () => {
+      const result = role('system');
+      expect(result.toString()).toBe('<<<dotprompt:role:system>>>');
+    });
+
+    it('should return a role marker for user', () => {
+      const result = role('user');
+      expect(result.toString()).toBe('<<<dotprompt:role:user>>>');
+    });
+
+    it('should return a role marker for model', () => {
+      const result = role('model');
+      expect(result.toString()).toBe('<<<dotprompt:role:model>>>');
+    });
+  });
+
+  describe('history', () => {
+    it('should return a history marker', () => {
+      const result = history();
+      expect(result.toString()).toBe('<<<dotprompt:history>>>');
+    });
+  });
+
+  describe('section', () => {
+    it('should return a section marker', () => {
+      const result = section('examples');
+      expect(result.toString()).toBe('<<<dotprompt:section examples>>>');
+    });
+  });
+
+  describe('media', () => {
+    it('should return a media marker with url only', () => {
+      const result = media({
+        hash: { url: 'https://example.com/image.png' },
+      } as Handlebars.HelperOptions);
+      expect(result.toString()).toBe(
+        '<<<dotprompt:media:url https://example.com/image.png>>>'
+      );
+    });
+
+    it('should return a media marker with url and contentType', () => {
+      const result = media({
+        hash: {
+          url: 'https://example.com/image.png',
+          contentType: 'image/png',
+        },
+      } as Handlebars.HelperOptions);
+      expect(result.toString()).toBe(
+        '<<<dotprompt:media:url https://example.com/image.png image/png>>>'
+      );
+    });
+  });
+
+  describe('ifEquals', () => {
+    const mockContext = {};
+    const createOptions = (fn: () => string, inverse: () => string) =>
+      ({
+        fn: () => fn(),
+        inverse: () => inverse(),
+      }) as unknown as Handlebars.HelperOptions;
+
+    it('should return fn result when values are equal', () => {
+      const options = createOptions(
+        () => 'equal',
+        () => 'not equal'
+      );
+      const result = ifEquals.call(mockContext, 5, 5, options);
+      expect(result).toBe('equal');
+    });
+
+    it('should return inverse result when values are not equal', () => {
+      const options = createOptions(
+        () => 'equal',
+        () => 'not equal'
+      );
+      const result = ifEquals.call(mockContext, 5, 6, options);
+      expect(result).toBe('not equal');
+    });
+
+    it('should use strict equality (different types are not equal)', () => {
+      const options = createOptions(
+        () => 'equal',
+        () => 'not equal'
+      );
+      // 5 !== "5" in strict equality
+      const result = ifEquals.call(mockContext, 5, '5', options);
+      expect(result).toBe('not equal');
+    });
+
+    it('should compare boolean values correctly', () => {
+      const options = createOptions(
+        () => 'equal',
+        () => 'not equal'
+      );
+      expect(ifEquals.call(mockContext, true, true, options)).toBe('equal');
+      expect(ifEquals.call(mockContext, false, false, options)).toBe('equal');
+      expect(ifEquals.call(mockContext, true, false, options)).toBe(
+        'not equal'
+      );
+    });
+
+    it('should compare null values correctly', () => {
+      const options = createOptions(
+        () => 'equal',
+        () => 'not equal'
+      );
+      expect(ifEquals.call(mockContext, null, null, options)).toBe('equal');
+      expect(ifEquals.call(mockContext, null, 0, options)).toBe('not equal');
+      expect(ifEquals.call(mockContext, null, undefined, options)).toBe(
+        'not equal'
+      );
+    });
+  });
+
+  describe('unlessEquals', () => {
+    const mockContext = {};
+    const createOptions = (fn: () => string, inverse: () => string) =>
+      ({
+        fn: () => fn(),
+        inverse: () => inverse(),
+      }) as unknown as Handlebars.HelperOptions;
+
+    it('should return fn result when values are not equal', () => {
+      const options = createOptions(
+        () => 'not equal',
+        () => 'equal'
+      );
+      const result = unlessEquals.call(mockContext, 5, 6, options);
+      expect(result).toBe('not equal');
+    });
+
+    it('should return inverse result when values are equal', () => {
+      const options = createOptions(
+        () => 'not equal',
+        () => 'equal'
+      );
+      const result = unlessEquals.call(mockContext, 5, 5, options);
+      expect(result).toBe('equal');
+    });
+
+    it('should use strict inequality (different types are not equal)', () => {
+      const options = createOptions(
+        () => 'not equal',
+        () => 'equal'
+      );
+      // 5 !== "5" in strict comparison
+      const result = unlessEquals.call(mockContext, 5, '5', options);
+      expect(result).toBe('not equal');
+    });
+
+    it('should compare boolean values correctly', () => {
+      const options = createOptions(
+        () => 'not equal',
+        () => 'equal'
+      );
+      expect(unlessEquals.call(mockContext, true, false, options)).toBe(
+        'not equal'
+      );
+      expect(unlessEquals.call(mockContext, true, true, options)).toBe('equal');
+    });
+
+    it('should compare null values correctly', () => {
+      const options = createOptions(
+        () => 'not equal',
+        () => 'equal'
+      );
+      expect(unlessEquals.call(mockContext, null, null, options)).toBe('equal');
+      expect(unlessEquals.call(mockContext, null, 0, options)).toBe(
+        'not equal'
+      );
+    });
+  });
+});

--- a/python/dotpromptz/src/dotpromptz/helpers.py
+++ b/python/dotpromptz/src/dotpromptz/helpers.py
@@ -51,6 +51,10 @@ def json_helper(params: list[Any], options: HelperOptions) -> str:
 
     Returns:
         JSON string representation of the value.
+
+    Raises:
+        TypeError: If the value cannot be serialized to JSON.
+        ValueError: If the value contains invalid data for JSON serialization.
     """
     if not params or len(params) < 1:
         return ''
@@ -63,12 +67,10 @@ def json_helper(params: list[Any], options: HelperOptions) -> str:
     except (ValueError, TypeError):
         indent = 0
 
-    try:
-        if indent == 0:
-            return json.dumps(obj, separators=(',', ':'))
-        return json.dumps(obj, indent=indent)
-    except (TypeError, ValueError):
-        return '{}'
+    # Let serialization errors propagate like JS JSON.stringify
+    if indent == 0:
+        return json.dumps(obj, separators=(',', ':'))
+    return json.dumps(obj, indent=indent)
 
 
 def role_helper(params: list[Any], options: HelperOptions) -> str:

--- a/spec/helpers/ifEquals.yaml
+++ b/spec/helpers/ifEquals.yaml
@@ -67,3 +67,58 @@
         messages:
           - role: user
             content: [{ text: "Values are not equal\n" }]
+
+# Tests boolean value comparisons to ensure consistent handling across runtimes.
+- name: boolean_comparison
+  template: |
+    {{#ifEquals value1 value2}}
+    Values are equal
+    {{else}}
+    Values are not equal
+    {{/ifEquals}}
+  tests:
+    - desc: correctly compares true values
+      data:
+        input: { value1: true, value2: true }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are equal\n" }]
+    - desc: correctly compares false values
+      data:
+        input: { value1: false, value2: false }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are equal\n" }]
+    - desc: correctly compares different boolean values
+      data:
+        input: { value1: true, value2: false }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are not equal\n" }]
+
+# Tests null value comparisons to ensure consistent handling across runtimes.
+- name: null_comparison
+  template: |
+    {{#ifEquals value1 value2}}
+    Values are equal
+    {{else}}
+    Values are not equal
+    {{/ifEquals}}
+  tests:
+    - desc: correctly compares null values
+      data:
+        input: { value1: null, value2: null }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are equal\n" }]
+    - desc: correctly compares null with non-null
+      data:
+        input: { value1: null, value2: 0 }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are not equal\n" }]

--- a/spec/helpers/json.yaml
+++ b/spec/helpers/json.yaml
@@ -41,3 +41,49 @@
         messages:
           - role: user
             content: [{ text: "{\n  \"test\": true\n}" }]
+
+# Tests 4-space indentation to ensure indent parameter is properly respected
+# across all runtime implementations.
+- name: indented_4_spaces
+  template: "{{json this indent=4}}"
+  tests:
+    - desc: renders json with 4-space indentation
+      data: { input: { test: true } }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "{\n    \"test\": true\n}" }]
+
+# Tests nested object serialization to ensure complex structures are handled
+# consistently across runtimes.
+- name: nested_objects
+  template: "{{json this}}"
+  tests:
+    - desc: renders nested objects correctly
+      data: { input: { outer: { inner: { value: 42 } } } }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: '{"outer":{"inner":{"value":42}}}' }]
+
+# Tests array serialization
+- name: arrays
+  template: "{{json this}}"
+  tests:
+    - desc: renders arrays correctly
+      data: { input: { items: [1, 2, 3] } }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: '{"items":[1,2,3]}' }]
+
+# Tests empty value serialization
+- name: empty_values
+  template: "{{json this}}"
+  tests:
+    - desc: renders empty object
+      data: { input: {} }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: '{}' }]

--- a/spec/helpers/media.yaml
+++ b/spec/helpers/media.yaml
@@ -14,10 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
-# Tests for the {{media}} helper which formats media URLs with content type
-# information in message content.
-
 # Tests that media URLs are properly formatted with content type in the
 # message content array.
 - name: basic
@@ -34,3 +30,35 @@
                   media: { "contentType": "image/jpeg", "url": "http://a/b/c" },
                 },
               ]
+
+# Tests media URL without content type to ensure optional parameter handling
+# is consistent across runtimes.
+- name: url_only
+  template: "{{media url=url}}"
+  tests:
+    - desc: renders media part with url only
+      data: { input: { url: "http://example.com/image.png" } }
+      expect:
+        messages:
+          - role: user
+            content:
+              - media: { url: "http://example.com/image.png" }
+
+# Tests various content types to ensure proper handling across runtimes.
+- name: content_types
+  template: "{{media contentType=contentType url=url}}"
+  tests:
+    - desc: renders video content type
+      data: { input: { contentType: "video/mp4", url: "http://example.com/video.mp4" } }
+      expect:
+        messages:
+          - role: user
+            content:
+              - media: { contentType: "video/mp4", url: "http://example.com/video.mp4" }
+    - desc: renders audio content type
+      data: { input: { contentType: "audio/mpeg", url: "http://example.com/audio.mp3" } }
+      expect:
+        messages:
+          - role: user
+            content:
+              - media: { contentType: "audio/mpeg", url: "http://example.com/audio.mp3" }

--- a/spec/helpers/unlessEquals.yaml
+++ b/spec/helpers/unlessEquals.yaml
@@ -67,3 +67,58 @@
         messages:
           - role: user
             content: [{ text: "Values are not equal\n" }]
+
+# Tests boolean value comparisons to ensure consistent handling across runtimes.
+- name: boolean_comparison
+  template: |
+    {{#unlessEquals value1 value2}}
+    Values are not equal
+    {{else}}
+    Values are equal
+    {{/unlessEquals}}
+  tests:
+    - desc: correctly compares true values
+      data:
+        input: { value1: true, value2: true }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are equal\n" }]
+    - desc: correctly compares false values
+      data:
+        input: { value1: false, value2: false }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are equal\n" }]
+    - desc: correctly compares different boolean values
+      data:
+        input: { value1: true, value2: false }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are not equal\n" }]
+
+# Tests null value comparisons to ensure consistent handling across runtimes.
+- name: null_comparison
+  template: |
+    {{#unlessEquals value1 value2}}
+    Values are not equal
+    {{else}}
+    Values are equal
+    {{/unlessEquals}}
+  tests:
+    - desc: correctly compares null values
+      data:
+        input: { value1: null, value2: null }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are equal\n" }]
+    - desc: correctly compares null with non-null
+      data:
+        input: { value1: null, value2: 0 }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Values are not equal\n" }]


### PR DESCRIPTION
fix: Ensure helper behavior parity across all runtimes

Fix helper implementations to match JavaScript's canonical behavior:

- Python: Let json serialization errors propagate (fail-fast)
- Rust: Respect json indent parameter value
- Java: Respect json indent parameter with correct ": " separator
- Go: Panic on json serialization errors (fail-fast)

Also fixed:

- Go spec_test.go: Only include contentType when not empty
- Go parse.go: Don't initialize empty contentType in MediaPart

Added comprehensive unit tests across all runtimes:

- JS: 26 tests covering all helpers with edge cases
- Python: 26 tests including type safety and exception behavior
- Java: 29 tests including indent variations and null comparisons
- Rust: 25 helper unit tests covering json, role, history, section,
  media, ifEquals, unlessEquals with type safety tests
- Go: 7 unit tests + spec test coverage

Added spec tests for cross-runtime parity:

- spec/helpers/json.yaml: 4-space indent, nested objects
- spec/helpers/ifEquals.yaml: Boolean and null comparisons
- spec/helpers/unlessEquals.yaml: Boolean and null comparisons
- spec/helpers/media.yaml: URL-only and content type tests