### PR TITLE
feat: integrate pyrefly type checker and improve CI workflows

### DIFF
--- a/.github/workflows/engdoc.yml
+++ b/.github/workflows/engdoc.yml
@@ -18,12 +18,28 @@ name: Eng Documentation Checks
 
 on:
   pull_request:
-    paths:
-      - "docs/**"
-      - ".github/workflows/engdoc.yml"
+    branches: [ main ]
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            docs/**
+            .github/workflows/engdoc.yml
+
   engdoc-checks:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     env:
       PATH: ${{ github.workspace }}/go/bin:${{ github.workspace }}/.cargo/bin:${{ github.workspace }}/.local/share/pnpm:${{ github.workspace }}/.local/bin:/usr/local/bin:/usr/bin:/bin
@@ -80,3 +96,17 @@ jobs:
 
       - name: Build documentation
         run: uv run mkdocs build
+
+  engdoc-checks-all:
+    if: always()
+    needs: [engdoc-checks]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.engdoc-checks.result }}" == "failure" ]]; then
+            echo "Eng documentation checks failed"
+            exit 1
+          fi
+          echo "Eng documentation checks passed or were skipped"
+          exit 0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,13 +18,29 @@ name: Go checks
 
 on:
   pull_request:
-    paths:
-      - "go/**"
-      - "spec/**"
-      - ".github/workflows/go.yml"
+    branches: [ main ]
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            go/**
+            spec/**
+            .github/workflows/go.yml
+
   format-check:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     name: Go Format Check
     steps:
@@ -38,8 +54,6 @@ jobs:
 
       - name: Check formatting with gofmt
         run: |
-          # gofmt -d returns diff output if files need formatting
-          # Use find to get all .go files excluding vendor
           UNFORMATTED=$(gofmt -l go/)
           if [ -n "${UNFORMATTED}" ]; then
             echo "❌ The following Go files need formatting:"
@@ -52,10 +66,10 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    needs: format-check
+    needs: [check-paths, format-check]
+    if: needs.check-paths.outputs.any_changed == 'true'
     strategy:
       matrix:
-        # Track only the latest 2 stable versions of Go.
         go-version: ["1.24.x", "1.25.x"]
       fail-fast: false
 
@@ -80,3 +94,17 @@ jobs:
 
       - name: Run vulncheck
         run: govulncheck -C go ./...
+
+  go-checks-all:
+    if: always()
+    needs: [format-check, tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.format-check.result }}" == "failure" || "${{ needs.tests.result }}" == "failure" ]]; then
+            echo "Go checks failed"
+            exit 1
+          fi
+          echo "Go checks passed or were skipped"
+          exit 0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,17 +21,31 @@ on:
       - main
       - master
   pull_request:
-    paths:
-      - "go/**"
-      - ".github/workflows/golangci-lint.yml"
+    branches: [ main ]
 
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            go/**
+            .github/workflows/golangci-lint.yml
+
   golangci:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -44,3 +58,17 @@ jobs:
         with:
           version: v1.64
           working-directory: go
+
+  golangci-lint-all:
+    if: always()
+    needs: [golangci]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.golangci.result }}" == "failure" ]]; then
+            echo "GolangCI Lint failed"
+            exit 1
+          fi
+          echo "GolangCI Lint passed or was skipped"
+          exit 0

--- a/.github/workflows/ide_plugins.yml
+++ b/.github/workflows/ide_plugins.yml
@@ -19,24 +19,36 @@ name: IDE Plugins
 on:
   push:
     branches: [main]
-    paths:
-      - 'packages/jetbrains/**'
-      - 'packages/vim/**'
-      - 'packages/emacs/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'packages/jetbrains/**'
-      - 'packages/vim/**'
-      - 'packages/emacs/**'
   workflow_dispatch:
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            packages/jetbrains/**
+            packages/vim/**
+            packages/emacs/**
+            .github/workflows/ide_plugins.yml
+
   jetbrains:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: JetBrains Plugin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -68,20 +80,23 @@ jobs:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
 
   vim:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: Vim/Neovim
     runs-on: ubuntu-latest
     steps:
-      # Simple check for syntax validity
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Check Lua formatting
         run: ./scripts/format_lua_files --check
 
   emacs:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: Emacs Mode
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Setup Emacs
         uses: purcell/setup-emacs@master
@@ -91,3 +106,17 @@ jobs:
       - name: Byte compile
         working-directory: packages/emacs
         run: emacs -Q -batch -L . -f batch-byte-compile dotprompt-mode.el
+
+  ide-plugins-all:
+    if: always()
+    needs: [jetbrains, vim, emacs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.jetbrains.result }}" == "failure" || "${{ needs.vim.result }}" == "failure" || "${{ needs.emacs.result }}" == "failure" ]]; then
+            echo "IDE plugins checks failed"
+            exit 1
+          fi
+          echo "IDE plugins checks passed or were skipped"
+          exit 0

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -20,18 +20,30 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "java/**"
-      - "spec/**"
-      - ".github/workflows/java.yml"
   pull_request:
-    paths:
-      - "java/**"
-      - "spec/**"
-      - ".github/workflows/java.yml"
+    branches: [ main ]
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            java/**
+            spec/**
+            .github/workflows/java.yml
+
   format-check:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     name: Java Format Check
     steps:
@@ -51,12 +63,9 @@ jobs:
 
       - name: Check Java formatting
         run: |
-          # Find all Java files (excluding build directories)
           JAVA_FILES=$(find java -name "*.java" -type f)
           if [ -n "${JAVA_FILES}" ]; then
             echo "Checking formatting for Java files..."
-            # --dry-run will exit with non-zero if files need formatting
-            # --set-exit-if-changed makes it return 1 if any files would be changed
             java -jar .cache/google-java-format.jar --dry-run --set-exit-if-changed ${JAVA_FILES}
             echo "✅ All Java files are properly formatted."
           else
@@ -65,7 +74,8 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    needs: format-check
+    needs: [check-paths, format-check]
+    if: needs.check-paths.outputs.any_changed == 'true'
     strategy:
       matrix:
         java-version: ['17', '21', '23', '24']
@@ -85,10 +95,23 @@ jobs:
         uses: bazelbuild/setup-bazelisk@v3
 
       - name: Run Tests
-        # Force Bazel to use the local JDK setup by actions/setup-java
         run: |
           bazel test \
             --java_runtime_version=local_jdk \
             --tool_java_runtime_version=local_jdk \
             --test_output=errors \
             //java/com/google/dotprompt/...
+
+  java-checks-all:
+    if: always()
+    needs: [format-check, tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.format-check.result }}" == "failure" || "${{ needs.tests.result }}" == "failure" ]]; then
+            echo "Java checks failed"
+            exit 1
+          fi
+          echo "Java checks passed or were skipped"
+          exit 0

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -18,13 +18,29 @@ name: "JS checks"
 
 on:
   pull_request:
-    paths:
-      - "js/**"
-      - "spec/**"
-      - ".github/workflows/js.yml"
+    branches: [ main ]
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            js/**
+            spec/**
+            .github/workflows/js.yml
+
   format-check:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     name: JS/TS Format Check
     steps:
@@ -49,7 +65,8 @@ jobs:
   test:
     name: Run tests (Node ${{ matrix.node-version }}, ${{ matrix.typescript-compiler }})
     runs-on: ubuntu-latest
-    needs: format-check
+    needs: [check-paths, format-check]
+    if: needs.check-paths.outputs.any_changed == 'true'
     strategy:
       matrix:
         node-version: ["20", "21", "22", "23", "24"]
@@ -81,3 +98,16 @@ jobs:
         if: matrix.typescript-compiler == 'tsgo'
         run: pnpm -C js build:native
 
+  js-checks-all:
+    if: always()
+    needs: [format-check, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.format-check.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
+            echo "JS checks failed"
+            exit 1
+          fi
+          echo "JS checks passed or were skipped"
+          exit 0

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,12 +18,29 @@ name: Python checks
 
 on:
   pull_request:
-    paths:
-      - "python/**"
-      - "spec/**"
-      - ".github/workflows/python.yml"
+    branches: [main]
+
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            python/**
+            spec/**
+            .github/workflows/python.yml
+
   uv-lock-check:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -47,6 +64,8 @@ jobs:
         run: scripts/run_python_security_checks
 
   python-checks:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     env:
       PATH: ${{ github.workspace }}/go/bin:${{ github.workspace }}/.cargo/bin:${{ github.workspace }}/.local/share/pnpm:${{ github.workspace }}/.local/bin:/usr/local/bin:/usr/bin:/bin
@@ -96,8 +115,11 @@ jobs:
       - name: Lint with ruff
         run: uv run --active --directory python ruff check --select I .
 
-      - name: Static type check
+      - name: Static type check (ty)
         run: uv run --active --directory python ty check
+
+      - name: Static type check (pyrefly)
+        run: uv run --active --directory python pyrefly check
 
       # TODO: Move this to a rust workflow once we have one.
       - name: Run rust lint
@@ -121,3 +143,17 @@ jobs:
 
       - name: Build distributions
         run: ./scripts/build_dists
+
+  python-checks-all:
+    if: always()
+    needs: [uv-lock-check, python-checks]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.uv-lock-check.result }}" == "failure" || "${{ needs.python-checks.result }}" == "failure" ]]; then
+            echo "Python checks failed"
+            exit 1
+          fi
+          echo "Python checks passed or were skipped"
+          exit 0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,14 +18,30 @@ name: "Rust checks"
 
 on:
   pull_request:
-    paths:
-      - "rs/**" # TODO: Add python/handlebarrz after fixing linker errors.
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/rust.yml"
+    branches: [ main ]
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            rs/**
+            Cargo.toml
+            Cargo.lock
+            .github/workflows/rust.yml
+
   format-check:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: Format Check
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +57,8 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy-lint:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: Clippy Linting
     runs-on: ubuntu-latest
     steps:
@@ -56,13 +74,14 @@ jobs:
         run: cargo clippy --all-targets --workspace -- -D warnings
 
   check-build-test:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: Check, Build & Test (${{ matrix.toolchain }}, ${{ matrix.os_config.os }}-${{ matrix.os_config.arch }})
     runs-on: ${{ matrix.os_config.os }}
     env:
-      # Fix for PyO3 forward compatibility with newer Python versions (e.g., 3.14 on macOS runner)
       PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
     strategy:
-      fail-fast: false # Keep running other jobs even if one fails
+      fail-fast: false
       matrix:
         os_config:
           - { os: ubuntu-latest, arch: x64 }
@@ -87,19 +106,16 @@ jobs:
 
       - name: Check code
         run: cargo check --all-targets --workspace
-        # Allow nightly check to fail without failing the entire workflow
         continue-on-error: ${{ matrix.toolchain == 'nightly' }}
 
       - name: Build code
         run: cargo build --all-targets --workspace
-        # Allow nightly build to fail
         continue-on-error: ${{ matrix.toolchain == 'nightly' }}
 
       - name: Run tests
         env:
           RUST_BACKTRACE: 1
         run: cargo test --all-targets --workspace
-        # Allow nightly tests to fail
         continue-on-error: ${{ matrix.toolchain == 'nightly' }}
 
       - name: Verify SPEC_FILE support
@@ -113,71 +129,16 @@ jobs:
           done
         continue-on-error: ${{ matrix.toolchain == 'nightly' }}
 
-  #check-build-test-musl-matrix:
-  #  name: Check, Build & Test (${{ matrix.toolchain }}, alpine-${{ matrix.arch }}-musl)
-  #  runs-on: ubuntu-latest # Runner OS
-  #  container: # Run steps inside this container
-  #    image: rust:alpine # Use official Rust image based on Alpine (multi-arch)
-  #  strategy:
-  #    fail-fast: false
-  #    matrix:
-  #      include:
-  #        - arch: x86_64
-  #          target: x86_64-unknown-linux-musl
-  #        - arch: aarch64
-  #          target: aarch64-unknown-linux-musl
-  #      toolchain: [stable, nightly]
-  #  steps:
-  #    - name: Checkout code
-  #      uses: actions/checkout@v6
-
-  #    - name: Install musl build dependencies
-  #      run: |
-  #        # Install native gcc, bash, docker-cli
-  #        apk add --no-cache musl-dev gcc bash docker-cli
-
-  #    - name: Set up QEMU
-  #      uses: docker/setup-qemu-action@v3
-
-  #    - name: Install Rust toolchain (${{ matrix.toolchain }}) via rustup
-  #      shell: bash
-  #      run: |
-  #        echo "Installing toolchain: ${{ matrix.toolchain }} and target: ${{ matrix.target }}"
-  #        rustup toolchain install ${{ matrix.toolchain }} --profile minimal --target ${{ matrix.target }}
-  #        rustup default ${{ matrix.toolchain }}
-
-  #        echo "Rust toolchain info:"
-  #        rustc --version --verbose
-  #        cargo --version --verbose
-
-  #    - name: Cache Cargo registry and index (musl)
-  #      uses: actions/cache@v5
-  #      with:
-  #        path: |
-  #          /usr/local/cargo/registry/index/
-  #          /usr/local/cargo/registry/cache/
-  #          /usr/local/cargo/git/db/
-  #          target/
-  #        # Include architecture and toolchain in cache key
-  #        key: linux-musl-${{ matrix.arch }}-cargo-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-
-  #    - name: Check code (musl, ${{ matrix.arch }}, ${{ matrix.toolchain }})
-  #      shell: bash
-  #      run: cargo check --all-targets --workspace --target ${{ matrix.target }}
-  #      # Allow nightly check to fail
-  #      continue-on-error: ${{ matrix.toolchain == 'nightly' }}
-
-  #    - name: Build code (musl, ${{ matrix.arch }}, ${{ matrix.toolchain }})
-  #      shell: bash
-  #      run: cargo build --all-targets --workspace --target ${{ matrix.target }}
-  #      # Allow nightly build to fail
-  #      continue-on-error: ${{ matrix.toolchain == 'nightly' }}
-
-  #    - name: Run tests (musl, ${{ matrix.arch }}, ${{ matrix.toolchain }})
-  #      shell: bash
-  #      env:
-  #        RUST_BACKTRACE: 1 # Keep the backtrace env var
-  #      run: cargo test --all-targets --workspace --target ${{ matrix.target }}
-  #      # Allow nightly tests to fail
-  #      continue-on-error: ${{ matrix.toolchain == 'nightly' }}
-
+  rust-checks-all:
+    if: always()
+    needs: [format-check, clippy-lint, check-build-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.format-check.result }}" == "failure" || "${{ needs.clippy-lint.result }}" == "failure" || "${{ needs.check-build-test.result }}" == "failure" ]]; then
+            echo "Rust checks failed"
+            exit 1
+          fi
+          echo "Rust checks passed or were skipped"
+          exit 0

--- a/.github/workflows/treesitter.yml
+++ b/.github/workflows/treesitter.yml
@@ -19,16 +19,30 @@ name: Tree-sitter
 on:
   push:
     branches: [main]
-    paths:
-      - 'packages/treesitter/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'packages/treesitter/**'
   workflow_dispatch:
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            packages/treesitter/**
+            .github/workflows/treesitter.yml
+
   test:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: Test and Build
     runs-on: ubuntu-latest
     steps:
@@ -53,8 +67,8 @@ jobs:
         
   publish:
     name: Publish to NPM
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.modified, 'packages/treesitter/package.json')
+    needs: [check-paths, test]
+    if: needs.check-paths.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.modified, 'packages/treesitter/package.json')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -76,3 +90,17 @@ jobs:
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  treesitter-checks-all:
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            echo "Tree-sitter checks failed"
+            exit 1
+          fi
+          echo "Tree-sitter checks passed or were skipped"
+          exit 0

--- a/.github/workflows/vscode_extension.yml
+++ b/.github/workflows/vscode_extension.yml
@@ -18,19 +18,30 @@ name: "VS Code Extension"
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "packages/vscode/**"
-      - ".github/workflows/vscode_extension.yml"
+    branches: [ main ]
   pull_request:
-    paths:
-      - "packages/vscode/**"
-      - ".github/workflows/vscode_extension.yml"
-
+    branches: [ main ]
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            packages/vscode/**
+            .github/workflows/vscode_extension.yml
+
   build:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: Build and Package
     runs-on: ubuntu-latest
     steps:
@@ -61,4 +72,16 @@ jobs:
           name: dotprompt-vscode
           path: packages/vscode/*.vsix
 
-
+  vscode-extension-all:
+    if: always()
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.build.result }}" == "failure" ]]; then
+            echo "VS Code extension checks failed"
+            exit 1
+          fi
+          echo "VS Code extension checks passed or were skipped"
+          exit 0

--- a/.github/workflows/web_editors.yml
+++ b/.github/workflows/web_editors.yml
@@ -19,18 +19,31 @@ name: Web Editor Packages
 on:
   push:
     branches: [main]
-    paths:
-      - 'packages/monaco/**'
-      - 'packages/codemirror/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'packages/monaco/**'
-      - 'packages/codemirror/**'
   workflow_dispatch:
 
 jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            packages/monaco/**
+            packages/codemirror/**
+            .github/workflows/web_editors.yml
+
   test:
+    needs: check-paths
+    if: needs.check-paths.outputs.any_changed == 'true'
     name: Test and Build
     runs-on: ubuntu-latest
     strategy:
@@ -63,8 +76,8 @@ jobs:
         
   publish:
     name: Publish to NPM
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [check-paths, test]
+    if: needs.check-paths.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -102,3 +115,17 @@ jobs:
           pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  web-editors-checks-all:
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check overall status
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            echo "Web editor checks failed"
+            exit 1
+          fi
+          echo "Web editor checks passed or were skipped"
+          exit 0

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -1,83 +1,277 @@
-# Instructions for Gemini
+# Dotprompt Development Guidelines
 
-You are an expert Python developer contributing to the Google Dotprompt project. When modifying or generating code, you must strictly adhere to the following guidelines.
+## Overview
 
-## 1. Project Context
-- **Target Python Version**: Python 3.10 or newer. Ensure code is compatible with Python 3.10+.
-- **Language**: Python.
-- **Environment Management**: Use `uv` for packaging and environment management.
+Dotprompt is a multi-language library implementing an executable prompt template file format
+for Generative AI. The codebase supports **Go**, **Python**, **JavaScript/TypeScript**,
+**Java**, and **Rust** implementations.
 
-### Python Libraries
-- **JSON**: Use the built-in `json` module or `pydantic` for serialization.
-- **Testing**: Use `pytest` and `unittest` for testing.
+## Code Quality & Linting
 
-### Java Libraries
-- **JSON**: Use **Jackson** for JSON parsing and serialization. Avoid Gson.
-- **Testing**: Use **Google Truth** (`com.google.truth.Truth`) for assertions. Use JUnit 4/5 for test runners.
-- **Utilities**: Use **Guava** for immutable collections and common utilities.
-- **Dependency Injection**: Use **Dagger** for dependency injection.
+* **Run Linting**: Always run `./scripts/lint` from the repo root for Python code changes,
+  and the language-specific check scripts for other languages.
+  0 diagnostics should be reported for all blocking checks.
+* **Treat Warnings as Errors**: Do not ignore warnings from linters or type checkers
+  unless there is a compelling, documented reason.
+* **Check Licenses**: Run `./scripts/check_license` to ensure all files have proper
+  license headers.
 
-### Java Style Guidelines
-- **Imports**: Always use proper imports instead of fully qualified type names. Never write `com.github.jknack.handlebars.Context` inline; instead, add an `import` statement and use `Context`.
-- **Formatting**: Use `google-java-format` for code formatting.
-- **Javadoc**: Write comprehensive Javadoc for all public classes and methods.
-- **Doc Sync**: Keep Javadoc comments in sync with the code. When modifying method signatures, parameters, or return types, update the corresponding Javadoc.
-- **Method Chaining**: Fluent builder methods should return `this` for chaining.
-- Please don't add section marker comments.
+***
 
-### Rust Style Guidelines
-- **Section Comments**: Do not add section marker comments (e.g., `// ==== Section ====`). Use module organization and doc comments instead.
-- **Documentation**: Write comprehensive rustdoc comments for all public types and functions.
-- **Error Handling**: Use Result types for fallible operations; avoid `unwrap()` and `expect()` in library code.
-- **Clippy**: Follow `clippy::pedantic` lints. Use `#[allow(...)]` annotations sparingly and with justification.
+## Python Development
 
-## 2. Typing & Style
-- **Type Unions**: Use the pipe operator `|` (PEP 604) for union types (e.g., `int | str`) instead of `typing.Union`. Use `| None` for optional types.
-- **Generics**: Use standard collection generics (PEP 585) like `list`, `dict`, `tuple` (lowercase) for type hints instead of `typing.List`, `typing.Dict`.
-- **Imports**: Import deprecated typing types (`Callable`, `Awaitable`, etc.) from `collections.abc` instead of `typing`.
-- **Strict Typing**: Apply type hints strictly to all function arguments and return values. Always include `-> None` for functions that do not return a value.
-- **Type Aliases**: Use standard assignment or `TypeAlias` (from `typing`) for type aliases (e.g., `MyAlias = int | str`). Do NOT use the `type` keyword (PEP 695) as it requires Python 3.12+.
-- **Enums**: Use `(str, Enum)` for string-based enums to maintain Python 3.10 compatibility. Do not use `StrEnum` until Python 3.10 support is dropped.
-- **Interfaces**: Code against interfaces (Protocols), not implementations.
-- **Design Patterns**: Use the adapter pattern for optional implementations.
-- **Comments**:
-  - Use proper punctuation.
-  - Avoid comments explaining obvious code.
-  - Add TODO comments in the format: `TODO: Fix this later.` when adding stub implementations.
+### Target Environment
 
-## 3. Documentation
-- **Docstrings**: Write comprehensive Google-style docstrings for all modules, classes, and functions.
-- **Content Requirements**:
-  - **Overview**: A one-line description followed by optional rationale.
-  - **Key Operations**: Describe the purpose.
-  - **Arguments**: Required for callables.
-  - **Returns**: Required for callables.
-  - **Examples**: Required for user-facing APIs.
-  - **Caveats**: Note any limitations or side effects.
+* **Python Version**: Target Python 3.10 or newer.
+* **Environment**: Use `uv` for packaging and environment management.
 
-## 4. Formatting
-- **Tools**: Format code using `ruff`. See the scripts/fmt script for more details.
-- **Line Length**: Limit lines to 120 characters to distinguish vertical code flow.
-- **Configuration**: Respect rules in `.editorconfig` or `pyproject.toml`.
-- **Wrapping**: Wrap long lines and strings appropriately.
+### Type Checking
 
-## 5. Testing
-- **Frameworks**: Use `pytest` and `unittest`.
-- **Docstrings**: Add docstrings to test modules, classes, and functions explaining their scope. Use the Google Python Style Guide for docstrings.
-- **Execution**: Run tests via the scripts in `scripts/`.
-- **Parity**: If porting tests from another language, maintain 1:1 logic parity; do not invent new behavior.
-- **Purity**: Fix underlying code issues rather than special-casing tests.
+Two type checkers are configured (both blocking, must pass with zero errors):
 
-## 6. Tooling & Ecosystem
-- **Static Analysis**: Use `ty` for static type checking.
-- **Logging**:
-  - Use `structlog` for structured logging.
-  - Use the async API (`await logger.ainfo(...)`) within coroutines.
-  - Avoid f-strings in log calls; let `structlog` handle formatting (e.g. `logger.info("msg", var=val)`).
-  - Use the sync API (`logger.exception(...)`) for exception handling.
+* **ty** (Astral/Ruff) - Fast type checker from the Ruff team
+* **pyrefly** (Meta) - Static type checker from Meta
 
-## 7. Licensing
-- **Header**: Include the following Apache 2.0 license header at the top of each file, ensuring the year is current (e.g., 2025):
+Run type checks with:
+
+```bash
+cd python
+uv run ty check
+uv run pyrefly check
+```
+
+Or use the lint script which runs both:
+
+```bash
+./scripts/lint
+```
+
+### Type Checker Configuration
+
+Both type checkers are configured in `python/pyproject.toml`.
+
+**pyrefly** (`[tool.pyrefly]`):
+
+* `project_includes`: Specifies which directories to check (`dotpromptz`, `handlebarrz`, `tests`)
+* `untyped_def_behavior = "check-and-infer-return-type"`: Check untyped functions
+  and infer return types
+* `python_version = "3.10"`: Matches ruff.target-version
+
+**ty** (`[tool.ty.src]`):
+
+* `exclude`: Excludes the `samples` directory (external dependencies not in workspace)
+
+### Error Suppression Policy
+
+Avoid ignoring warnings from the type checker (`# type: ignore`, `# pyrefly: ignore`, etc.)
+unless there is a compelling, documented reason.
+
+* **Try to fix first**: Before suppressing, try to rework the code to avoid the
+  warning entirely. Use explicit type annotations, asserts for type narrowing,
+  local variables to capture narrowed types in closures, or refactor the logic.
+* **Acceptable suppressions**: Only suppress when the warning is due to:
+  * Type checker limitations (e.g., closure narrowing issues)
+  * External library type stub issues
+  * Intentional design choices
+* **Minimize surface area**: Suppress on the specific line, not globally in config.
+* **Always add a comment**: Explain why the suppression is needed.
+* **Be specific**: Use the exact error code when possible (e.g., `# pyrefly: ignore[missing-attribute]`).
+
+### Typing & Style
+
+* **Syntax**:
+  * Use `|` for union types instead of `Union`.
+  * Use `| None` instead of `Optional`.
+  * Use lowercase `list`, `dict` for type hints (avoid `List`, `Dict`).
+  * Use modern generics (PEP 585, 695).
+* **Imports**: Import types like `Callable`, `Awaitable` from `collections.abc`,
+  not standard library `typing`.
+* **Strictness**: Apply type hints strictly, including `-> None` for void functions.
+
+### Formatting
+
+* **Tool**: Format code using `ruff` (or `./scripts/fmt`).
+* **Line Length**: Max 120 characters.
+* **Config**: Refer to `.editorconfig` or `python/pyproject.toml` for rules.
+
+### Testing
+
+* **Framework**: Use `pytest`.
+* **Execution**: Run via `uv run pytest .` in the `python` directory.
+* **Coverage**: Aim for 85% or higher coverage.
+
+### Docstrings
+
+* **Format**: Write comprehensive Google-style docstrings for modules, classes,
+  and functions.
+* **Required Sections**:
+  * **Overview**: One-liner description followed by rationale.
+  * **Args/Attributes**: Required for callables/classes.
+  * **Returns**: Required for callables.
+  * **Examples**: Required for user-facing API.
+
+***
+
+## JavaScript/TypeScript Development
+
+### Target Environment
+
+* **Node.js Version**: Support Node.js 20, 21, 22, 23, and 24.
+* **Package Manager**: Use `pnpm` for dependency management.
+
+### Type Checking
+
+TypeScript's built-in type checker (`tsc`) is used. The project also supports
+the native TypeScript compiler (`tsgo`).
+
+```bash
+pnpm -C js build       # Build with tsc
+pnpm -C js build:native # Build with tsgo
+```
+
+### Linting & Formatting
+
+* **Linter**: Biome is used for linting JavaScript/TypeScript code.
+* **Formatter**: Biome is also used for formatting.
+* **Config**: See `biome.json` in the repo root.
+
+```bash
+pnpm dlx @biomejs/biome check --formatter-enabled=true js/
+```
+
+### Testing
+
+* **Framework**: Vitest is used for testing.
+* **Execution**: Run `pnpm -C js test`.
+
+***
+
+## Go Development
+
+### Target Environment
+
+* **Go Version**: Support Go 1.24 and 1.25.
+
+### Linting
+
+* **golangci-lint**: Primary linter for Go code.
+* **go vet**: Standard Go static analysis.
+* **govulncheck**: Vulnerability scanning.
+
+```bash
+cd go
+golangci-lint run ./...
+go vet -v ./...
+govulncheck ./...
+```
+
+### Formatting
+
+* **Tool**: Use `gofmt` for formatting.
+* **Check**: Run `gofmt -l go/` to list unformatted files.
+* **Fix**: Run `gofmt -w go/` or `./scripts/format_go_files`.
+
+### Testing
+
+```bash
+go test -C go -v ./...
+```
+
+Or use the comprehensive check script:
+
+```bash
+./scripts/run_go_checks
+```
+
+***
+
+## Rust Development
+
+### Target Environment
+
+* **Toolchains**: Support both stable and nightly toolchains.
+* **Stable is blocking**: Nightly failures are allowed but logged.
+
+### Linting
+
+* **Clippy**: Primary linter with strict settings.
+* **Workspace lints**: Configured in `Cargo.toml` at the workspace level.
+
+```bash
+cargo clippy --all-targets --workspace -- -D warnings
+```
+
+Key lint settings (from `Cargo.toml`):
+
+* `unsafe_code = "forbid"` - No unsafe code allowed
+* `missing_docs = "deny"` - All public items must be documented
+* All clippy categories enabled: `pedantic`, `nursery`, `correctness`, etc.
+
+### Formatting
+
+```bash
+cargo fmt --all -- --check
+```
+
+### Testing
+
+```bash
+cargo test --all-targets --workspace
+```
+
+Or use the comprehensive check script:
+
+```bash
+./scripts/run_rust_checks
+```
+
+***
+
+## Java Development
+
+### Target Environment
+
+* **JDK Version**: Support JDK 17, 21, 23, and 24.
+* **Build System**: Bazel.
+
+### Formatting
+
+* **Tool**: google-java-format
+* **Check**:
+
+```bash
+java -jar google-java-format.jar --dry-run --set-exit-if-changed $(find java -name "*.java")
+```
+
+### Testing
+
+```bash
+bazel test --test_output=errors //java/com/google/dotprompt/...
+```
+
+***
+
+## Cross-Language Specifications
+
+The `spec/` directory contains YAML specification files that define expected
+behavior across all language implementations. These specs are used for
+conformance testing:
+
+* `spec/helpers/` - Helper function specifications
+* `spec/metadata.yaml` - Metadata parsing specifications
+* `spec/partials.yaml` - Partial template specifications
+* `spec/picoschema.yaml` - Picoschema specifications
+* `spec/variables.yaml` - Variable substitution specifications
+
+All language implementations should pass these specification tests.
+
+***
+
+## Licensing
+
+Include the Apache 2.0 license header at the top of each file (update year as needed):
+
+### Python/Bash/YAML
 
 ```python
 # Copyright 2026 Google LLC
@@ -96,3 +290,63 @@ You are an expert Python developer contributing to the Google Dotprompt project.
 #
 # SPDX-License-Identifier: Apache-2.0
 ```
+
+### JavaScript/TypeScript/Java/Rust
+
+```javascript
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+```
+
+***
+
+## Git Commit Message Guidelines
+
+* Use conventional commits format (e.g., `feat:`, `fix:`, `docs:`, `chore:`).
+* For scope, refer to `.release-please-config.json` if available.
+* Add a rationale paragraph explaining the why and the what before listing changes.
+* Keep it short and simple.
+* Do not include absolute file paths as links in commit messages.
+
+***
+
+## Available Scripts
+
+| Script | Description |
+|--------|-------------|
+| `scripts/lint` | Run Python linting (ruff, ty, pyrefly) |
+| `scripts/fmt` | Format all code |
+| `scripts/check_license` | Check license headers |
+| `scripts/run_go_checks` | Run all Go checks and tests |
+| `scripts/run_rust_checks` | Run all Rust checks and tests |
+| `scripts/run_js_checks` | Run all JS/TS checks and tests |
+| `scripts/run_python_checks` | Run Python checks |
+| `scripts/run_python_security_checks` | Run security scanning |
+| `scripts/build_dists` | Build distribution packages |
+
+***
+
+## CI/CD
+
+All pull requests trigger GitHub Actions workflows for each language:
+
+* `.github/workflows/python.yml` - Python checks
+* `.github/workflows/go.yml` - Go checks
+* `.github/workflows/js.yml` - JavaScript/TypeScript checks
+* `.github/workflows/java.yml` - Java checks
+* `.github/workflows/rust.yml` - Rust checks
+
+All checks must pass before merging.

--- a/python/dotpromptz/tests/dotpromptz/helpers_test.py
+++ b/python/dotpromptz/tests/dotpromptz/helpers_test.py
@@ -206,7 +206,7 @@ class TestDotpromptHelpers(unittest.TestCase):
 
         self.handlebars.register_template('non_serial', '{{json data}}')
 
-        with self.assertRaises((TypeError, Exception)):
+        with self.assertRaises(Exception):
             self.handlebars.render('non_serial', {'data': NonSerializable()})
 
     def test_if_equals_type_safety_int_vs_string(self) -> None:

--- a/python/dotpromptz/tests/dotpromptz/parse_test.py
+++ b/python/dotpromptz/tests/dotpromptz/parse_test.py
@@ -779,6 +779,8 @@ Hello!"""
         result: ParsedPrompt[dict[str, str]] = parse_document(source)
 
         self.assertIsInstance(result, ParsedPrompt)
+        self.assertIsNotNone(result.raw)
+        assert result.raw is not None  # Type narrowing for pyrefly
         self.assertEqual(result.raw.get('model'), 'gemini-pro')
         self.assertEqual(result.template, 'Hello!')
 
@@ -793,6 +795,8 @@ Hello shebang!"""
         result: ParsedPrompt[dict[str, str]] = parse_document(source)
 
         self.assertIsInstance(result, ParsedPrompt)
+        self.assertIsNotNone(result.raw)
+        assert result.raw is not None  # Type narrowing for pyrefly
         self.assertEqual(result.raw.get('model'), 'gemini-flash')
         self.assertEqual(result.template, 'Hello shebang!')
 
@@ -809,5 +813,7 @@ Hello combined!"""
         result: ParsedPrompt[dict[str, str]] = parse_document(source)
 
         self.assertIsInstance(result, ParsedPrompt)
+        self.assertIsNotNone(result.raw)
+        assert result.raw is not None  # Type narrowing for pyrefly
         self.assertEqual(result.raw.get('model'), 'gemini-2.0')
         self.assertEqual(result.template, 'Hello combined!')

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -178,13 +178,18 @@ python_version = "3.10" # Matches ruff.target-version
 search_path = ["."]
 
 # How to handle untyped function definitions.
-# "error": Emit an error (similar to mypy's disallow_untyped_defs = true).
-# "check": Type check the body as if it were annotated.
-# "skip": Skip checking the body (default).
-untyped_def_behavior = "error"
+# "check-and-infer-return-type": Check and infer return type.
+# "check-and-infer-return-any": Check but infer Any for return type.
+# "skip-and-infer-return-any": Skip checking the body (default).
+untyped_def_behavior = "check-and-infer-return-type"
 
 # By default, all errors are enabled if the [tool.pyrefly.errors] table is empty or not present.
 # For maximum strictness similar to 'mypy --strict', we rely on this default behavior.
 # If specific errors need to be disabled later, they can be added here:
 # [tool.pyrefly.errors]
 # example-error-code = false
+
+# ty (Astral/Ruff) type checker configuration.
+[tool.ty.src]
+# Exclude samples directory as they have external dependencies not in the workspace.
+exclude = ["samples"]

--- a/python/samples/streamlit-monaco-demo/README.md
+++ b/python/samples/streamlit-monaco-demo/README.md
@@ -1,0 +1,30 @@
+# Streamlit Monaco Dotprompt Demo
+
+This sample demonstrates how to use the Monaco Editor with Dotprompt syntax highlighting in a Streamlit application.
+
+## Setup
+
+1.  Navigate to this directory:
+    ```bash
+    cd python/samples/streamlit-monaco-demo
+    ```
+
+2.  Create a virtual environment and install dependencies using `uv`:
+    ```bash
+    uv venv
+    source .venv/bin/activate
+    uv pip install -r requirements.txt
+    ```
+
+## Running the Demo
+
+Run the Streamlit app:
+
+```bash
+streamlit run app.py
+```
+
+## Note on Syntax Highlighting
+
+This demo uses the `streamlit-monaco` component. If the component does not have the `dotprompt` language registered, syntax highlighting might fall back to plain text or standard Handlebars if configured. 
+To fully enable `dotprompt` highlighting, the Monaco instance in the browser needs the grammar definition registered via `monaco.languages.register`.

--- a/python/samples/streamlit-monaco-demo/app.py
+++ b/python/samples/streamlit-monaco-demo/app.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import streamlit as st
+from dotprompt_grammar import LANGUAGE_ID, language_configuration, monarch_language
+from streamlit_monaco import st_monaco
+
+st.set_page_config(layout='wide')
+st.title('Dotprompt Monaco Editor Demo')
+
+st.markdown("""
+This example demonstrates syntax highlighting for **Dotprompt** files using the Monaco Editor.
+""")
+
+# Sample Dotprompt content
+DEFAULT_CONTENT = """---
+model: gemini-2.0-flash
+config:
+  temperature: 0.7
+  topP: 0.95
+---
+
+{{#role "system"}}
+You are a helpful AI assistant specialized in coding tasks.
+{{/role}}
+
+{{#role "user"}}
+Can you help me write a Python script to parse JSON?
+{{/role}}
+
+{{#role "model"}}
+Certainly! Here is a simple example using the `json` module:
+
+```python
+import json
+
+data = '{"name": "Alice", "age": 30}'
+parsed = json.loads(data)
+print(parsed["name"])
+```
+{{/role}}
+"""
+
+col1, col2 = st.columns([2, 1])
+
+with col1:
+    st.subheader('Editor')
+    # Note: Streamlit-Monaco may not strictly support custom language injection via Python arguments
+    # out-of-the-box depending on the version.
+    # If 'dotprompt' is not registered, Monaco falls back to plain text.
+    # To get partial highlighting immediately, 'handlebars' can be used as a fallback.
+    # However, for this demo, we attempt to use the 'dotprompt' ID assuming the environment
+    # or component might support it or it's a placeholder for full integration.
+    content = st_monaco(
+        value=DEFAULT_CONTENT,
+        height='600px',
+        language=LANGUAGE_ID,  # defined in dotprompt_grammar.py
+        theme='vs-dark',
+        options={
+            'minimap': {'enabled': False},
+            'wordWrap': 'on',
+        },
+    )
+
+with col2:
+    st.subheader('Preview / Output')
+    st.text_area('Raw Content', value=content, height=600, disabled=True)

--- a/python/samples/streamlit-monaco-demo/dotprompt_grammar.py
+++ b/python/samples/streamlit-monaco-demo/dotprompt_grammar.py
@@ -1,0 +1,241 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+LANGUAGE_ID = 'dotprompt'
+
+# Monarch tokenizer for Dotprompt syntax highlighting.
+# Handles YAML frontmatter, Handlebars templates, and Dotprompt markers.
+monarch_language = {
+    'defaultToken': '',
+    'tokenPostfix': '.dotprompt',
+    # Handlebars keywords
+    'keywords': ['if', 'unless', 'each', 'with', 'else', 'log', 'lookup'],
+    # Dotprompt-specific helpers
+    'dotpromptHelpers': [
+        'json',
+        'role',
+        'history',
+        'section',
+        'media',
+        'ifEquals',
+        'unlessEquals',
+    ],
+    # YAML frontmatter keys
+    'yamlKeys': [
+        'model',
+        'config',
+        'input',
+        'output',
+        'tools',
+        'metadata',
+        'default',
+        'schema',
+        'format',
+        'temperature',
+        'maxOutputTokens',
+        'topP',
+        'topK',
+    ],
+    # Operators and brackets
+    'brackets': [
+        {'open': '{{', 'close': '}}', 'token': 'delimiter.handlebars'},
+        {'open': '{{#', 'close': '}}', 'token': 'delimiter.handlebars.block'},
+        {'open': '{{/', 'close': '}}', 'token': 'delimiter.handlebars.block'},
+        {'open': '{', 'close': '}', 'token': 'delimiter.curly'},
+        {'open': '[', 'close': ']', 'token': 'delimiter.square'},
+    ],
+    'tokenizer': {
+        'root': [
+            # License header comments (lines starting with #)
+            [r'^#.*$', 'comment.line'],
+            # Frontmatter delimiter
+            [r'^---\s*$', {'token': 'delimiter.frontmatter', 'next': '@frontmatter'}],
+            # Dotprompt markers <<<dotprompt:...>>>
+            [r'<<<dotprompt:[^>]+>>>', 'keyword.marker'],
+            # Include template tokens
+            {'include': '@template'},
+        ],
+        'frontmatter': [
+            # End of frontmatter
+            [r'^---\s*$', {'token': 'delimiter.frontmatter', 'next': '@root'}],
+            # YAML comments
+            [r'#.*$', 'comment.yaml'],
+            # YAML keys
+            [
+                r'([a-zA-Z_][a-zA-Z0-9_-]*)(\s*)(:)',
+                [
+                    {
+                        'cases': {
+                            '@yamlKeys': 'keyword.yaml',
+                            '@default': 'variable.yaml',
+                        },
+                    },
+                    '',
+                    'delimiter.colon',
+                ],
+            ],
+            # YAML strings
+            [r'"([^"\\]|\\.)*$', 'string.invalid'],  # non-terminated string
+            [r'"', {'token': 'string.quote', 'next': '@yamlDoubleString'}],
+            [r"'", {'token': 'string.quote', 'next': '@yamlSingleString'}],
+            # YAML numbers
+            [r'\d+(\.\d+)?', 'number'],
+            # YAML booleans
+            [r'\b(true|false|null)\b', 'constant.language'],
+            # Everything else in frontmatter
+            [r'.', 'source.yaml'],
+        ],
+        'yamlDoubleString': [
+            [r'[^\\"]+', 'string'],
+            [r'\\.', 'string.escape'],
+            [r'"', {'token': 'string.quote', 'next': '@pop'}],
+        ],
+        'yamlSingleString': [
+            [r"[^\\']+", 'string'],
+            [r'\\.', 'string.escape'],
+            [r"'", {'token': 'string.quote', 'next': '@pop'}],
+        ],
+        'template': [
+            # Handlebars comments {{! ... }}
+            [r'\{\{!--', {'token': 'comment.block', 'next': '@handlebarsBlockComment'}],
+            [r'\{\{!+', {'token': 'comment.block', 'next': '@handlebarsComment'}],
+            # Handlebars block start {{#helper ...}}
+            [
+                r'(\{\{#)(\s*)(\w+)',
+                [
+                    'delimiter.handlebars.block',
+                    '',
+                    {
+                        'cases': {
+                            '@keywords': 'keyword.handlebars',
+                            '@dotpromptHelpers': 'keyword.dotprompt',
+                            '@default': 'variable.handlebars',
+                        },
+                    },
+                ],
+            ],
+            # Handlebars block end {{/helper}}
+            [
+                r'(\{\{\/)(\s*)(\w+)(\s*)(\}\})',
+                [
+                    'delimiter.handlebars.block',
+                    '',
+                    {
+                        'cases': {
+                            '@keywords': 'keyword.handlebars',
+                            '@dotpromptHelpers': 'keyword.dotprompt',
+                            '@default': 'variable.handlebars',
+                        },
+                    },
+                    '',
+                    'delimiter.handlebars.block',
+                ],
+            ],
+            # Handlebars else {{else}}
+            [r'\{\{else\}\}', 'keyword.handlebars'],
+            # Partials {{> partialName}}
+            [
+                r'(\{\{>)(\s*)([a-zA-Z_][a-zA-Z0-9_-]*)(\s*)(\}\})',
+                [
+                    'delimiter.handlebars',
+                    '',
+                    'variable.partial',
+                    '',
+                    'delimiter.handlebars',
+                ],
+            ],
+            # Handlebars expressions {{ ... }}
+            [
+                r'\{\{',
+                {'token': 'delimiter.handlebars', 'next': '@handlebarsExpression'},
+            ],
+            # Plain text
+            [r'[^{<]+', ''],
+            [r'.', ''],
+        ],
+        'handlebarsExpression': [
+            # Close expression
+            [r'\}\}', {'token': 'delimiter.handlebars', 'next': '@pop'}],
+            # Helpers
+            [
+                r'\b(\w+)\b',
+                {
+                    'cases': {
+                        '@keywords': 'keyword.handlebars',
+                        '@dotpromptHelpers': 'keyword.dotprompt',
+                        '@default': 'variable',
+                    },
+                },
+            ],
+            # Strings in expressions
+            [r'"([^"\\]|\\.)*"', 'string'],
+            [r"'([^'\\]|\\.)*'", 'string'],
+            # Numbers
+            [r'\d+', 'number'],
+            # Operators
+            [r'[=]', 'operator'],
+            # Dotted paths
+            [r'\.', 'delimiter.dot'],
+            # @ variables (@index, @first, etc.)
+            [r'@\w+', 'variable.special'],
+            # Whitespace
+            [r'\s+', ''],
+        ],
+        'handlebarsComment': [
+            [r'\}\}', {'token': 'comment.block', 'next': '@pop'}],
+            [r'.', 'comment.block'],
+        ],
+        'handlebarsBlockComment': [
+            [r'--\}\}', {'token': 'comment.block', 'next': '@pop'}],
+            [r'.', 'comment.block'],
+        ],
+    },
+}
+
+# Language configuration for Dotprompt.
+# Provides bracket matching, auto-closing, and comment toggling.
+language_configuration = {
+    'comments': {
+        'blockComment': ['{{!', '}}'],
+    },
+    'brackets': [
+        ['{{', '}}'],
+        ['{{#', '}}'],
+        ['{{/', '}}'],
+        ['{', '}'],
+        ['[', ']'],
+        ['(', ')'],
+    ],
+    'autoClosingPairs': [
+        {'open': '{{', 'close': '}}'},
+        {'open': '{', 'close': '}'},
+        {'open': '[', 'close': ']'},
+        {'open': '(', 'close': ')'},
+        {'open': '"', 'close': '"'},
+        {'open': "'", 'close': "'"},
+    ],
+    'surroundingPairs': [
+        {'open': '{{', 'close': '}}'},
+        {'open': '{', 'close': '}'},
+        {'open': '[', 'close': ']'},
+        {'open': '(', 'close': ')'},
+        {'open': '"', 'close': '"'},
+        {'open': "'", 'close': "'"},
+    ],
+    # Folding and Indentation rules are regex-heavy and might not transfer easily via JSON without
+    # manual regex object reconstruction on JS side. We limit to basic configuration for now.
+    # If the Streamlit component supports regex strings for these, we could add them.
+}

--- a/python/samples/streamlit-monaco-demo/requirements.txt
+++ b/python/samples/streamlit-monaco-demo/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+streamlit-monaco

--- a/scripts/install_vim_plugin
+++ b/scripts/install_vim_plugin
@@ -108,6 +108,7 @@ echo "Step 2: Installing Vim plugin to: $DEST_DIR"
 # Create directories
 mkdir -p "$DEST_DIR/syntax"
 mkdir -p "$DEST_DIR/ftdetect"
+mkdir -p "$DEST_DIR/lua"
 
 # Copy files
 echo "  Copying syntax/dotprompt.vim..."
@@ -134,6 +135,20 @@ if [ -f "$DEST_DIR/ftdetect/dotprompt.vim" ] && [ "$FORCE" = false ]; then
   fi
 else
   cp "$VIM_PKG_DIR/ftdetect/dotprompt.vim" "$DEST_DIR/ftdetect/"
+fi
+
+echo "  Copying lua/dotprompt..."
+if [ -d "$DEST_DIR/lua/dotprompt" ] && [ "$FORCE" = false ]; then
+  read -p "  Directory lua/dotprompt exists. Overwrite? (y/N) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "  Skipping lua module."
+  else
+    rm -rf "$DEST_DIR/lua/dotprompt"
+    cp -r "$VIM_PKG_DIR/lua/dotprompt" "$DEST_DIR/lua/"
+  fi
+else
+  cp -r "$VIM_PKG_DIR/lua/dotprompt" "$DEST_DIR/lua/"
 fi
 
 echo ""

--- a/scripts/lint
+++ b/scripts/lint
@@ -26,12 +26,11 @@ TOP_DIR=$(git rev-parse --show-toplevel)
 PY_DIR="${TOP_DIR}/python"
 
 uv run --directory "${PY_DIR}" ruff check --select I --fix --preview --unsafe-fixes .
-# uv run --directory "${PY_DIR}" mypy .
 
-# Add pylyzer, ty, and pyrefly
-#uv run --directory "${PY_DIR}" pylyzer --check .
+# Static type checking with ty (Astral/Ruff) and pyrefly (Meta).
+# Both must pass with zero errors.
 uv run --directory "${PY_DIR}" ty check
-#uv run --directory "${PY_DIR}" pyrefly check
+uv run --directory "${PY_DIR}" pyrefly check
 
 # Run security scanning
 "${TOP_DIR}/scripts/run_python_security_checks"


### PR DESCRIPTION
feat: integrate pyrefly type checker and improve CI workflows

This commit adds pyrefly (Meta's static type checker) as a blocking check
for Python code and standardizes CI workflow patterns across all languages.

Python type checking:
- Add pyrefly as second blocking type checker alongside ty (Astral/Ruff)
- Fix pyrefly config: use valid `untyped_def_behavior` value
- Fix 4 type errors in test files for pyrefly compatibility
- Configure ty to exclude samples/ directory (external dependencies)
- Enable pyrefly in scripts/lint (was previously commented out)

CI workflow improvements:
- Standardize path-based triggering using tj-actions/changed-files
- Add check-paths job pattern for conditional workflow execution
- Add *-checks-all summary jobs for clear pass/fail status
- Update to actions/checkout@v6 and other action version bumps

New sample:
- Add streamlit-monaco-demo: interactive Dotprompt editor with Monaco

Documentation:
- Rewrite GEMINI.md (coding_guidelines.md) with comprehensive guidelines
  for all supported languages: Python, JS/TS, Go, Rust, and Java

Other:
- Update scripts/install_vim_plugin with additional functionality

The lint script now reports 0 diagnostics for both ty and pyrefly.