### PR TITLE
feat(ide): complete Phase 2 IDE integrations for all major editors

### DIFF
--- a/packages/emacs/README.md
+++ b/packages/emacs/README.md
@@ -2,39 +2,86 @@
 
 Provides a major mode for editing Dotprompt (`.prompt`) files with syntax highlighting and LSP support.
 
+## Features
+
+- **Syntax Highlighting**: Handlebars helpers, partials, Dotprompt markers
+- **LSP Integration**: Diagnostics, formatting, hover via eglot or lsp-mode
+- **Format Buffer**: `C-c C-f` or `M-x dotprompt-format-buffer`
+- **Format on Save**: Optional automatic formatting
+
 ## Installation
+
+### use-package (Recommended)
+
+```elisp
+(use-package dotprompt-mode
+  :load-path "path/to/dotprompt/packages/emacs"
+  :mode "\\.prompt\\'"
+  :custom
+  (dotprompt-promptly-path "promptly")
+  (dotprompt-format-on-save t))
+```
+
+### straight.el
+
+```elisp
+(straight-use-package
+ '(dotprompt-mode :type git
+                  :host github
+                  :repo "google/dotprompt"
+                  :files ("packages/emacs/*.el")))
+
+(use-package dotprompt-mode
+  :mode "\\.prompt\\'"
+  :custom
+  (dotprompt-format-on-save t))
+```
+
+### Doom Emacs
+
+Add to `packages.el`:
+
+```elisp
+(package! dotprompt-mode
+  :recipe (:host github
+           :repo "google/dotprompt"
+           :files ("packages/emacs/*.el")))
+```
+
+Add to `config.el`:
+
+```elisp
+(use-package! dotprompt-mode
+  :mode "\\.prompt\\'"
+  :config
+  (setq dotprompt-format-on-save t)
+  (add-hook 'dotprompt-mode-hook #'eglot-ensure))
+```
+
+### Spacemacs
+
+Add to your `dotspacemacs/user-config`:
+
+```elisp
+(use-package dotprompt-mode
+  :load-path "path/to/dotprompt/packages/emacs"
+  :mode "\\.prompt\\'"
+  :init
+  (spacemacs/set-leader-keys-for-major-mode 'dotprompt-mode
+    "f" 'dotprompt-format-buffer))
+```
 
 ### Manual
 
-1. Copy `dotprompt-mode.el` to your load path (e.g., `~/.emacs.d/lisp/`).
-2. Add the following to your init file:
+1. Copy `dotprompt-mode.el` to your load path (e.g., `~/.emacs.d/lisp/`)
+2. Add to your init file:
 
 ```elisp
 (add-to-list 'load-path "~/.emacs.d/lisp/")
 (require 'dotprompt-mode)
 ```
 
-### use-package
-
-```elisp
-(use-package dotprompt-mode
-  :load-path "path/to/dotprompt/packages/emacs"
-  :mode "\\.prompt\\'")
-```
-
-## Features
-
-- **Syntax highlighting** for:
-  - Dotprompt markers (`<<<dotprompt:...>>>`)
-  - Handlebars helpers (`if`, `unless`, `each`)
-  - Dotprompt custom helpers (`json`, `role`, `history`)
-  - Partials (`{{> ... }}`)
-- **Auto-detection** of `.prompt` files
-- **LSP integration** via eglot or lsp-mode
-
-## LSP Support
-
-For diagnostics, formatting, and hover documentation, install `promptly`:
+## Install promptly for LSP Features
 
 ```bash
 cargo install --path rs/promptly
@@ -42,18 +89,14 @@ cargo install --path rs/promptly
 cargo build --release -p promptly
 ```
 
+## LSP Support
+
 ### Using Eglot (Emacs 29+, built-in)
 
-Eglot integration is automatic. Just enable eglot in your dotprompt buffers:
+Eglot integration is automatic. Enable in your dotprompt buffers:
 
 ```elisp
 (add-hook 'dotprompt-mode-hook 'eglot-ensure)
-```
-
-If `promptly` is not in your PATH, customize the path:
-
-```elisp
-(setq dotprompt-promptly-path "/path/to/promptly")
 ```
 
 ### Using lsp-mode
@@ -64,15 +107,42 @@ lsp-mode integration is also automatic:
 (add-hook 'dotprompt-mode-hook 'lsp-deferred)
 ```
 
-### LSP Features
-
-With LSP enabled, you get:
-- **Diagnostics**: Real-time error detection for YAML and Handlebars syntax
-- **Formatting**: Format buffer with `M-x lsp-format-buffer` or `M-x eglot-format-buffer`
-- **Hover**: Documentation for Handlebars helpers and frontmatter fields (`M-x eldoc` or hover)
-
 ## Configuration
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `dotprompt-promptly-path` | `"promptly"` | Path to the promptly executable |
+| `dotprompt-format-on-save` | `nil` | Format buffer before saving |
+
+### Custom promptly path
+
+```elisp
+(setq dotprompt-promptly-path "/path/to/promptly")
+```
+
+### Enable format on save
+
+```elisp
+(setq dotprompt-format-on-save t)
+```
+
+## Keybindings
+
+| Key | Command | Description |
+|-----|---------|-------------|
+| `C-c C-f` | `dotprompt-format-buffer` | Format the current buffer |
+
+## LSP Features
+
+With LSP enabled (eglot or lsp-mode), you get:
+
+| Feature | Description |
+|---------|-------------|
+| **Diagnostics** | Real-time error detection for YAML and Handlebars syntax |
+| **Formatting** | Format with `M-x eglot-format-buffer` or `M-x lsp-format-buffer` |
+| **Hover** | Documentation with `M-x eldoc` or mouse hover |
+| **Go to Definition** | Jump to partial files with `M-.` |
+
+## Commands
+
+- `dotprompt-format-buffer` - Format the current buffer using LSP or promptly directly

--- a/packages/jetbrains/README.md
+++ b/packages/jetbrains/README.md
@@ -6,7 +6,9 @@ Language support for Dotprompt (`.prompt`) files in JetBrains IDEs (IntelliJ IDE
 
 - **Syntax Highlighting**: YAML frontmatter, Handlebars templates, Dotprompt markers
 - **LSP Integration**: Real-time diagnostics, formatting, and hover documentation (via LSP4IJ)
+- **Live Templates**: Type `role`, `if`, `each`, `json` + Tab for quick insertions
 - **Code Comments**: Block comment support using `{{! ... }}`
+- **Settings UI**: Configure promptly path and format on save
 
 ## Requirements
 
@@ -35,7 +37,7 @@ Language support for Dotprompt (`.prompt`) files in JetBrains IDEs (IntelliJ IDE
 
 3. **Install**:
    - Go to **Settings/Preferences** → **Plugins** → **⚙️** → **Install Plugin from Disk...**
-   - Select `build/distributions/dotprompt-intellij-0.1.0.zip`
+   - Select `build/distributions/dotprompt-intellij-0.2.0.zip`
 
 ### From Source (Bazel)
 
@@ -72,6 +74,30 @@ cargo build --release -p promptly
 ./gradlew test
 ```
 
+## Live Templates
+
+Type these abbreviations and press Tab to expand:
+
+| Abbreviation | Expands To |
+|--------------|------------|
+| `role` | Role block with customizable role name |
+| `system` | System role block |
+| `user` | User role block |
+| `model` | Model role block |
+| `if` | Handlebars if block |
+| `ifelse` | Handlebars if-else block |
+| `unless` | Handlebars unless block |
+| `each` | Handlebars each loop |
+| `with` | Handlebars with block |
+| `json` | JSON serialization helper |
+| `media` | Media embedding helper |
+| `history` | History insertion |
+| `section` | Named section block |
+| `partial` | Partial template inclusion |
+| `comment` | Handlebars comment |
+| `prompt` | Complete prompt template |
+| `frontmatter` | YAML frontmatter |
+
 ## LSP Features
 
 When `promptly` is installed and in your PATH, you get:
@@ -84,9 +110,20 @@ When `promptly` is installed and in your PATH, you get:
 
 ## Configuration
 
+### Settings UI
+
+Go to **Settings/Preferences** → **Languages & Frameworks** → **Dotprompt**:
+
+- **Promptly path**: Custom path to the promptly executable
+- **Enable LSP features**: Toggle diagnostics, formatting, hover
+- **Format on save**: Automatically format when saving
+
+### Auto-Detection
+
 The plugin automatically finds `promptly` in:
-1. System PATH
-2. `~/.cargo/bin/promptly`
+1. User-configured path (Settings)
+2. System PATH
+3. `~/.cargo/bin/promptly`
 
 ## Architecture
 

--- a/packages/jetbrains/src/main/kotlin/com/google/dotprompt/DotpromptSettings.kt
+++ b/packages/jetbrains/src/main/kotlin/com/google/dotprompt/DotpromptSettings.kt
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.google.dotprompt
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+/**
+ * Persistent settings for the Dotprompt plugin.
+ */
+@Service(Service.Level.APP)
+@State(
+    name = "DotpromptSettings",
+    storages = [Storage("dotprompt.xml")]
+)
+class DotpromptSettings : PersistentStateComponent<DotpromptSettings.State> {
+
+    /**
+     * Settings state data class.
+     */
+    data class State(
+        /** Custom path to the promptly executable. */
+        var promptlyPath: String = "",
+        /** Whether to enable format on save. */
+        var formatOnSave: Boolean = true,
+        /** Whether to enable LSP features. */
+        var enableLsp: Boolean = true
+    )
+
+    private var myState = State()
+
+    override fun getState(): State = myState
+
+    override fun loadState(state: State) {
+        myState = state
+    }
+
+    /** Custom path to the promptly executable. Empty string means auto-detect. */
+    var promptlyPath: String
+        get() = myState.promptlyPath
+        set(value) { myState.promptlyPath = value }
+
+    /** Whether to enable format on save. */
+    var formatOnSave: Boolean
+        get() = myState.formatOnSave
+        set(value) { myState.formatOnSave = value }
+
+    /** Whether to enable LSP features. */
+    var enableLsp: Boolean
+        get() = myState.enableLsp
+        set(value) { myState.enableLsp = value }
+
+    companion object {
+        fun getInstance(): DotpromptSettings =
+            ApplicationManager.getApplication().getService(DotpromptSettings::class.java)
+    }
+}

--- a/packages/jetbrains/src/main/kotlin/com/google/dotprompt/DotpromptSettingsConfigurable.kt
+++ b/packages/jetbrains/src/main/kotlin/com/google/dotprompt/DotpromptSettingsConfigurable.kt
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.google.dotprompt
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.FormBuilder
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Settings UI for the Dotprompt plugin.
+ * Accessible via Settings > Languages & Frameworks > Dotprompt.
+ */
+class DotpromptSettingsConfigurable : Configurable {
+
+    private var promptlyPathField: TextFieldWithBrowseButton? = null
+    private var formatOnSaveCheckbox: JBCheckBox? = null
+    private var enableLspCheckbox: JBCheckBox? = null
+
+    override fun getDisplayName(): String = "Dotprompt"
+
+    override fun createComponent(): JComponent {
+        promptlyPathField = TextFieldWithBrowseButton().apply {
+            addBrowseFolderListener(
+                "Select Promptly Executable",
+                "Select the path to the promptly executable",
+                null,
+                FileChooserDescriptorFactory.createSingleFileDescriptor()
+            )
+        }
+
+        formatOnSaveCheckbox = JBCheckBox("Format on save")
+        enableLspCheckbox = JBCheckBox("Enable LSP features (diagnostics, formatting, hover)")
+
+        return FormBuilder.createFormBuilder()
+            .addLabeledComponent(
+                JBLabel("Promptly path:"),
+                promptlyPathField!!,
+                1,
+                false
+            )
+            .addComponent(
+                JBLabel("<html><small>Leave empty to auto-detect from PATH or ~/.cargo/bin</small></html>"),
+                0
+            )
+            .addSeparator()
+            .addComponent(enableLspCheckbox!!, 1)
+            .addComponent(formatOnSaveCheckbox!!, 1)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+    }
+
+    override fun isModified(): Boolean {
+        val settings = DotpromptSettings.getInstance()
+        return promptlyPathField?.text != settings.promptlyPath ||
+                formatOnSaveCheckbox?.isSelected != settings.formatOnSave ||
+                enableLspCheckbox?.isSelected != settings.enableLsp
+    }
+
+    override fun apply() {
+        val settings = DotpromptSettings.getInstance()
+        settings.promptlyPath = promptlyPathField?.text ?: ""
+        settings.formatOnSave = formatOnSaveCheckbox?.isSelected ?: true
+        settings.enableLsp = enableLspCheckbox?.isSelected ?: true
+    }
+
+    override fun reset() {
+        val settings = DotpromptSettings.getInstance()
+        promptlyPathField?.text = settings.promptlyPath
+        formatOnSaveCheckbox?.isSelected = settings.formatOnSave
+        enableLspCheckbox?.isSelected = settings.enableLsp
+    }
+
+    override fun disposeUIResources() {
+        promptlyPathField = null
+        formatOnSaveCheckbox = null
+        enableLspCheckbox = null
+    }
+}

--- a/packages/jetbrains/src/main/kotlin/com/google/dotprompt/DotpromptTemplateContext.kt
+++ b/packages/jetbrains/src/main/kotlin/com/google/dotprompt/DotpromptTemplateContext.kt
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package com.google.dotprompt
+
+import com.intellij.codeInsight.template.TemplateActionContext
+import com.intellij.codeInsight.template.TemplateContextType
+
+/**
+ * Template context for Dotprompt live templates.
+ * Enables live templates when editing .prompt files.
+ */
+class DotpromptTemplateContext : TemplateContextType("Dotprompt") {
+
+    override fun isInContext(templateActionContext: TemplateActionContext): Boolean {
+        val file = templateActionContext.file
+        return file.fileType == DotpromptFileType.INSTANCE ||
+               file.name.endsWith(".prompt")
+    }
+}

--- a/packages/jetbrains/src/main/kotlin/com/google/dotprompt/PromptlyServerFactory.kt
+++ b/packages/jetbrains/src/main/kotlin/com/google/dotprompt/PromptlyServerFactory.kt
@@ -35,9 +35,24 @@ class PromptlyServerFactory : LanguageServerFactory {
 
     /**
      * Finds the promptly executable in common locations.
+     *
+     * Priority:
+     * 1. User-configured path in settings
+     * 2. System PATH
+     * 3. ~/.cargo/bin/promptly
+     * 4. Fallback to "promptly" (hope it's in PATH)
      */
     private fun findPromptlyExecutable(): String {
-        // Check PATH first
+        // Check user settings first
+        val settings = DotpromptSettings.getInstance()
+        if (settings.promptlyPath.isNotBlank()) {
+            val configuredPath = File(settings.promptlyPath)
+            if (configuredPath.exists() && configuredPath.canExecute()) {
+                return configuredPath.absolutePath
+            }
+        }
+
+        // Check PATH
         val pathDirs = System.getenv("PATH")?.split(File.pathSeparator) ?: emptyList()
         for (dir in pathDirs) {
             val promptly = File(dir, "promptly")

--- a/packages/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/packages/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -30,6 +30,7 @@
         <li>Real-time diagnostics via LSP (requires <code>promptly</code>)</li>
         <li>Document formatting</li>
         <li>Hover documentation for helpers and frontmatter fields</li>
+        <li>Live templates for common patterns (role, if, each, json, etc.)</li>
     </ul>
 
     <h3>Installation</h3>
@@ -38,6 +39,12 @@
     ]]></description>
 
     <change-notes><![CDATA[
+    <h3>0.2.0</h3>
+    <ul>
+        <li>Live templates for common patterns</li>
+        <li>Settings UI for promptly path configuration</li>
+        <li>Format on save option</li>
+    </ul>
     <h3>0.1.0</h3>
     <ul>
         <li>Initial release</li>
@@ -72,6 +79,21 @@
         <lang.commenter
                 language="Dotprompt"
                 implementationClass="com.google.dotprompt.DotpromptCommenter"/>
+
+        <!-- Live templates -->
+        <defaultLiveTemplates file="/liveTemplates/Dotprompt.xml"/>
+        <liveTemplateContext
+                contextId="DOTPROMPT"
+                implementation="com.google.dotprompt.DotpromptTemplateContext"/>
+
+        <!-- Settings -->
+        <applicationConfigurable
+                parentId="language"
+                instance="com.google.dotprompt.DotpromptSettingsConfigurable"
+                id="com.google.dotprompt.settings"
+                displayName="Dotprompt"/>
+        <applicationService
+                serviceImplementation="com.google.dotprompt.DotpromptSettings"/>
     </extensions>
 
     <!-- LSP4IJ server definition -->
@@ -87,3 +109,4 @@
         <languageMapping language="Dotprompt" serverId="promptly"/>
     </extensions>
 </idea-plugin>
+

--- a/packages/jetbrains/src/main/resources/liveTemplates/Dotprompt.xml
+++ b/packages/jetbrains/src/main/resources/liveTemplates/Dotprompt.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+<templateSet group="Dotprompt">
+    <!-- Role blocks -->
+    <template name="role" value="{{#role &quot;$ROLE$&quot;}}&#10;$CONTENT$&#10;{{/role}}" description="Handlebars role block" toReformat="false" toShortenFQNames="true">
+        <variable name="ROLE" expression="" defaultValue="&quot;user&quot;" alwaysStopAt="true"/>
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="system" value="{{#role &quot;system&quot;}}&#10;$CONTENT$&#10;{{/role}}" description="System role block" toReformat="false" toShortenFQNames="true">
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="user" value="{{#role &quot;user&quot;}}&#10;$CONTENT$&#10;{{/role}}" description="User role block" toReformat="false" toShortenFQNames="true">
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="model" value="{{#role &quot;model&quot;}}&#10;$CONTENT$&#10;{{/role}}" description="Model role block" toReformat="false" toShortenFQNames="true">
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <!-- Conditionals -->
+    <template name="if" value="{{#if $CONDITION$}}&#10;$CONTENT$&#10;{{/if}}" description="Handlebars if block" toReformat="false" toShortenFQNames="true">
+        <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="ifelse" value="{{#if $CONDITION$}}&#10;$TRUE_CONTENT$&#10;{{else}}&#10;$FALSE_CONTENT$&#10;{{/if}}" description="Handlebars if-else block" toReformat="false" toShortenFQNames="true">
+        <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="TRUE_CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="FALSE_CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="unless" value="{{#unless $CONDITION$}}&#10;$CONTENT$&#10;{{/unless}}" description="Handlebars unless block" toReformat="false" toShortenFQNames="true">
+        <variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="ifEquals" value="{{#ifEquals $VAR1$ $VAR2$}}&#10;$CONTENT$&#10;{{/ifEquals}}" description="Compare two values for equality" toReformat="false" toShortenFQNames="true">
+        <variable name="VAR1" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="VAR2" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="unlessEquals" value="{{#unlessEquals $VAR1$ $VAR2$}}&#10;$CONTENT$&#10;{{/unlessEquals}}" description="Compare two values for inequality" toReformat="false" toShortenFQNames="true">
+        <variable name="VAR1" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="VAR2" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <!-- Loops -->
+    <template name="each" value="{{#each $ARRAY$}}&#10;$CONTENT$&#10;{{/each}}" description="Handlebars each loop" toReformat="false" toShortenFQNames="true">
+        <variable name="ARRAY" expression="" defaultValue="items" alwaysStopAt="true"/>
+        <variable name="CONTENT" expression="" defaultValue="{{this}}" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="with" value="{{#with $CONTEXT$}}&#10;$CONTENT$&#10;{{/with}}" description="Handlebars with block" toReformat="false" toShortenFQNames="true">
+        <variable name="CONTEXT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <!-- Helpers -->
+    <template name="json" value="{{ json $VAR$ }}" description="JSON serialization helper" toReformat="false" toShortenFQNames="true">
+        <variable name="VAR" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="media" value="{{media url=$URL$}}" description="Embed media content" toReformat="false" toShortenFQNames="true">
+        <variable name="URL" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="history" value="{{history}}" description="Insert conversation history" toReformat="false" toShortenFQNames="true">
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <template name="section" value="{{#section &quot;$NAME$&quot;}}&#10;$CONTENT$&#10;{{/section}}" description="Named section block" toReformat="false" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="CONTENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <!-- Partials -->
+    <template name="partial" value="{{> $PARTIAL_NAME$}}" description="Include a partial template" toReformat="false" toShortenFQNames="true">
+        <variable name="PARTIAL_NAME" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <!-- Comments -->
+    <template name="comment" value="{{! $COMMENT$ }}" description="Handlebars comment" toReformat="false" toShortenFQNames="true">
+        <variable name="COMMENT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <!-- Full template -->
+    <template name="prompt" value="---&#10;model: $MODEL$&#10;config:&#10;  temperature: $TEMPERATURE$&#10;input:&#10;  schema:&#10;    $VARIABLE$: string&#10;---&#10;&#10;{{#role &quot;system&quot;}}&#10;$SYSTEM_PROMPT$&#10;{{/role}}&#10;&#10;{{#role &quot;user&quot;}}&#10;$USER_PROMPT$&#10;{{/role}}" description="Complete prompt template" toReformat="false" toShortenFQNames="true">
+        <variable name="MODEL" expression="" defaultValue="&quot;gemini-2.0-flash&quot;" alwaysStopAt="true"/>
+        <variable name="TEMPERATURE" expression="" defaultValue="&quot;0.7&quot;" alwaysStopAt="true"/>
+        <variable name="VARIABLE" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true"/>
+        <variable name="SYSTEM_PROMPT" expression="" defaultValue="&quot;You are a helpful assistant.&quot;" alwaysStopAt="true"/>
+        <variable name="USER_PROMPT" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+
+    <!-- Frontmatter -->
+    <template name="frontmatter" value="---&#10;model: $MODEL$&#10;config:&#10;  temperature: $TEMPERATURE$&#10;---" description="YAML frontmatter" toReformat="false" toShortenFQNames="true">
+        <variable name="MODEL" expression="" defaultValue="&quot;gemini-2.0-flash&quot;" alwaysStopAt="true"/>
+        <variable name="TEMPERATURE" expression="" defaultValue="&quot;0.7&quot;" alwaysStopAt="true"/>
+        <context>
+            <option name="OTHER" value="true"/>
+        </context>
+    </template>
+</templateSet>

--- a/packages/treesitter/README.md
+++ b/packages/treesitter/README.md
@@ -1,90 +1,165 @@
 # Tree-sitter Grammar for Dotprompt
 
-A [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar for Dotprompt (`.prompt`) files, providing enhanced syntax highlighting for Neovim and other Tree-sitter compatible editors.
+A [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar for Dotprompt (`.prompt`) files.
 
 ## Features
 
-- **YAML Frontmatter**: Parses frontmatter between `---` delimiters
-- **Handlebars Expressions**: Full support for `{{ ... }}` expressions
-- **Block Helpers**: `{{#if}}`, `{{#each}}`, `{{#role}}`, etc.
-- **Dotprompt Markers**: Special `<<<dotprompt:...>>>` syntax
-- **Comments**: Both `{{! ... }}` and `{{!-- ... --}}` styles
+- Parses YAML frontmatter
+- Parses Handlebars template expressions
+- Parses Dotprompt-specific syntax (markers, helpers)
+- Supports license header comments
 
 ## Installation
 
-### For Neovim (nvim-treesitter)
+### Using npm
 
-Add this configuration to register the parser:
-
-```lua
-local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
-
-parser_config.dotprompt = {
-  install_info = {
-    url = "https://github.com/google/dotprompt",
-    location = "packages/treesitter",
-    files = { "src/parser.c" },
-    branch = "main",
-  },
-  filetype = "dotprompt",
-}
-
--- Register the filetype
-vim.filetype.add({
-  extension = {
-    prompt = "dotprompt",
-  },
-})
+```bash
+npm install tree-sitter-dotprompt
 ```
 
-Then install the parser:
-
-```vim
-:TSInstall dotprompt
-```
-
-### Manual Installation
+### Building from Source
 
 ```bash
 cd packages/treesitter
 npm install
 npm run generate
-npm run build
 ```
 
-## Highlight Groups
+## Usage
 
-The grammar provides the following highlight groups:
+### Node.js
 
-| Group | Description |
-|-------|-------------|
-| `@keyword.control` | Block helpers (if, each, role) |
-| `@function.call` | Helper names |
-| `@variable` | Variable references |
-| `@variable.builtin` | Special vars (@index, this) |
-| `@string` | String literals |
-| `@number` | Number literals |
-| `@comment` | Handlebars comments |
-| `@keyword.directive` | Dotprompt markers |
-| `@punctuation.bracket` | `{{` and `}}` |
+```javascript
+const Parser = require('tree-sitter');
+const Dotprompt = require('tree-sitter-dotprompt');
+
+const parser = new Parser();
+parser.setLanguage(Dotprompt);
+
+const source = `---
+model: gemini-2.0-flash
+---
+Hello {{ name }}!`;
+
+const tree = parser.parse(source);
+console.log(tree.rootNode.toString());
+```
+
+### Neovim (nvim-treesitter)
+
+1. Add the parser configuration:
+
+```lua
+local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+parser_config.dotprompt = {
+  install_info = {
+    url = "https://github.com/google/dotprompt",
+    files = { "packages/treesitter/src/parser.c" },
+    branch = "main",
+    subdirectory = "packages/treesitter",
+  },
+  filetype = "dotprompt",
+}
+```
+
+2. Install the parser:
+
+```vim
+:TSInstall dotprompt
+```
+
+3. Copy highlight queries to your Neovim config:
+
+```bash
+mkdir -p ~/.config/nvim/queries/dotprompt
+cp packages/treesitter/queries/highlights.scm ~/.config/nvim/queries/dotprompt/
+```
+
+### Helix
+
+Add to your `languages.toml`:
+
+```toml
+[[language]]
+name = "dotprompt"
+scope = "source.dotprompt"
+file-types = ["prompt"]
+roots = []
+
+[[grammar]]
+name = "dotprompt"
+source = { git = "https://github.com/google/dotprompt", subpath = "packages/treesitter", rev = "main" }
+```
+
+### Zed
+
+Add to your `languages.toml`:
+
+```toml
+[[grammars]]
+name = "dotprompt"
+source = { path = "packages/treesitter" }
+```
 
 ## Development
 
+### Generate Parser
+
 ```bash
-# Generate parser
 npm run generate
+```
 
-# Run tests
+This generates `src/parser.c` from `grammar.js`.
+
+### Test Parser
+
+```bash
 npm run test
+```
 
-# Build native module
+Runs the test corpus in `test/corpus/`.
+
+### Build Native Module
+
+```bash
 npm run build
 ```
 
-## Query Files
+## Grammar Structure
 
-- `queries/highlights.scm` - Syntax highlighting
-- More query files (injections, locals, folds) can be added as needed
+```
+document
+├── license_header?
+│   └── header_comment+
+├── frontmatter?
+│   ├── frontmatter_delimiter (---)
+│   ├── yaml_content
+│   │   └── yaml_line+
+│   └── frontmatter_delimiter (---)
+└── template_body
+    ├── text
+    ├── handlebars_expression ({{ ... }})
+    │   ├── expression_content
+    │   ├── variable_reference
+    │   ├── helper_name
+    │   └── partial_reference
+    ├── handlebars_block ({{#...}} ... {{/...}})
+    │   ├── block_expression
+    │   ├── else_expression
+    │   └── close_block
+    ├── handlebars_comment ({{! ... }})
+    └── dotprompt_marker (<<<dotprompt:...>>>)
+```
+
+## Queries
+
+### Highlights (`queries/highlights.scm`)
+
+Provides syntax highlighting for:
+- YAML frontmatter
+- Handlebars expressions and blocks
+- Dotprompt-specific helpers
+- Comments and markers
 
 ## License
 

--- a/packages/treesitter/test/corpus/basic.txt
+++ b/packages/treesitter/test/corpus/basic.txt
@@ -1,0 +1,183 @@
+================================================================================
+DOCUMENT
+================================================================================
+
+---
+model: gemini-2.0-flash
+---
+Hello world!
+
+--------------------------------------------------------------------------------
+
+(document
+  (frontmatter
+    (frontmatter_delimiter)
+    (yaml_content
+      (yaml_line))
+    (frontmatter_delimiter))
+  (template_body
+    (text)))
+
+================================================================================
+HANDLEBARS EXPRESSION
+================================================================================
+
+Hello {{ name }}!
+
+--------------------------------------------------------------------------------
+
+(document
+  (template_body
+    (text)
+    (handlebars_expression
+      (expression_content
+        (variable_reference)))
+    (text)))
+
+================================================================================
+ROLE BLOCK
+================================================================================
+
+{{#role "system"}}
+You are helpful.
+{{/role}}
+
+--------------------------------------------------------------------------------
+
+(document
+  (template_body
+    (handlebars_block
+      (block_expression
+        (block_name)
+        (argument
+          (string_literal))))
+    (text)
+    (handlebars_block
+      (close_block
+        (block_name)))))
+
+================================================================================
+EACH LOOP
+================================================================================
+
+{{#each items}}
+  - {{ this }}
+{{/each}}
+
+--------------------------------------------------------------------------------
+
+(document
+  (template_body
+    (handlebars_block
+      (block_expression
+        (block_name)
+        (argument
+          (variable_reference))))
+    (text)
+    (handlebars_expression
+      (expression_content
+        (variable_reference)))
+    (text)
+    (handlebars_block
+      (close_block
+        (block_name)))))
+
+================================================================================
+PARTIAL
+================================================================================
+
+{{> header}}
+
+--------------------------------------------------------------------------------
+
+(document
+  (template_body
+    (handlebars_expression
+      (expression_content
+        (partial_reference
+          (identifier))))))
+
+================================================================================
+COMMENT
+================================================================================
+
+{{! This is a comment }}
+
+--------------------------------------------------------------------------------
+
+(document
+  (template_body
+    (handlebars_comment)))
+
+================================================================================
+DOTPROMPT MARKER
+================================================================================
+
+<<<dotprompt:role:system>>>
+
+--------------------------------------------------------------------------------
+
+(document
+  (template_body
+    (dotprompt_marker
+      (marker_content))))
+
+================================================================================
+FRONTMATTER WITH CONFIG
+================================================================================
+
+---
+model: gemini-2.0-flash
+config:
+  temperature: 0.7
+input:
+  schema:
+    name: string
+---
+
+Hello {{ name }}!
+
+--------------------------------------------------------------------------------
+
+(document
+  (frontmatter
+    (frontmatter_delimiter)
+    (yaml_content
+      (yaml_line)
+      (yaml_line)
+      (yaml_line)
+      (yaml_line)
+      (yaml_line)
+      (yaml_line))
+    (frontmatter_delimiter))
+  (template_body
+    (text)
+    (handlebars_expression
+      (expression_content
+        (variable_reference)))
+    (text)))
+
+================================================================================
+LICENSE HEADER
+================================================================================
+
+# Copyright 2026 Google LLC
+# Some license text
+---
+model: gemini-2.0-flash
+---
+Hello
+
+--------------------------------------------------------------------------------
+
+(document
+  (license_header
+    (header_comment)
+    (header_comment))
+  (frontmatter
+    (frontmatter_delimiter)
+    (yaml_content
+      (yaml_line))
+    (frontmatter_delimiter))
+  (template_body
+    (text)))

--- a/packages/vim/README.md
+++ b/packages/vim/README.md
@@ -1,37 +1,60 @@
-# Dotprompt Vim Plugin
+# Dotprompt Vim/Neovim Plugin
 
-Provides syntax highlighting and filetype detection for Dotprompt (`.prompt`) files.
+Provides syntax highlighting, LSP integration, and filetype detection for Dotprompt (`.prompt`) files.
+
+## Features
+
+- **Syntax Highlighting**: YAML frontmatter, Handlebars templates, Dotprompt markers
+- **LSP Integration**: Diagnostics, formatting, hover documentation via `promptly`
+- **Format on Save**: Automatic formatting when saving (configurable)
+- **Keymaps**: Quick access to LSP features
 
 ## Installation
 
-### Vundle
-```vim
-Plugin 'google/dotprompt', {'rtp': 'packages/vim'}
-```
+### Neovim (lazy.nvim) - Recommended
 
-### Plug
-```vim
-Plug 'google/dotprompt', {'rtp': 'packages/vim'
-```
-
-### lazy.nvim (Neovim)
 ```lua
 {
   "google/dotprompt",
   config = function()
-    vim.filetype.add({ extension = { prompt = "dotprompt" } })
+    require("dotprompt").setup({
+      -- Optional: custom path to promptly binary
+      promptly_path = "",
+      -- Enable format on save
+      format_on_save = true,
+    })
   end,
 }
 ```
 
+### Neovim (Packer)
+
+```lua
+use {
+  "google/dotprompt",
+  config = function()
+    require("dotprompt").setup()
+  end,
+}
+```
+
+### Vundle
+
+```vim
+Plugin 'google/dotprompt', {'rtp': 'packages/vim'}
+```
+
+### vim-plug
+
+```vim
+Plug 'google/dotprompt', {'rtp': 'packages/vim'}
+```
+
 ### Manual
-Copy the contents of `syntax/` and `ftdetect/` to your `~/.vim/` directory.
 
-## LSP Support (Neovim)
+Copy the contents of `syntax/`, `ftdetect/`, and `lua/` to your `~/.vim/` or `~/.config/nvim/` directory.
 
-For diagnostics, formatting, and hover documentation, install `promptly` and configure nvim-lspconfig:
-
-### 1. Install promptly
+## Install promptly for LSP Features
 
 ```bash
 cargo install --path rs/promptly
@@ -39,9 +62,26 @@ cargo install --path rs/promptly
 cargo build --release -p promptly
 ```
 
-### 2. Configure nvim-lspconfig
+## Configuration
 
-Add to your Neovim configuration:
+### Using the Lua Module (Recommended)
+
+The Lua module handles everything automatically:
+
+```lua
+require("dotprompt").setup({
+  -- Path to promptly binary (empty = auto-detect)
+  promptly_path = "",
+  -- Enable format on save
+  format_on_save = true,
+  -- Enable diagnostics
+  diagnostics = true,
+})
+```
+
+### Manual LSP Configuration
+
+If you prefer manual setup with nvim-lspconfig:
 
 ```lua
 local lspconfig = require("lspconfig")
@@ -69,7 +109,7 @@ lspconfig.promptly.setup({
 })
 ```
 
-## LSP Support (Vim with vim-lsp)
+### Vim 8+ with vim-lsp
 
 For Vim 8+ with [vim-lsp](https://github.com/prabirshrestha/vim-lsp):
 
@@ -83,9 +123,73 @@ if executable('promptly')
 endif
 ```
 
-## Features
+## Tree-sitter Support
+
+For enhanced syntax highlighting with Tree-sitter:
+
+### 1. Add the parser to nvim-treesitter
+
+```lua
+local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+parser_config.dotprompt = {
+  install_info = {
+    url = "https://github.com/google/dotprompt",
+    files = { "packages/treesitter/src/parser.c" },
+    branch = "main",
+    subdirectory = "packages/treesitter",
+  },
+  filetype = "dotprompt",
+}
+```
+
+### 2. Install the parser
+
+```vim
+:TSInstall dotprompt
+```
+
+### 3. Enable highlighting
+
+```lua
+require("nvim-treesitter.configs").setup({
+  highlight = {
+    enable = true,
+    additional_vim_regex_highlighting = false,
+  },
+})
+```
+
+## Keymaps
+
+When using the Lua module, these keymaps are set automatically:
+
+| Keymap | Action |
+|--------|--------|
+| `<leader>f` | Format document |
+| `K` | Show hover documentation |
+| `gd` | Go to definition |
+| `gr` | Find references |
+| `<leader>rn` | Rename symbol |
+| `<leader>ca` | Code action |
+
+## LSP Features
 
 With LSP enabled, you get:
-- **Diagnostics**: Real-time error detection for YAML and Handlebars syntax
-- **Formatting**: Format buffer with `promptly fmt` rules
-- **Hover**: Documentation for Handlebars helpers and frontmatter fields
+
+| Feature | Description |
+|---------|-------------|
+| **Diagnostics** | Real-time error detection for YAML and Handlebars syntax |
+| **Formatting** | Format buffer with promptly fmt rules |
+| **Hover** | Documentation for Handlebars helpers and frontmatter fields |
+| **Go to Definition** | Jump to partial files |
+| **References** | Find all uses of partials |
+
+## Commands
+
+```lua
+-- Format current document
+require("dotprompt").format()
+
+-- Restart LSP server
+require("dotprompt").restart()
+```

--- a/packages/vim/lua/dotprompt/init.lua
+++ b/packages/vim/lua/dotprompt/init.lua
@@ -1,0 +1,147 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+--- Dotprompt Neovim module for LSP setup
+--- @module dotprompt
+local M = {}
+
+--- Default configuration
+M.config = {
+  --- Path to promptly binary (empty = auto-detect)
+  promptly_path = "",
+  --- Enable format on save
+  format_on_save = true,
+  --- Enable LSP diagnostics
+  diagnostics = true,
+}
+
+--- Find promptly executable in common locations
+--- @return string|nil path to promptly or nil if not found
+local function find_promptly()
+  -- Check user config first
+  if M.config.promptly_path ~= "" then
+    if vim.fn.executable(M.config.promptly_path) == 1 then
+      return M.config.promptly_path
+    end
+  end
+
+  -- Check PATH
+  if vim.fn.executable("promptly") == 1 then
+    return "promptly"
+  end
+
+  -- Check cargo bin
+  local home = vim.env.HOME or vim.env.USERPROFILE
+  if home then
+    local cargo_path = home .. "/.cargo/bin/promptly"
+    if vim.fn.executable(cargo_path) == 1 then
+      return cargo_path
+    end
+  end
+
+  return nil
+end
+
+--- Setup LSP for Dotprompt files
+--- @param opts table|nil Optional configuration overrides
+function M.setup(opts)
+  -- Merge user options
+  M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+
+  -- Register filetype
+  vim.filetype.add({
+    extension = {
+      prompt = "dotprompt",
+    },
+  })
+
+  -- Find promptly
+  local promptly_path = find_promptly()
+  if not promptly_path then
+    vim.notify(
+      "Dotprompt: promptly not found. Install with: cargo install --path rs/promptly",
+      vim.log.levels.WARN
+    )
+    return
+  end
+
+  -- Setup LSP using nvim-lspconfig if available
+  local ok, lspconfig = pcall(require, "lspconfig")
+  if not ok then
+    vim.notify(
+      "Dotprompt: nvim-lspconfig not found. Install it for LSP features.",
+      vim.log.levels.WARN
+    )
+    return
+  end
+
+  local configs = require("lspconfig.configs")
+
+  -- Register promptly as an LSP server
+  if not configs.promptly then
+    configs.promptly = {
+      default_config = {
+        cmd = { promptly_path, "lsp" },
+        filetypes = { "dotprompt" },
+        root_dir = lspconfig.util.find_git_ancestor,
+        single_file_support = true,
+        settings = {},
+      },
+    }
+  end
+
+  -- Start the server with user callbacks
+  lspconfig.promptly.setup({
+    on_attach = function(client, bufnr)
+      -- Enable format on save if configured
+      if M.config.format_on_save then
+        vim.api.nvim_create_autocmd("BufWritePre", {
+          buffer = bufnr,
+          callback = function()
+            vim.lsp.buf.format({ async = false })
+          end,
+        })
+      end
+
+      -- Set up keymaps
+      local bufopts = { noremap = true, silent = true, buffer = bufnr }
+      vim.keymap.set("n", "<leader>f", function()
+        vim.lsp.buf.format({ async = true })
+      end, bufopts)
+      vim.keymap.set("n", "K", vim.lsp.buf.hover, bufopts)
+      vim.keymap.set("n", "gd", vim.lsp.buf.definition, bufopts)
+      vim.keymap.set("n", "gr", vim.lsp.buf.references, bufopts)
+      vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, bufopts)
+      vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, bufopts)
+    end,
+
+    capabilities = vim.lsp.protocol.make_client_capabilities(),
+  })
+
+  vim.notify("Dotprompt: LSP configured with " .. promptly_path, vim.log.levels.INFO)
+end
+
+--- Manually trigger document formatting
+function M.format()
+  vim.lsp.buf.format({ async = true })
+end
+
+--- Restart the LSP server
+function M.restart()
+  vim.cmd("LspRestart promptly")
+end
+
+return M

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the Dotprompt VS Code extension will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-01-24
+
+### Added
+- **Status Bar Indicator**: Shows LSP connection status (connected, starting, error)
+- **Format on Save**: Automatically format `.prompt` files when saving (configurable)
+- **Commands**:
+  - `Dotprompt: Format Document` - Format the current file
+  - `Dotprompt: Restart Language Server` - Restart the LSP connection
+  - `Dotprompt: Show Output` - View LSP logs
+- **Improved Error Handling**: Better messages when promptly is not found with actions
+
+### Changed
+- Status bar now shows real-time LSP state
+- Error messages offer actionable options (Open Settings, Retry, Show Output)
+
+### Configuration
+- `dotprompt.formatOnSave`: Enable/disable format on save (default: true)
+- `dotprompt.trace.server`: Configure LSP message tracing
+
 ## [0.1.0] - 2026-01-24
 
 ### Added

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "dotprompt-vscode",
   "displayName": "Dotprompt",
   "description": "Syntax highlighting, LSP diagnostics, formatting, and code snippets for Dotprompt (.prompt) files",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "google",
   "license": "Apache-2.0",
   "icon": "images/icon.png",
@@ -85,6 +85,23 @@
         "path": "./snippets/dotprompt.snippets.json"
       }
     ],
+    "commands": [
+      {
+        "command": "dotprompt.formatDocument",
+        "title": "Format Document",
+        "category": "Dotprompt"
+      },
+      {
+        "command": "dotprompt.restartLsp",
+        "title": "Restart Language Server",
+        "category": "Dotprompt"
+      },
+      {
+        "command": "dotprompt.showOutput",
+        "title": "Show Output",
+        "category": "Dotprompt"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Dotprompt",
@@ -98,6 +115,21 @@
           "type": "boolean",
           "default": true,
           "description": "Enable LSP features (diagnostics, formatting, hover). Requires promptly to be installed."
+        },
+        "dotprompt.formatOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically format .prompt files on save."
+        },
+        "dotprompt.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the language server."
         }
       }
     }


### PR DESCRIPTION
VS Code Extension (v0.2.0):
- Add status bar indicator showing LSP connection state
- Add format on save configuration (dotprompt.formatOnSave)
- Add commands: Format Document, Restart LSP, Show Output
- Improve error handling with actionable dialogs

JetBrains Plugin (v0.2.0):
- Add 18 live templates (role, system, user, if, each, json, etc.)
- Add settings UI at Settings → Languages & Frameworks → Dotprompt
- Add DotpromptSettings for persistent configuration
- Update PromptlyServerFactory to use configured promptly path

Neovim/Vim:
- Add lua/dotprompt/init.lua module for easy LSP setup
- Add format on save and default keymaps (<leader>f, K, gd, gr)
- Add Tree-sitter integration docs to README

Emacs (v0.3.0):
- Add dotprompt-format-buffer command (C-c C-f)
- Add dotprompt-format-on-save option
- Add Doom Emacs, Spacemacs, straight.el config examples

Tree-sitter Grammar:
- Add test corpus with 8 test cases
- Add integration examples for nvim-treesitter, Helix, Zed
