### PR TITLE
fix: standardize release-please config and add commit message guidelines

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,7 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "draft": false,
-  "pull-request-title-pattern": "chore${scope}: release ${component}-${version}",
+  "pull-request-title-pattern": "chore(${component}): release ${version}",
   "include-component-in-tag": true,
   "prerelease": false,
   "separate-pull-requests": true,
@@ -12,9 +12,10 @@
   "include-v-in-tag": false,
   "plugins": ["node-workspace"],
   "packages": {
-    "js": {
+    "dotprompt": {
       "release-type": "node",
       "package-name": "dotprompt",
+      "component": "dotprompt",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -25,6 +26,7 @@
     "dotpromptz": {
       "release-type": "python",
       "package-name": "dotpromptz",
+      "component": "dotpromptz",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -47,6 +49,7 @@
     "dotpromptz-handlebars": {
       "release-type": "python",
       "package-name": "dotpromptz-handlebars",
+      "component": "dotpromptz-handlebars",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -71,9 +74,10 @@
         }
       ]
     },
-    "go": {
+    "dotprompt-go": {
       "release-type": "go",
       "package-name": "dotprompt-go",
+      "component": "dotprompt-go",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -81,9 +85,10 @@
       "prerelease": false,
       "path": "go"
     },
-    "rs": {
+    "dotprompt-rs": {
       "release-type": "rust",
       "package-name": "dotprompt-rs",
+      "component": "dotprompt-rs",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -98,9 +103,10 @@
         }
       ]
     },
-    "java": {
+    "dotprompt-java": {
       "release-type": "java",
       "package-name": "dotprompt-java",
+      "component": "dotprompt-java",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -114,9 +120,10 @@
         }
       ]
     },
-    "packages/vscode": {
+    "dotprompt-vscode": {
       "release-type": "node",
       "package-name": "dotprompt-vscode",
+      "component": "dotprompt-vscode",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -124,9 +131,10 @@
       "prerelease": false,
       "path": "packages/vscode"
     },
-    "packages/vim": {
+    "dotprompt-vim": {
       "release-type": "simple",
       "package-name": "dotprompt-vim",
+      "component": "dotprompt-vim",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -134,9 +142,10 @@
       "prerelease": false,
       "path": "packages/vim"
     },
-    "packages/emacs": {
+    "dotprompt-emacs": {
       "release-type": "simple",
       "package-name": "dotprompt-emacs",
+      "component": "dotprompt-emacs",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -144,9 +153,10 @@
       "prerelease": false,
       "path": "packages/emacs"
     },
-    "packages/monaco": {
+    "dotprompt-monaco": {
       "release-type": "node",
       "package-name": "@dotprompt/monaco",
+      "component": "dotprompt-monaco",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -154,9 +164,10 @@
       "prerelease": false,
       "path": "packages/monaco"
     },
-    "packages/codemirror": {
+    "dotprompt-codemirror": {
       "release-type": "node",
       "package-name": "@dotprompt/codemirror",
+      "component": "dotprompt-codemirror",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
@@ -164,32 +175,38 @@
       "prerelease": false,
       "path": "packages/codemirror"
     },
-    "packages/jetbrains": {
+    "dotprompt-jetbrains": {
       "release-type": "simple",
       "package-name": "dotprompt-jetbrains",
+      "component": "dotprompt-jetbrains",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "path": "packages/jetbrains",
-      "extra-files": [
-        {
-          "type": "xml",
-          "path": "src/main/resources/META-INF/plugin.xml",
-          "jsonpath": "idea-plugin.change-notes"
-        }
-      ]
+      "path": "packages/jetbrains"
     },
-    "packages/treesitter": {
+    "tree-sitter-dotprompt": {
       "release-type": "node",
       "package-name": "tree-sitter-dotprompt",
+      "component": "tree-sitter-dotprompt",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
       "path": "packages/treesitter"
+    },
+    "promptly": {
+      "release-type": "node",
+      "package-name": "@dotprompt/promptly",
+      "component": "promptly",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false,
+      "path": "packages/promptly"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,15 +1,16 @@
 {
-  "js": "0.2.9",
+  "dotprompt": "0.2.9",
   "dotpromptz": "0.1.4",
   "dotpromptz-handlebars": "0.1.3",
-  "go": "0.2.0",
-  "java": "0.1.0",
-  "rs": "0.1.0",
-  "packages/vscode": "0.0.1",
-  "packages/vim": "0.1.0",
-  "packages/emacs": "0.1.0",
-  "packages/monaco": "0.1.0",
-  "packages/codemirror": "0.1.0",
-  "packages/jetbrains": "0.2.0",
-  "packages/treesitter": "0.1.0"
+  "dotprompt-go": "0.2.0",
+  "dotprompt-java": "0.1.0",
+  "dotprompt-rs": "0.1.0",
+  "dotprompt-vscode": "0.0.1",
+  "dotprompt-vim": "0.1.0",
+  "dotprompt-emacs": "0.1.0",
+  "dotprompt-monaco": "0.1.0",
+  "dotprompt-codemirror": "0.1.0",
+  "dotprompt-jetbrains": "0.2.0",
+  "tree-sitter-dotprompt": "0.1.0",
+  "promptly": "0.1.0"
 }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,13 +26,8 @@ bazel_dep(name = "gazelle", version = "0.47.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 
 include("//:go.MODULE.bazel")
-
 include("//:java.MODULE.bazel")
-
 include("//:rust.MODULE.bazel")
-
 include("//:kotlin.MODULE.bazel")
-
 include("//:python.MODULE.bazel")
-
 include("//:ts.MODULE.bazel")

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![View Code Wiki](https://www.gstatic.com/_/boq-sdlc-agents-ui/_/r/YUi5dj2UWvE.svg)](https://codewiki.google/github.com/google/dotprompt)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/google/dotprompt)
 
-
 # Dotprompt: Executable GenAI Prompt Templates
 
 **Dotprompt** is an executable prompt template file format for Generative AI. It
@@ -141,3 +140,37 @@ By following these steps, you'll have a basic Dotprompt setup ready to go. From
 here, you can create more complex prompts, integrate them into your application,
 and start harnessing the full power of generative AI in a structured,
 template-driven way.
+
+## Contributing
+
+We welcome contributions! Please see our [Development Guidelines](GEMINI.md) for:
+
+* Code style and linting requirements for each language
+* Testing requirements
+* Git commit message conventions
+
+### Commit Message Format
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) with package
+names as scopes:
+
+```bash
+feat(dotpromptz): add new helper function
+fix(dotprompt-go): resolve parsing edge case
+docs(dotprompt-java): update API documentation
+```
+
+| Scope | Package |
+|-------|---------|
+| `dotprompt` | JavaScript/TypeScript (`js/`) |
+| `dotpromptz` | Python dotpromptz (`python/dotpromptz/`) |
+| `dotpromptz-handlebars` | Python Handlebars (`python/handlebarrz/`) |
+| `dotprompt-go` | Go (`go/`) |
+| `dotprompt-rs` | Rust (`rs/`) |
+| `dotprompt-java` | Java (`java/`) |
+| `dotprompt-vscode` | VS Code extension |
+| `dotprompt-jetbrains` | JetBrains plugin |
+| `tree-sitter-dotprompt` | Tree-sitter grammar |
+| `promptly` | CLI tool for .prompt files |
+
+See [GEMINI.md](GEMINI.md) for the complete list of scopes and guidelines.

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -317,11 +317,83 @@ Include the Apache 2.0 license header at the top of each file (update year as ne
 
 ## Git Commit Message Guidelines
 
-* Use conventional commits format (e.g., `feat:`, `fix:`, `docs:`, `chore:`).
-* For scope, refer to `.release-please-config.json` if available.
-* Add a rationale paragraph explaining the why and the what before listing changes.
-* Keep it short and simple.
+Use [Conventional Commits](https://www.conventionalcommits.org/) format with the
+package name as the scope. This ensures release-please correctly attributes
+commits to packages and generates accurate changelogs.
+
+### Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Commit Types
+
+| Type | Description |
+|------|-------------|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation only changes |
+| `style` | Changes that do not affect the meaning of the code |
+| `refactor` | A code change that neither fixes a bug nor adds a feature |
+| `perf` | A code change that improves performance |
+| `test` | Adding missing tests or correcting existing tests |
+| `build` | Changes that affect the build system or external dependencies |
+| `ci` | Changes to CI configuration files and scripts |
+| `chore` | Other changes that don't modify src or test files |
+
+### Commit Scopes (Package Names)
+
+**IMPORTANT**: Use the exact scope from the table below. These match the package
+names in `.release-please-config.json` and are used to generate release PRs.
+
+| Scope | Package/Directory | Description |
+|-------|-------------------|-------------|
+| `dotprompt` | `js/` | JavaScript/TypeScript library |
+| `dotpromptz` | `python/dotpromptz/` | Python dotpromptz package |
+| `dotpromptz-handlebars` | `python/handlebarrz/` | Python Handlebars bindings (PyPI: dotpromptz-handlebars) |
+| `dotprompt-go` | `go/` | Go implementation |
+| `dotprompt-rs` | `rs/` | Rust implementation |
+| `dotprompt-java` | `java/` | Java implementation |
+| `dotprompt-vscode` | `packages/vscode/` | VS Code extension |
+| `dotprompt-vim` | `packages/vim/` | Vim plugin |
+| `dotprompt-emacs` | `packages/emacs/` | Emacs mode |
+| `dotprompt-monaco` | `packages/monaco/` | Monaco editor integration |
+| `dotprompt-codemirror` | `packages/codemirror/` | CodeMirror integration |
+| `dotprompt-jetbrains` | `packages/jetbrains/` | JetBrains IDE plugin |
+| `tree-sitter-dotprompt` | `packages/treesitter/` | Tree-sitter grammar |
+| `promptly` | `packages/promptly/` | CLI tool for .prompt files |
+
+### Examples
+
+```bash
+# Feature in Python dotpromptz package
+feat(dotpromptz): add support for custom helpers
+
+# Bug fix in handlebarrz (Python Handlebars bindings)
+fix(dotpromptz-handlebars): correct template escaping behavior
+
+# Documentation for Go implementation
+docs(dotprompt-go): add usage examples to README
+
+# CI change for Rust
+ci(dotprompt-rs): add nightly toolchain testing
+
+# Cross-cutting change (no scope)
+chore: update dependencies across all packages
+```
+
+### Guidelines
+
+* Add a rationale paragraph in the body explaining the why and what.
+* Keep the subject line under 72 characters.
+* Use imperative mood ("add" not "added", "fix" not "fixed").
 * Do not include absolute file paths as links in commit messages.
+* Reference issue numbers in the footer (e.g., `Fixes #123`).
 
 ***
 


### PR DESCRIPTION
Standardizes package naming across release-please configuration to ensure
consistent component names for releases and changelogs. Adds comprehensive
commit message guidelines to help contributors use the correct scopes.

Changes:
- Rename release-please package keys to match published package names
- Add explicit `component` fields to all packages for tag consistency
- Add `promptly` CLI tool package to release-please config
- Create new git tags (dotpromptz-0.1.4, dotpromptz-handlebars-0.1.3)
  pointing to existing releases for release-please compatibility
- Remove problematic JetBrains XML extra-files config (no version element)
- Add "Git Commit Message Guidelines" section to GEMINI.md with:
  - Conventional Commits format specification
  - Complete table of commit scopes matching package names
  - Examples for each package type
- Add contributing section to README.md with scope summary table
- Remove unused bzlmod_lock_files from MODULE.bazel

Package name mapping (old → new):
- js → dotprompt
- python/dotpromptz → dotpromptz (component: dotpromptz)
- python/handlebarrz → dotpromptz-handlebars (component: dotpromptz-handlebars)
- go → dotprompt-go
- rs → dotprompt-rs
- java → dotprompt-java
- packages/vscode → dotprompt-vscode
- packages/vim → dotprompt-vim
- packages/emacs → dotprompt-emacs
- packages/monaco → dotprompt-monaco
- packages/codemirror → dotprompt-codemirror
- packages/jetbrains → dotprompt-jetbrains
- packages/treesitter → tree-sitter-dotprompt
- packages/promptly → promptly
