### PR TITLE
fix(dotpromptz): enable type-safe schema field in Pydantic models

### DIFF
--- a/python/dotpromptz/src/dotpromptz/dotprompt.py
+++ b/python/dotpromptz/src/dotpromptz/dotprompt.py
@@ -393,8 +393,8 @@ class Dotprompt:
         Returns:
             The rendered prompt metadata.
         """
-        needs_input_processing = meta.input is not None and meta.input.schema_ is not None
-        needs_output_processing = meta.output is not None and meta.output.schema_ is not None
+        needs_input_processing = meta.input is not None and meta.input.schema is not None
+        needs_output_processing = meta.output is not None and meta.output.schema is not None
 
         if not needs_input_processing and not needs_output_processing:
             return meta
@@ -403,14 +403,14 @@ class Dotprompt:
 
         async def _process_input_schema(schema_to_process: Any) -> None:
             if new_meta.input is not None:
-                new_meta.input.schema_ = await picoschema_to_json_schema(
+                new_meta.input.schema = await picoschema_to_json_schema(
                     schema_to_process,
                     self._wrapped_schema_resolver,
                 )
 
         async def _process_output_schema(schema_to_process: Any) -> None:
             if new_meta.output is not None:
-                new_meta.output.schema_ = await picoschema_to_json_schema(
+                new_meta.output.schema = await picoschema_to_json_schema(
                     schema_to_process,
                     self._wrapped_schema_resolver,
                 )
@@ -418,10 +418,10 @@ class Dotprompt:
         async with anyio.create_task_group() as tg:
             if needs_input_processing and meta.input is not None:
                 # TODO: use meta.input.model_dump(exclude_none=True)?
-                tg.start_soon(_process_input_schema, meta.input.schema_)
+                tg.start_soon(_process_input_schema, meta.input.schema)
             if needs_output_processing and meta.output is not None:
                 # TODO: use meta.output.model_dump(exclude_none=True)?
-                tg.start_soon(_process_output_schema, meta.output.schema_)
+                tg.start_soon(_process_output_schema, meta.output.schema)
 
         return new_meta
 

--- a/python/dotpromptz/src/dotpromptz/typing.py
+++ b/python/dotpromptz/src/dotpromptz/typing.py
@@ -155,7 +155,7 @@ from typing import (
     TypeVar,
 )
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 Schema = Any
 """Type alias for a generic schema."""
@@ -244,14 +244,13 @@ class PromptInputConfig(BaseModel):
     Attributes:
         default: A dictionary providing default values for input variables
                  if not supplied at runtime.
-        schema_: A schema definition constraining the expected input
-                 variables. Aliased as 'schema'. Using `schema_` avoids
-                 collision with Pydantic methods.
+        schema: A schema definition constraining the expected input
+                variables. Can be passed as `schema` or `schema_` at runtime.
     """
 
     default: dict[str, Any] | None = None
-    schema_: Schema | None = Field(default=None, alias='schema')
-    model_config = ConfigDict(populate_by_name=True)
+    schema: Schema | None = Field(default=None, validation_alias=AliasChoices('schema', 'schema_'))
+    model_config = ConfigDict(populate_by_name=True, protected_namespaces=())
 
 
 class PromptOutputConfig(BaseModel):
@@ -259,13 +258,13 @@ class PromptOutputConfig(BaseModel):
 
     Attributes:
         format: Specifies the desired output format.
-        schema_: A schema definition constraining the structure of the
-                 expected output. Aliased as 'schema'.
+        schema: A schema definition constraining the structure of the
+                expected output. Can be passed as `schema` or `schema_` at runtime.
     """
 
     format: Literal['json', 'text'] | str | None = None
-    schema_: Schema | None = Field(default=None, alias='schema')
-    model_config = ConfigDict(populate_by_name=True)
+    schema: Schema | None = Field(default=None, validation_alias=AliasChoices('schema', 'schema_'))
+    model_config = ConfigDict(populate_by_name=True, protected_namespaces=())
 
 
 class PromptMetadata(HasMetadata, Generic[ModelConfigT]):

--- a/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
+++ b/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
@@ -373,9 +373,9 @@ class TestRenderPicoSchema(IsolatedAsyncioTestCase):
         # Now call the function that uses picoschema.picoschema internally
         result: PromptMetadata[dict[str, Any]] = await dotprompt._render_picoschema(metadata)
         assert result.input is not None
-        assert result.input.schema_ == values_assert
+        assert result.input.schema == values_assert
         assert result.output is not None
-        assert result.output.schema_ == values_assert
+        assert result.output.schema == values_assert
 
     async def test_returns_original_metadata_when_no_schemas_present(self) -> None:
         """Test that the original metadata is returned unchanged when no schemas are present."""


### PR DESCRIPTION
The PromptInputConfig and PromptOutputConfig classes used schema_
as the Python field name with `alias='schema'`. Type checkers only
recognized schema_ as valid, even though `populate_by_name=True`
allowed `schema=` at runtime.

Changes:
- Rename field from schema to schema using `validation_alias`
  with `AliasChoices('schema', 'schema_')` for backward compatibility
- Add `protected_namespaces=()` to suppress Pydantic BaseModel warning
- Update all `.schema_` references to `.schema` in dotprompt.py
- Update test assertions to use `.schema`

Now PromptInputConfig(schema=...) is recognized as valid by type
checkers like ty, pyright, and mypy.
