### PR TITLE
docs: clarify input.default type in frontmatter docs

### DIFF
--- a/third_party/docsite/src/content/docs/reference/frontmatter.mdx
+++ b/third_party/docsite/src/content/docs/reference/frontmatter.mdx
@@ -117,7 +117,7 @@ metadata:
 - **Description:** Defines the input variables the prompt. If `input` is not specified, the implementation should accept any `Map<string,any>` values as input and pass them to the prompt template.
 - **Properties:**
   - `default`:
-    - **Type:** `any`
+    - **Type:** `Map<string,any>`
     - **Description:** Defines the default input variable values to use if none are provided. Input values passed from the implementation should be merged into these values with a shallow merge strategy.
   - `schema`:
     - **Type:** [Schema](schema)


### PR DESCRIPTION
## Summary

Clarifies the type annotation for `input.default` in the frontmatter documentation from `any` to `Map<string,any>` to align with the TypeScript implementation.

## Changes

- Updated `third_party/docsite/src/content/docs/reference/frontmatter.mdx` line 120
- Changed type from `any` to `Map<string,any>`

## Reference

Fixes #306