### PR TITLE
docs: clarify picoschema usage in frontmatter docs

### DIFF
--- a/third_party/docsite/src/content/docs/reference/frontmatter.mdx
+++ b/third_party/docsite/src/content/docs/reference/frontmatter.mdx
@@ -121,7 +121,7 @@ metadata:
     - **Description:** Defines the default input variable values to use if none are provided. Input values passed from the implementation should be merged into these values with a shallow merge strategy.
   - `schema`:
     - **Type:** [Schema](schema)
-    - **Description:** Schema representing the input values for the prompt. Must correspond to a JSON Schema `object` type.
+    - **Description:** Schema representing the input values for the prompt. Schemas use [Picoschema](/reference/picoschema/) syntax—a compact YAML format that compiles to JSON Schema.
 
 ### `output`
 
@@ -134,7 +134,7 @@ metadata:
     - **Description:** Desired output format for this prompt. Output formats are implementation-specific, but
   - `schema`:
     - **Type:** [Schema](schema)
-    - **Description:** Schema representing the expected output from the prompt. Must correspond to a JSON Schema `object` type.
+    - **Description:** Schema representing the expected output from the prompt. Schemas use [Picoschema](/reference/picoschema/) syntax—a compact YAML format that compiles to JSON Schema.
 
 ### `metadata`
 


### PR DESCRIPTION
## Summary

Clarifies that schemas in Dotprompt frontmatter use **Picoschema** format—not standard JSON Schema. Adds links to the Picoschema reference page to help users understand the compact YAML syntax used in examples.

## Changes

- Updated `input.schema` description to mention Picoschema with link
- Updated `output.schema` description to mention Picoschema with link
- Both now explain that Picoschema compiles to JSON Schema

## Context

Issue #307 raised confusion because the documentation mentioned "JSON Schema" but examples used Picoschema syntax (e.g., `name: string`, `tags(array): string`). This change makes the schema format explicit.

## Reference

Fixes #307