### PR TITLE
fix(vscode): bundle vscode-languageclient and improve extension installation

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -430,7 +430,7 @@
         "bzlTransitiveDigest": "vNLGL9GTi8PaP46e/11lxRuFDmmGkBjize7/iPfRypI=",
         "usagesDigest": "DERK4k9FbVzQIB4bXDGJ1nM+IQ2xMRKyoKFkkDE1cIk=",
         "recordedFileInputs": {
-          "@@//package.json": "7e1a5834d3f7355d90deb8d693833f2d6109385dc603b18f96d9657339cbd23c"
+          "@@//package.json": "306f2484ca1c40120233bf514d60fb586f457facb4e84cc7bbb1d3a1acdf6e81"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -37,12 +37,15 @@
   ],
   "main": "./dist/extension.js",
   "activationEvents": [
-    "onLanguage:dotprompt"
+    "onLanguage:dotprompt",
+    "onCommand:dotprompt.restartLsp",
+    "onCommand:dotprompt.formatDocument",
+    "onCommand:dotprompt.showOutput"
   ],
   "scripts": {
     "vscode:prepublish": "pnpm run build",
-    "build": "tsup src/extension.ts --format cjs --external vscode --sourcemap",
-    "watch": "tsup src/extension.ts --format cjs --external vscode --sourcemap --watch",
+    "build": "tsup",
+    "watch": "tsup --watch",
     "package": "vsce package --no-dependencies"
   },
   "dependencies": {

--- a/packages/vscode/tsup.config.ts
+++ b/packages/vscode/tsup.config.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/extension.ts'],
+  format: ['cjs'],
+  external: ['vscode'],
+  // Don't externalize vscode-languageclient - it must be bundled
+  noExternal: ['vscode-languageclient'],
+  sourcemap: true,
+  clean: true,
+});

--- a/scripts/install_emacs_mode
+++ b/scripts/install_emacs_mode
@@ -68,6 +68,21 @@ if [ "$BUILD_LSP" = true ]; then
     PROMPTLY_BIN="$REPO_ROOT/target/release/promptly"
     if [ -f "$PROMPTLY_BIN" ]; then
       echo "  ✓ promptly built successfully"
+      
+      # Install to ~/.local/bin for PATH discovery
+      LOCAL_BIN="$HOME/.local/bin"
+      mkdir -p "$LOCAL_BIN"
+      cp "$PROMPTLY_BIN" "$LOCAL_BIN/promptly"
+      chmod +x "$LOCAL_BIN/promptly"
+      echo "  ✓ Installed promptly to $LOCAL_BIN/promptly"
+      
+      # Check if ~/.local/bin is in PATH
+      if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
+        echo ""
+        echo "  ⚠ $LOCAL_BIN is not in your PATH."
+        echo "    Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+      fi
     fi
   else
     echo "  ⚠ cargo not found. Skipping LSP build."
@@ -109,8 +124,11 @@ echo "For LSP support with eglot (Emacs 29+), also add:"
 echo ""
 echo "  (add-hook 'dotprompt-mode-hook 'eglot-ensure)"
 echo ""
-if [ "$BUILD_LSP" = true ] && [ -f "$REPO_ROOT/target/release/promptly" ]; then
-  echo "If promptly is not in your PATH, add:"
+if [ "$BUILD_LSP" = true ] && [ -f "$HOME/.local/bin/promptly" ]; then
+  echo "promptly is installed at ~/.local/bin/promptly"
+  echo "If ~/.local/bin is in your PATH, LSP will work automatically."
   echo ""
-  echo "  (setq dotprompt-promptly-path \"$REPO_ROOT/target/release/promptly\")"
+  echo "Otherwise, add to your Emacs config:"
+  echo ""
+  echo "  (setq dotprompt-promptly-path \"$HOME/.local/bin/promptly\")"
 fi

--- a/scripts/install_jetbrains_plugin
+++ b/scripts/install_jetbrains_plugin
@@ -69,6 +69,21 @@ if [ "$BUILD_LSP" = true ]; then
     PROMPTLY_BIN="$REPO_ROOT/target/release/promptly"
     if [ -f "$PROMPTLY_BIN" ]; then
       echo "  ✓ promptly built successfully"
+      
+      # Install to ~/.local/bin for PATH discovery
+      LOCAL_BIN="$HOME/.local/bin"
+      mkdir -p "$LOCAL_BIN"
+      cp "$PROMPTLY_BIN" "$LOCAL_BIN/promptly"
+      chmod +x "$LOCAL_BIN/promptly"
+      echo "  ✓ Installed promptly to $LOCAL_BIN/promptly"
+      
+      # Check if ~/.local/bin is in PATH
+      if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
+        echo ""
+        echo "  ⚠ $LOCAL_BIN is not in your PATH."
+        echo "    Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+      fi
     fi
   else
     echo "  ⚠ cargo not found. Skipping LSP build."

--- a/scripts/install_vim_plugin
+++ b/scripts/install_vim_plugin
@@ -79,6 +79,22 @@ if [ "$BUILD_LSP" = true ]; then
     PROMPTLY_BIN="$REPO_ROOT/target/release/promptly"
     if [ -f "$PROMPTLY_BIN" ]; then
       echo "  ✓ promptly built successfully"
+      
+      # Install to ~/.local/bin for PATH discovery
+      LOCAL_BIN="$HOME/.local/bin"
+      mkdir -p "$LOCAL_BIN"
+      cp "$PROMPTLY_BIN" "$LOCAL_BIN/promptly"
+      chmod +x "$LOCAL_BIN/promptly"
+      echo "  ✓ Installed promptly to $LOCAL_BIN/promptly"
+      PROMPTLY_BIN="$LOCAL_BIN/promptly"
+      
+      # Check if ~/.local/bin is in PATH
+      if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
+        echo ""
+        echo "  ⚠ $LOCAL_BIN is not in your PATH."
+        echo "    Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+      fi
     fi
   else
     echo "  ⚠ cargo not found. Skipping LSP build."

--- a/scripts/install_vscode_ext
+++ b/scripts/install_vscode_ext
@@ -40,9 +40,21 @@ if [ -d "${PROMPTLY_DIR}" ]; then
     PROMPTLY_BIN="${ROOT_DIR}/target/release/promptly"
     if [ -f "${PROMPTLY_BIN}" ]; then
       echo "  ✓ promptly built successfully: ${PROMPTLY_BIN}"
-      echo ""
-      echo "  TIP: Add to PATH or configure in VS Code settings:"
-      echo "       \"dotprompt.promptlyPath\": \"${PROMPTLY_BIN}\""
+      
+      # Install to ~/.local/bin for PATH discovery
+      LOCAL_BIN="${HOME}/.local/bin"
+      mkdir -p "${LOCAL_BIN}"
+      cp "${PROMPTLY_BIN}" "${LOCAL_BIN}/promptly"
+      chmod +x "${LOCAL_BIN}/promptly"
+      echo "  ✓ Installed promptly to ${LOCAL_BIN}/promptly"
+      
+      # Check if ~/.local/bin is in PATH
+      if [[ ":$PATH:" != *":${LOCAL_BIN}:"* ]]; then
+        echo ""
+        echo "  ⚠ ${LOCAL_BIN} is not in your PATH."
+        echo "    Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+      fi
     fi
   else
     echo "  ⚠ cargo not found. Skipping promptly build."
@@ -77,15 +89,22 @@ if [ -z "${VSIX_FILE}" ]; then
   exit 1
 fi
 
+# Uninstall existing extension if present
+echo "  Uninstalling existing extension (if any)..."
+code --uninstall-extension google.dotprompt-vscode 2>/dev/null || true
+
 # Install the extension
 echo "  Installing ${VSIX_FILE}..."
 code --install-extension "${VSIX_FILE}" --force
 
-# Configure VS Code settings if promptly was built
-PROMPTLY_BIN="${ROOT_DIR}/target/release/promptly"
+# Configure VS Code settings if promptly was built (optional if ~/.local/bin is in PATH)
+LOCAL_BIN="${HOME}/.local/bin"
+PROMPTLY_BIN="${LOCAL_BIN}/promptly"
 if [ -f "${PROMPTLY_BIN}" ]; then
   echo ""
-  echo "Step 3: Configuring VS Code settings..."
+  echo "Step 3: Configuring VS Code settings (optional)..."
+  echo "  Note: If ~/.local/bin is in your PATH, VS Code will find promptly automatically."
+  echo "  The setting below is only needed if you want to use a custom path."
   
   # Determine the VS Code settings directory
   if [ -d "${HOME}/Library/Application Support/Code/User" ]; then
@@ -141,7 +160,7 @@ echo "Next steps:"
 echo "  1. Reload VS Code (Cmd+Shift+P > 'Developer: Reload Window')"
 echo "  2. Open a .prompt file from examples/ to test the extension"
 echo ""
-if [ -f "${ROOT_DIR}/target/release/promptly" ]; then
+if [ -f "${HOME}/.local/bin/promptly" ]; then
   echo "LSP features enabled! You should see:"
   echo "  - Real-time diagnostics for YAML and Handlebars errors"
   echo "  - Document formatting (Shift+Alt+F)"
@@ -152,5 +171,5 @@ if [ -f "${ROOT_DIR}/target/release/promptly" ]; then
   echo "  - examples/valid-greeting.prompt (should be clean)"
 else
   echo "Note: LSP features are disabled (promptly not built)."
-  echo "Run 'cargo build --release -p promptly' to enable them."
+  echo "Re-run this script with cargo installed to enable them."
 fi


### PR DESCRIPTION
- Add tsup.config.ts to properly bundle vscode-languageclient dependency
  (fixes "Cannot find module 'vscode-languageclient/node'" activation error)
- Install promptly binary to ~/.local/bin for automatic PATH discovery
- Add ~/.local/bin to extension's promptly search paths
- Add onCommand activation events so commands work before opening .prompt files
- Uninstall existing extension before reinstalling to ensure clean updates
- Add detailed logging for command registration debugging

The extension bundle size increased from ~13KB to ~788KB due to including
the language client library, but this is necessary for LSP functionality.

<img width="1060" height="889" alt="Screenshot 2026-01-25 at 3 16 42 AM" src="https://github.com/user-attachments/assets/6fbdbdca-7d20-4293-a498-a49edcb59f58" />
