### PR TITLE
docs: add comprehensive API documentation for all language implementations

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,33 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Read the Docs configuration file for MkDocs
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+    golang: "1.23"
+  commands:
+    # Install D2 diagramming tool (required by mkdocs-d2-plugin)
+    - go install oss.terrastruct.com/d2@latest
+  jobs:
+    post_checkout:
+      # Ensure git history is available for versioning
+      - git fetch --unshallow || true
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    # Install the Python packages in editable mode for mkdocstrings
+    - method: pip
+      path: python/dotpromptz
+    - method: pip
+      path: python/handlebarrz
+    # Install documentation dependencies
+    - requirements: docs/requirements.txt

--- a/docs/api/go/index.md
+++ b/docs/api/go/index.md
@@ -1,0 +1,276 @@
+# Go API
+
+The `dotprompt` package is the Go implementation of the Dotprompt file format.
+
+## Installation
+
+```bash
+go get github.com/google/dotprompt/go/dotprompt
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/google/dotprompt/go/dotprompt"
+)
+
+func main() {
+    source := `
+---
+model: gemini-pro
+input:
+  schema:
+    name: string
+---
+Hello, {{name}}!
+`
+
+    dp := dotprompt.New()
+
+    rendered, err := dp.Render(context.Background(), source, dotprompt.DataArgument{
+        Input: map[string]any{"name": "World"},
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, msg := range rendered.Messages {
+        fmt.Printf("%s: %v\n", msg.Role, msg.Content)
+    }
+}
+```
+
+## Core Types
+
+### Dotprompt
+
+The main entry point for working with Dotprompt templates.
+
+```go
+// New creates a new Dotprompt instance with default options.
+func New(opts ...Option) *Dotprompt
+
+// NewWithOptions creates a new Dotprompt instance with the given options.
+func NewWithOptions(options DotpromptOptions) *Dotprompt
+```
+
+#### Options
+
+```go
+type DotpromptOptions struct {
+    DefaultModel    string
+    ModelConfigs    map[string]any
+    Helpers         map[string]HelperFn
+    Partials        map[string]string
+    Tools           map[string]ToolDefinition
+    ToolResolver    ToolResolver
+    Schemas         map[string]JsonSchema
+    SchemaResolver  SchemaResolver
+    PartialResolver PartialResolver
+}
+```
+
+### Methods
+
+#### Parse
+
+```go
+// Parse parses a Dotprompt template string into a ParsedPrompt.
+func (d *Dotprompt) Parse(source string) (*ParsedPrompt, error)
+```
+
+#### Compile
+
+```go
+// Compile compiles a template into a reusable PromptFunction.
+func (d *Dotprompt) Compile(ctx context.Context, source string) (PromptFunction, error)
+```
+
+#### Render
+
+```go
+// Render parses, compiles, and renders a template in one step.
+func (d *Dotprompt) Render(
+    ctx context.Context,
+    source string,
+    data DataArgument,
+    options ...PromptMetadata,
+) (*RenderedPrompt, error)
+```
+
+#### DefineHelper
+
+```go
+// DefineHelper registers a custom Handlebars helper.
+func (d *Dotprompt) DefineHelper(name string, fn HelperFn) *Dotprompt
+```
+
+#### DefinePartial
+
+```go
+// DefinePartial registers a partial template.
+func (d *Dotprompt) DefinePartial(name string, source string) *Dotprompt
+```
+
+#### DefineTool
+
+```go
+// DefineTool registers a tool definition.
+func (d *Dotprompt) DefineTool(definition ToolDefinition) *Dotprompt
+```
+
+## Types
+
+### ParsedPrompt
+
+```go
+type ParsedPrompt struct {
+    Template    string
+    Name        string
+    Description string
+    Variant     string
+    Version     string
+    Model       string
+    Config      any
+    Input       *PromptInputConfig
+    Output      *PromptOutputConfig
+    Tools       []string
+    ToolDefs    []ToolDefinition
+    Ext         map[string]map[string]any
+    Raw         map[string]any
+}
+```
+
+### RenderedPrompt
+
+```go
+type RenderedPrompt struct {
+    PromptMetadata
+    Messages []Message
+}
+```
+
+### Message
+
+```go
+type Message struct {
+    Role     Role
+    Content  []Part
+    Metadata map[string]any
+}
+
+type Role string
+
+const (
+    RoleUser   Role = "user"
+    RoleModel  Role = "model"
+    RoleTool   Role = "tool"
+    RoleSystem Role = "system"
+)
+```
+
+### Part
+
+```go
+type Part interface {
+    isPart()
+}
+
+type TextPart struct {
+    Text     string
+    Metadata map[string]any
+}
+
+type MediaPart struct {
+    Media    MediaContent
+    Metadata map[string]any
+}
+
+type MediaContent struct {
+    URL         string
+    ContentType string
+}
+
+type DataPart struct {
+    Data     map[string]any
+    Metadata map[string]any
+}
+```
+
+### DataArgument
+
+```go
+type DataArgument struct {
+    Input    map[string]any
+    Docs     []Document
+    Messages []Message
+    Context  map[string]any
+}
+```
+
+### ToolDefinition
+
+```go
+type ToolDefinition struct {
+    Name         string
+    Description  string
+    InputSchema  JsonSchema
+    OutputSchema JsonSchema
+}
+```
+
+## Stores
+
+### DirStore
+
+Load prompts from a filesystem directory.
+
+```go
+import "github.com/google/dotprompt/go/dotprompt"
+
+store := dotprompt.NewDirStore(dotprompt.DirStoreOptions{
+    Directory: "./prompts",
+})
+
+prompt, err := store.Load(ctx, "greeting", nil)
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+### DirStoreSync
+
+Synchronous version of DirStore.
+
+```go
+store := dotprompt.NewDirStoreSync(dotprompt.DirStoreOptions{
+    Directory: "./prompts",
+})
+
+prompt, err := store.Load("greeting", nil)
+```
+
+## Picoschema
+
+Convert Picoschema to JSON Schema.
+
+```go
+schema := map[string]any{
+    "name":  "string",
+    "age?": "integer, The person's age",
+}
+
+jsonSchema, err := dotprompt.PicoschemaToJSONSchema(ctx, schema, nil)
+```
+
+## External Documentation
+
+* [pkg.go.dev](https://pkg.go.dev/github.com/google/dotprompt/go/dotprompt)
+* [GitHub source](https://github.com/google/dotprompt/tree/main/go)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,48 @@
+# API Reference
+
+Dotprompt provides implementations in multiple languages. Each implementation
+follows the same specification and provides equivalent functionality.
+
+## Language Implementations
+
+| Language | Package | Status | Documentation |
+|----------|---------|--------|---------------|
+| [Python](python/dotpromptz.md) | `dotpromptz` | Stable | This site |
+| [TypeScript/JavaScript](typescript/index.md) | `dotprompt` | Stable | This site |
+| [Go](go/index.md) | `github.com/google/dotprompt/go/dotprompt` | Stable | This site |
+| [Rust](rust/index.md) | `dotprompt` | Stable | This site |
+| [Java](java/index.md) | `com.google.dotprompt` | Stable | This site |
+
+## Quick Links
+
+### Python
+
+* [dotpromptz](python/dotpromptz.md) - Core Python library
+* [handlebarrz](python/handlebarrz.md) - Handlebars templating engine
+
+### TypeScript/JavaScript
+
+* [dotprompt](typescript/index.md) - Core TypeScript library
+
+### Go
+
+* [dotprompt](go/index.md) - Core Go package
+
+### Rust
+
+* [dotprompt](rust/index.md) - Core Rust crate
+
+### Java
+
+* [com.google.dotprompt](java/index.md) - Core Java package
+
+## Cross-Language Compatibility
+
+All implementations are tested against the same specification files in the
+`spec/` directory. This ensures consistent behavior across languages for:
+
+* Template parsing and rendering
+* Picoschema to JSON Schema conversion
+* Helper functions (role, media, history, etc.)
+* Partial template resolution
+* Message history handling

--- a/docs/api/java/index.md
+++ b/docs/api/java/index.md
@@ -1,0 +1,347 @@
+# Java API
+
+The `com.google.dotprompt` package is the Java implementation of the Dotprompt
+file format.
+
+## Installation
+
+\=== "Maven"
+`xml     <dependency>       <groupId>com.google.dotprompt</groupId>       <artifactId>dotprompt</artifactId>       <version>0.1.0</version>     </dependency>
+    `
+
+\=== "Gradle (Kotlin)"
+`kotlin
+    implementation("com.google.dotprompt:dotprompt:0.1.0")
+    `
+
+\=== "Gradle (Groovy)"
+`groovy
+    implementation 'com.google.dotprompt:dotprompt:0.1.0'
+    `
+
+## Quick Start
+
+```java
+import com.google.dotprompt.Dotprompt;
+import com.google.dotprompt.DotpromptOptions;
+import com.google.dotprompt.models.DataArgument;
+import com.google.dotprompt.models.RenderedPrompt;
+
+import java.util.Map;
+
+public class Example {
+    public static void main(String[] args) {
+        String source = """
+            ---
+            model: gemini-pro
+            input:
+              schema:
+                name: string
+            ---
+            Hello, {{name}}!
+            """;
+
+        Dotprompt dotprompt = new Dotprompt();
+
+        DataArgument data = DataArgument.builder()
+            .input(Map.of("name", "World"))
+            .build();
+
+        RenderedPrompt rendered = dotprompt.render(source, data, null);
+
+        rendered.getMessages().forEach(message -> {
+            System.out.printf("%s: %s%n", message.getRole(), message.getContent());
+        });
+    }
+}
+```
+
+## Core Classes
+
+### Dotprompt
+
+The main entry point for working with Dotprompt templates.
+
+```java
+public class Dotprompt {
+    // Constructors
+    public Dotprompt();
+    public Dotprompt(DotpromptOptions options);
+
+    // Parsing
+    public ParsedPrompt parse(String source);
+
+    // Compilation
+    public PromptFunction compile(String source);
+    public PromptFunction compile(String source, PromptMetadata additionalMetadata);
+
+    // Rendering
+    public RenderedPrompt render(String source, DataArgument data);
+    public RenderedPrompt render(String source, DataArgument data, PromptMetadata options);
+
+    // Registration
+    public Dotprompt defineHelper(String name, HelperFn fn);
+    public Dotprompt definePartial(String name, String source);
+    public Dotprompt defineTool(ToolDefinition definition);
+}
+```
+
+### DotpromptOptions
+
+Builder for configuring a Dotprompt instance.
+
+```java
+DotpromptOptions options = DotpromptOptions.builder()
+    .defaultModel("gemini-pro")
+    .modelConfigs(Map.of(
+        "gemini-pro", Map.of("temperature", 0.7)
+    ))
+    .helpers(Map.of(
+        "uppercase", (params, options) -> params.get(0).toString().toUpperCase()
+    ))
+    .partials(Map.of(
+        "header", "Welcome to {{appName}}!"
+    ))
+    .build();
+
+Dotprompt dotprompt = new Dotprompt(options);
+```
+
+## Models
+
+### ParsedPrompt
+
+Result of parsing a Dotprompt template.
+
+```java
+public class ParsedPrompt {
+    public String getTemplate();
+    public String getName();
+    public String getDescription();
+    public String getVariant();
+    public String getVersion();
+    public String getModel();
+    public Object getConfig();
+    public PromptInputConfig getInput();
+    public PromptOutputConfig getOutput();
+    public List<String> getTools();
+    public List<ToolDefinition> getToolDefs();
+    public Map<String, Map<String, Object>> getExt();
+    public Map<String, Object> getRaw();
+}
+```
+
+### RenderedPrompt
+
+Result of rendering a Dotprompt template.
+
+```java
+public class RenderedPrompt extends PromptMetadata {
+    public List<Message> getMessages();
+}
+```
+
+### Message
+
+A single message in a conversation.
+
+```java
+public class Message {
+    public Role getRole();
+    public List<Part> getContent();
+    public Map<String, Object> getMetadata();
+}
+
+public enum Role {
+    USER("user"),
+    MODEL("model"),
+    TOOL("tool"),
+    SYSTEM("system");
+}
+```
+
+### Part
+
+Content within a message. Part is a sealed interface with several implementations:
+
+```java
+public sealed interface Part permits TextPart, MediaPart, DataPart,
+    ToolRequestPart, ToolResponsePart, PendingPart {
+}
+
+public record TextPart(String text, Map<String, Object> metadata) implements Part {}
+
+public record MediaPart(MediaContent media, Map<String, Object> metadata) implements Part {}
+
+public record MediaContent(String url, String contentType) {}
+
+public record DataPart(Map<String, Object> data, Map<String, Object> metadata) implements Part {}
+```
+
+### DataArgument
+
+Runtime data for rendering a template.
+
+```java
+public class DataArgument {
+    public static Builder builder();
+
+    public Map<String, Object> getInput();
+    public List<Document> getDocs();
+    public List<Message> getMessages();
+    public Map<String, Object> getContext();
+
+    public static class Builder {
+        public Builder input(Map<String, Object> input);
+        public Builder docs(List<Document> docs);
+        public Builder messages(List<Message> messages);
+        public Builder context(Map<String, Object> context);
+        public DataArgument build();
+    }
+}
+```
+
+### ToolDefinition
+
+```java
+public class ToolDefinition {
+    public String getName();
+    public String getDescription();
+    public Object getInputSchema();
+    public Object getOutputSchema();
+
+    public static Builder builder();
+}
+```
+
+## Stores
+
+### DirStore
+
+Load prompts from a filesystem directory (async).
+
+```java
+import com.google.dotprompt.store.DirStore;
+import com.google.dotprompt.store.DirStoreOptions;
+
+DirStore store = new DirStore(DirStoreOptions.builder()
+    .directory("./prompts")
+    .build());
+
+CompletableFuture<PromptData> future = store.load("greeting", null);
+PromptData prompt = future.join();
+```
+
+### DirStoreSync
+
+Synchronous version.
+
+```java
+import com.google.dotprompt.store.DirStoreSync;
+import com.google.dotprompt.store.DirStoreOptions;
+
+DirStoreSync store = new DirStoreSync(DirStoreOptions.builder()
+    .directory("./prompts")
+    .build());
+
+PromptData prompt = store.load("greeting", null);
+```
+
+## Resolvers
+
+### ToolResolver
+
+```java
+@FunctionalInterface
+public interface ToolResolver {
+    CompletableFuture<ToolDefinition> resolve(String name);
+}
+
+// Usage
+DotpromptOptions options = DotpromptOptions.builder()
+    .toolResolver(name -> CompletableFuture.supplyAsync(() -> {
+        // Look up tool definition
+        return loadToolFromDatabase(name);
+    }))
+    .build();
+```
+
+### SchemaResolver
+
+```java
+@FunctionalInterface
+public interface SchemaResolver {
+    CompletableFuture<Object> resolve(String name);
+}
+```
+
+### PartialResolver
+
+```java
+@FunctionalInterface
+public interface PartialResolver {
+    CompletableFuture<String> resolve(String name);
+}
+```
+
+## Picoschema
+
+Convert Picoschema to JSON Schema.
+
+```java
+import com.google.dotprompt.parser.Picoschema;
+
+Map<String, Object> schema = Map.of(
+    "name", "string",
+    "age?", "integer, The person's age"
+);
+
+Object jsonSchema = Picoschema.toJsonSchema(schema, null);
+```
+
+## Built-in Helpers
+
+| Helper | Description | Example |
+|--------|-------------|---------|
+| `role` | Set message role | `{{role "system"}}` |
+| `media` | Insert media content | `{{media url="..." contentType="image/png"}}` |
+| `history` | Insert message history | `{{history}}` |
+| `section` | Create a content section | `{{section "code"}}` |
+| `json` | Serialize to JSON | `{{json data indent=2}}` |
+| `ifEquals` | Conditional equality | `{{#ifEquals a b}}...{{/ifEquals}}` |
+| `unlessEquals` | Conditional inequality | `{{#unlessEquals a b}}...{{/unlessEquals}}` |
+
+## Kotlin Interoperability
+
+The Java library works seamlessly with Kotlin:
+
+```kotlin
+import com.google.dotprompt.Dotprompt
+import com.google.dotprompt.models.DataArgument
+
+fun main() {
+    val source = """
+        ---
+        model: gemini-pro
+        ---
+        Hello, {{name}}!
+    """.trimIndent()
+
+    val dotprompt = Dotprompt()
+
+    val data = DataArgument.builder()
+        .input(mapOf("name" to "World"))
+        .build()
+
+    val rendered = dotprompt.render(source, data, null)
+
+    rendered.messages.forEach { message ->
+        println("${message.role}: ${message.content}")
+    }
+}
+```
+
+## External Documentation
+
+* [Javadoc](https://javadoc.io/doc/com.google.dotprompt/dotprompt)
+* [GitHub source](https://github.com/google/dotprompt/tree/main/java)

--- a/docs/api/python/dotpromptz.md
+++ b/docs/api/python/dotpromptz.md
@@ -1,0 +1,124 @@
+# dotpromptz
+
+The `dotpromptz` package is the Python implementation of the Dotprompt file
+format—an executable prompt template format for Generative AI.
+
+## Installation
+
+```bash
+pip install dotpromptz
+```
+
+## Quick Start
+
+```python
+from dotpromptz import Dotprompt
+
+# Create a Dotprompt instance
+dp = Dotprompt()
+
+# Parse and render a prompt
+source = '''
+---
+model: gemini-pro
+input:
+  schema:
+    name: string
+---
+Hello, {{name}}!
+'''
+
+rendered = await dp.render(source, data={'input': {'name': 'World'}})
+```
+
+## Core Classes
+
+### Dotprompt
+
+::: dotpromptz.dotprompt.Dotprompt
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false
+
+## Parsing
+
+::: dotpromptz.parse
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false
+
+## Picoschema
+
+::: dotpromptz.picoschema
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false
+
+## Helpers
+
+::: dotpromptz.helpers
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false
+
+## Resolvers
+
+::: dotpromptz.resolvers
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false
+
+## Types
+
+::: dotpromptz.typing
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false
+
+## Stores
+
+::: dotpromptz.stores
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false
+
+## Errors
+
+::: dotpromptz.errors
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false
+
+## Utilities
+
+::: dotpromptz.util
+options:
+show\_root\_heading: false
+show\_source: true
+members\_order: source
+show\_docstring\_description: true
+show\_docstring\_examples: false

--- a/docs/api/python/handlebarrz.md
+++ b/docs/api/python/handlebarrz.md
@@ -1,0 +1,70 @@
+# handlebarrz
+
+The `handlebarrz` package (published as `dotpromptz-handlebars` on PyPI) provides
+Python bindings to the Handlebars templating engine via Rust FFI.
+
+## Installation
+
+```bash
+pip install dotpromptz-handlebars
+```
+
+## Quick Start
+
+```python
+from handlebarrz import Handlebars
+
+# Create a Handlebars instance
+hbs = Handlebars()
+
+# Register and render a template
+hbs.register_template('greeting', 'Hello, {{name}}!')
+result = hbs.render('greeting', {'name': 'World'})
+print(result)  # "Hello, World!"
+```
+
+## Features
+
+- Block helpers with inverse sections (`else` blocks)
+- Built-in helpers (`each`, `if`, `unless`, `with`, `lookup`, `log`)
+- Context navigation (`this`, `../parent`, `@root`)
+- Custom helper functions
+- HTML escaping options and customization
+- Partial templates and blocks
+- Strict mode for missing fields
+- Subexpressions and parameter literals
+- Whitespace control with `~` operator
+
+## Module Reference
+
+::: handlebarrz
+    options:
+      show_root_heading: true
+      show_source: true
+      members_order: source
+
+## Template Class
+
+::: handlebarrz.Template
+    options:
+      show_root_heading: true
+      show_source: true
+      members_order: source
+      heading_level: 3
+
+## Escape Functions
+
+::: handlebarrz.EscapeFunction
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3
+
+## Helper Options
+
+::: handlebarrz.HelperOptions
+    options:
+      show_root_heading: true
+      show_source: true
+      members_order: source
+      heading_level: 3

--- a/docs/api/rust/index.md
+++ b/docs/api/rust/index.md
@@ -1,0 +1,301 @@
+# Rust API
+
+The `dotprompt` crate is the Rust implementation of the Dotprompt file format.
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+dotprompt = "0.1"
+```
+
+## Quick Start
+
+```rust
+use dotprompt::{Dotprompt, DataArgument, RenderedPrompt};
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+---
+model: gemini-pro
+input:
+  schema:
+    name: string
+---
+Hello, {{name}}!
+"#;
+
+    let dotprompt = Dotprompt::new(None);
+
+    let mut data = DataArgument::default();
+    data.input = Some(json!({"name": "World"}));
+
+    let rendered: RenderedPrompt = dotprompt.render(source, data, None)?;
+
+    for message in &rendered.messages {
+        println!("{:?}: {:?}", message.role, message.content);
+    }
+
+    Ok(())
+}
+```
+
+## Core Types
+
+### Dotprompt
+
+The main entry point for working with Dotprompt templates.
+
+```rust
+impl Dotprompt {
+    /// Create a new Dotprompt instance with optional configuration.
+    pub fn new(options: Option<DotpromptOptions>) -> Self;
+
+    /// Parse a template string into a ParsedPrompt.
+    pub fn parse(&self, source: &str) -> Result<ParsedPrompt, DotpromptError>;
+
+    /// Compile a template into a reusable PromptFunction.
+    pub fn compile(&self, source: &str) -> Result<PromptFunction, DotpromptError>;
+
+    /// Parse, compile, and render a template in one step.
+    pub fn render(
+        &self,
+        source: &str,
+        data: DataArgument,
+        options: Option<PromptMetadata>,
+    ) -> Result<RenderedPrompt, DotpromptError>;
+
+    /// Register a custom Handlebars helper.
+    pub fn define_helper<F>(&mut self, name: &str, helper: F) -> &mut Self
+    where
+        F: Fn(&[Value], &HelperOptions) -> String + Send + Sync + 'static;
+
+    /// Register a partial template.
+    pub fn define_partial(&mut self, name: &str, source: &str) -> &mut Self;
+
+    /// Register a tool definition.
+    pub fn define_tool(&mut self, definition: ToolDefinition) -> &mut Self;
+}
+```
+
+### DotpromptOptions
+
+```rust
+pub struct DotpromptOptions {
+    pub default_model: Option<String>,
+    pub model_configs: Option<HashMap<String, Value>>,
+    pub helpers: Option<HashMap<String, HelperFn>>,
+    pub partials: Option<HashMap<String, String>>,
+    pub tools: Option<HashMap<String, ToolDefinition>>,
+    pub tool_resolver: Option<Box<dyn ToolResolver>>,
+    pub schemas: Option<HashMap<String, JsonSchema>>,
+    pub schema_resolver: Option<Box<dyn SchemaResolver>>,
+    pub partial_resolver: Option<Box<dyn PartialResolver>>,
+}
+```
+
+## Types
+
+### ParsedPrompt
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParsedPrompt {
+    pub template: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub variant: Option<String>,
+    pub version: Option<String>,
+    pub model: Option<String>,
+    pub config: Option<Value>,
+    pub input: Option<PromptInputConfig>,
+    pub output: Option<PromptOutputConfig>,
+    pub tools: Option<Vec<String>>,
+    pub tool_defs: Option<Vec<ToolDefinition>>,
+    pub ext: Option<HashMap<String, HashMap<String, Value>>>,
+    pub raw: Option<HashMap<String, Value>>,
+}
+```
+
+### RenderedPrompt
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RenderedPrompt {
+    #[serde(flatten)]
+    pub metadata: PromptMetadata,
+    pub messages: Vec<Message>,
+}
+```
+
+### Message
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: Role,
+    pub content: Vec<Part>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    User,
+    Model,
+    Tool,
+    System,
+}
+```
+
+### Part
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Part {
+    Text(TextPart),
+    Media(MediaPart),
+    Data(DataPart),
+    ToolRequest(ToolRequestPart),
+    ToolResponse(ToolResponsePart),
+    Pending(PendingPart),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextPart {
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MediaPart {
+    pub media: MediaContent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MediaContent {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+}
+```
+
+### DataArgument
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DataArgument {
+    pub input: Option<Value>,
+    pub docs: Option<Vec<Document>>,
+    pub messages: Option<Vec<Message>>,
+    pub context: Option<HashMap<String, Value>>,
+}
+```
+
+### ToolDefinition
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub input_schema: JsonSchema,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<JsonSchema>,
+}
+```
+
+## Error Handling
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum DotpromptError {
+    #[error("Parse error: {0}")]
+    ParseError(String),
+
+    #[error("Render error: {0}")]
+    RenderError(String),
+
+    #[error("Schema error: {0}")]
+    SchemaError(String),
+
+    #[error("Tool not found: {0}")]
+    ToolNotFound(String),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+```
+
+## Stores
+
+### DirStore
+
+Load prompts from a filesystem directory.
+
+```rust
+use dotprompt::stores::{DirStore, DirStoreOptions, PromptStore};
+
+let store = DirStore::new(DirStoreOptions {
+    directory: "./prompts".into(),
+});
+
+let prompt = store.load("greeting", None).await?;
+```
+
+### DirStoreSync
+
+Synchronous version.
+
+```rust
+use dotprompt::stores::{DirStoreSync, DirStoreOptions, PromptStoreSync};
+
+let store = DirStoreSync::new(DirStoreOptions {
+    directory: "./prompts".into(),
+});
+
+let prompt = store.load("greeting", None)?;
+```
+
+## Picoschema
+
+Convert Picoschema to JSON Schema.
+
+```rust
+use dotprompt::picoschema::picoschema_to_json_schema;
+use serde_json::json;
+
+let schema = json!({
+    "name": "string",
+    "age?": "integer, The person's age"
+});
+
+let json_schema = picoschema_to_json_schema(schema, None).await?;
+```
+
+## Built-in Helpers
+
+| Helper | Description | Example |
+|--------|-------------|---------|
+| `role` | Set message role | `{{role "system"}}` |
+| `media` | Insert media content | `{{media url="..." contentType="image/png"}}` |
+| `history` | Insert message history | `{{history}}` |
+| `section` | Create a content section | `{{section "code"}}` |
+| `json` | Serialize to JSON | `{{json data indent=2}}` |
+| `ifEquals` | Conditional equality | `{{#ifEquals a b}}...{{/ifEquals}}` |
+| `unlessEquals` | Conditional inequality | `{{#unlessEquals a b}}...{{/unlessEquals}}` |
+
+## External Documentation
+
+* [docs.rs](https://docs.rs/dotprompt)
+* [crates.io](https://crates.io/crates/dotprompt)
+* [GitHub source](https://github.com/google/dotprompt/tree/main/rs)

--- a/docs/api/typescript/index.md
+++ b/docs/api/typescript/index.md
@@ -1,0 +1,254 @@
+# TypeScript/JavaScript API
+
+The `dotprompt` package is the canonical TypeScript/JavaScript implementation
+of the Dotprompt file format.
+
+## Installation
+
+\=== "npm"
+`bash
+    npm install dotprompt
+    `
+
+\=== "pnpm"
+`bash
+    pnpm add dotprompt
+    `
+
+\=== "yarn"
+`bash
+    yarn add dotprompt
+    `
+
+## Quick Start
+
+```typescript
+import { Dotprompt } from 'dotprompt';
+
+// Create a Dotprompt instance
+const dotprompt = new Dotprompt();
+
+// Parse and render a prompt
+const source = `
+---
+model: gemini-pro
+input:
+  schema:
+    name: string
+---
+Hello, {{name}}!
+`;
+
+const rendered = await dotprompt.render(source, {
+  input: { name: 'World' }
+});
+
+console.log(rendered.messages);
+```
+
+## Core Classes
+
+### Dotprompt
+
+The main entry point for working with Dotprompt templates.
+
+```typescript
+import { Dotprompt } from 'dotprompt';
+
+const dp = new Dotprompt({
+  defaultModel: 'gemini-pro',
+  helpers: {
+    uppercase: (params) => String(params[0]).toUpperCase(),
+  },
+  partials: {
+    header: 'Welcome to {{appName}}!',
+  },
+});
+```
+
+#### Constructor Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `defaultModel` | `string` | Default model to use when not specified in template |
+| `modelConfigs` | `Record<string, ModelConfig>` | Model-specific configurations |
+| `helpers` | `Record<string, HelperFn>` | Custom Handlebars helpers |
+| `partials` | `Record<string, string>` | Partial templates |
+| `tools` | `Record<string, ToolDefinition>` | Static tool definitions |
+| `toolResolver` | `ToolResolver` | Dynamic tool resolution function |
+| `schemas` | `Record<string, JsonSchema>` | Static schema definitions |
+| `schemaResolver` | `SchemaResolver` | Dynamic schema resolution function |
+| `partialResolver` | `PartialResolver` | Dynamic partial resolution function |
+
+#### Methods
+
+##### `parse(source: string): ParsedPrompt`
+
+Parse a Dotprompt template string into a structured object.
+
+```typescript
+const parsed = dp.parse(source);
+console.log(parsed.template);  // The Handlebars template
+console.log(parsed.model);     // The model name
+console.log(parsed.input);     // Input schema configuration
+```
+
+##### `compile(source: string): Promise<PromptFunction>`
+
+Compile a template into a reusable render function.
+
+```typescript
+const renderFn = await dp.compile(source);
+const result = await renderFn({ input: { name: 'World' } });
+```
+
+##### `render(source: string, data: DataArgument): Promise<RenderedPrompt>`
+
+Parse, compile, and render a template in one step.
+
+```typescript
+const rendered = await dp.render(source, {
+  input: { name: 'World' },
+  messages: previousMessages,  // Optional history
+});
+```
+
+##### `defineHelper(name: string, fn: HelperFn): Dotprompt`
+
+Register a custom Handlebars helper.
+
+```typescript
+dp.defineHelper('shout', (params) => {
+  return String(params[0]).toUpperCase() + '!';
+});
+```
+
+##### `definePartial(name: string, source: string): Dotprompt`
+
+Register a partial template.
+
+```typescript
+dp.definePartial('signature', 'Best regards,\n{{author}}');
+```
+
+##### `defineTool(definition: ToolDefinition): Dotprompt`
+
+Register a tool definition.
+
+```typescript
+dp.defineTool({
+  name: 'calculator',
+  description: 'Perform calculations',
+  inputSchema: { type: 'object', properties: { expression: { type: 'string' } } },
+});
+```
+
+## Types
+
+### ParsedPrompt
+
+Result of parsing a Dotprompt template.
+
+```typescript
+interface ParsedPrompt<T = any> {
+  template: string;
+  name?: string;
+  description?: string;
+  variant?: string;
+  version?: string;
+  model?: string;
+  config?: T;
+  input?: PromptInputConfig;
+  output?: PromptOutputConfig;
+  tools?: string[];
+  toolDefs?: ToolDefinition[];
+  ext?: Record<string, Record<string, any>>;
+  raw?: Record<string, any>;
+}
+```
+
+### RenderedPrompt
+
+Result of rendering a Dotprompt template.
+
+```typescript
+interface RenderedPrompt<T = any> extends PromptMetadata<T> {
+  messages: Message[];
+}
+```
+
+### Message
+
+A single message in a conversation.
+
+```typescript
+interface Message {
+  role: 'user' | 'model' | 'tool' | 'system';
+  content: Part[];
+  metadata?: Record<string, any>;
+}
+```
+
+### Part
+
+Content within a message.
+
+```typescript
+type Part = TextPart | MediaPart | DataPart | ToolRequestPart | ToolResponsePart | PendingPart;
+
+interface TextPart {
+  text: string;
+  metadata?: Record<string, any>;
+}
+
+interface MediaPart {
+  media: {
+    url: string;
+    contentType?: string;
+  };
+  metadata?: Record<string, any>;
+}
+```
+
+### DataArgument
+
+Runtime data for rendering a template.
+
+```typescript
+interface DataArgument<T = Record<string, any>> {
+  input?: T;
+  docs?: Document[];
+  messages?: Message[];
+  context?: Record<string, any>;
+}
+```
+
+## Built-in Helpers
+
+| Helper | Description | Example |
+|--------|-------------|---------|
+| `role` | Set message role | `{{role "system"}}` |
+| `media` | Insert media content | `{{media url="..." contentType="image/png"}}` |
+| `history` | Insert message history | `{{history}}` |
+| `section` | Create a content section | `{{section "code"}}` |
+| `json` | Serialize to JSON | `{{json data indent=2}}` |
+| `ifEquals` | Conditional equality | `{{#ifEquals a b}}...{{/ifEquals}}` |
+| `unlessEquals` | Conditional inequality | `{{#unlessEquals a b}}...{{/unlessEquals}}` |
+
+## Stores
+
+### DirStore
+
+Load prompts from a directory.
+
+```typescript
+import { DirStore } from 'dotprompt/stores';
+
+const store = new DirStore({ directory: './prompts' });
+const prompt = await store.load('greeting');
+```
+
+## External Documentation
+
+* [npm package](https://www.npmjs.com/package/dotprompt)
+* [GitHub source](https://github.com/google/dotprompt/tree/main/js)

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -106,11 +106,30 @@ unless there is a compelling, documented reason.
 
 * **Format**: Write comprehensive Google-style docstrings for modules, classes,
   and functions.
+* **Content**:
+  * **Explain Concepts**: Explain the terminology and concepts used in the
+    code to someone unfamiliar with the code so that first timers can easily
+    understand these ideas.
+  * **Visuals**: Prefer using tabular format and ASCII diagrams in the
+    docstrings to break down complex concepts or list terminology.
 * **Required Sections**:
   * **Overview**: One-liner description followed by rationale.
+  * **Key Operations**: Purpose of the component.
   * **Args/Attributes**: Required for callables/classes.
   * **Returns**: Required for callables.
   * **Examples**: Required for user-facing API.
+  * **Caveats**: Known limitations or edge cases.
+* **References**:
+  * Use the Dotprompt specification and documentation as the source of truth
+    for the API and concepts.
+  * When uncertain about API or concepts, refer to the JavaScript (canonical)
+    implementation.
+* Keep examples in documentation and docstrings simple.
+* Add links to relevant documentation on the Web or elsewhere in docstrings.
+* Add ASCII diagrams to illustrate relationships, flows, and concepts.
+* Always update module docstrings and function docstrings when updating code
+  to reflect updated reality of any file you add or modify.
+* Scan documentation for every module you edit and keep it up-to-date.
 
 ***
 

--- a/docs/extending/picoschema.md
+++ b/docs/extending/picoschema.md
@@ -1,0 +1,124 @@
+# Picoschema Reference
+
+Picoschema is a compact, YAML-optimized schema definition format specifically
+designed to aid in describing structured data for better understanding by
+generative AI models. Whenever a schema is accepted by dotprompt in its
+frontmatter, the Picoschema format is accepted.
+
+Picoschema compiles to JSON Schema and is a subset of JSON Schema capabilities.
+
+## Example
+
+```yaml
+product:
+  id: string, Unique identifier for the product
+  description?: string, Optional detailed description of the product
+  price: number, Current price of the product
+  inStock: integer, Number of items in stock
+  isActive: boolean, Whether the product is currently available
+  category(enum, Main category of the product): [ELECTRONICS, CLOTHING, BOOKS, HOME]
+  tags(array, List of tags associated with the product): string
+  primaryImage:
+    url: string, URL of the primary product image
+    altText: string, Alternative text for the image
+  attributes(object, Custom attributes of the product):
+    (*): any, Allow any attribute name with any value
+  variants?(array, List of product variant objects):
+    id: string, Unique identifier for the variant
+    name: string, Name of the variant
+    price: number, Price of the variant
+```
+
+## Basic Types
+
+Picoschema supports the following scalar types:
+
+| Type | Syntax | Description | Example |
+|------|--------|-------------|---------|
+| `string` | `fieldName: string[, description]` | String value | `title: string` |
+| `number` | `fieldName: number[, description]` | Numeric value (int/float) | `price: number` |
+| `integer` | `fieldName: integer[, description]` | Integer value | `age: integer` |
+| `boolean` | `fieldName: boolean[, description]` | Boolean value | `isActive: boolean` |
+| `null` | `fieldName: null[, description]` | Null value | `emptyField: null` |
+| `any` | `fieldName: any[, description]` | Any type | `data: any` |
+
+## Optional Fields
+
+* **Syntax:** Add `?` after the field name
+* **Description:** Marks a field as optional. Optional fields are also automatically nullable.
+* **Example:** `subtitle?: string`
+
+## Field Descriptions
+
+* **Syntax:** Add a comma followed by the description after the type
+* **Description:** Provides additional information about the field
+* **Example:** `date: string, the date of publication e.g. '2024-04-09'`
+
+## Arrays
+
+* **Syntax:** `fieldName(array[, description]): elementType`
+* **Description:** Defines an array of a specific type
+* **Example:** `tags(array, string list of tags): string`
+
+## Objects
+
+* **Syntax:** `fieldName(object[, description]):`
+* **Description:** Defines a nested object structure
+* **Example:**
+
+```yaml
+address(object, the address of the recipient):
+  address1: string, street address
+  address2?: string, optional apartment/unit number etc.
+  city: string
+  state: string
+```
+
+## Enums
+
+* **Syntax:** `fieldName(enum[, description]): [VALUE1, VALUE2, ...]`
+* **Description:** Defines a field with a fixed set of possible values
+* **Example:** `status(enum): [PENDING, APPROVED, REJECTED]`
+
+## Wildcard Fields
+
+* **Syntax:** `(*): type[, description]`
+* **Description:** Allows additional properties of a specified type in an object
+* **Example:** `(*): string`
+
+## Additional Notes
+
+1. By default, all fields are required unless marked as optional with `?`.
+2. Objects defined using Picoschema do not allow additional properties unless a wildcard `(*)` is added.
+3. Optional fields are automatically made nullable in the resulting JSON Schema.
+4. The `any` type results in an empty schema `{}` in JSON Schema, allowing any value.
+
+## Eject to JSON Schema
+
+Picoschema automatically detects if a schema is already in JSON Schema format.
+If the top-level schema contains a `type` property with values like "object",
+"array", or any of the scalar types, it's treated as JSON Schema.
+
+You can also explicitly use JSON Schema by defining `{"type": "object"}` at the
+top level. For example:
+
+```handlebars
+---
+output:
+  schema:
+    type: object # this is now JSON Schema
+    properties:
+      field1: {type: string, description: A sample field}
+---
+```
+
+## Error Handling
+
+Picoschema will throw errors in the following cases:
+
+* If an unsupported scalar type is used
+* If the schema contains values that are neither objects nor strings
+* If parenthetical types other than 'object' or 'array' are used (except for 'enum')
+
+These error checks ensure that the Picoschema is well-formed and can be
+correctly translated to JSON Schema.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Documentation dependencies for MkDocs and ReadTheDocs
+# These are installed by ReadTheDocs when building documentation.
+
+mkdocs>=1.6.0
+mkdocs-material>=9.5.0
+mkdocs-autorefs>=1.0.0
+mkdocs-d2-plugin>=1.3.0
+mkdocs-literate-nav>=0.6.0
+mkdocs-mermaid2-plugin>=1.1.0
+mkdocs-minify-plugin>=0.8.0
+mkdocstrings[python]>=0.27.0
+
+# Required by mkdocstrings for Python API documentation
+griffe>=1.0.0
+
+# Required by the Python packages being documented
+pydantic>=2.10.0
+pyyaml>=6.0.0
+structlog>=25.0.0
+anyio>=4.9.0
+aiofiles>=24.1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,9 @@ theme:
 markdown_extensions:
   - admonition
   - attr_list
+  - toc:
+      permalink: true
+      toc_depth: 3
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.highlight:
@@ -54,7 +57,35 @@ plugins:
   - tags
   - mermaid2
   - search
-  - mkdocstrings
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths:
+            - python/dotpromptz/src
+            - python/handlebarrz/src
+          options:
+            docstring_style: google
+            docstring_options:
+              ignore_init_summary: true
+            merge_init_into_class: true
+            show_root_heading: true
+            show_source: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            signature_crossrefs: true
+            # Prevent docstring headings from polluting the TOC
+            docstring_section_style: spacy
+            heading_level: 3
+            # Only show the summary/first line of module docstrings
+            show_docstring_description: true
+            show_docstring_examples: false
+            show_docstring_other_parameters: true
+            show_docstring_parameters: true
+            show_docstring_raises: true
+            show_docstring_returns: true
+            show_docstring_warns: true
+            show_docstring_yields: true
   - minify:
       minify_html: true
       minify_js: true
@@ -62,6 +93,31 @@ plugins:
       htmlmin_opts:
         remove_comments: true
       cache_safe: true
+nav:
+  - Home: index.md
+  - Extending:
+    - extending/index.md
+    - Specification: extending/specification.md
+    - Picoschema: extending/picoschema.md
+  - API Reference:
+    - api/index.md
+    - Python:
+      - dotpromptz: api/python/dotpromptz.md
+      - handlebarrz: api/python/handlebarrz.md
+    - TypeScript/JavaScript: api/typescript/index.md
+    - Go: api/go/index.md
+    - Rust: api/rust/index.md
+    - Java: api/java/index.md
+  - Contributing:
+    - contributing/index.md
+    - Coding Guidelines: contributing/coding_guidelines.md
+    - Git Workflow: contributing/git_workflow.md
+    - Releases: contributing/releases.md
+    - Packaging Rust: contributing/packagin_rust.md
+    - Troubleshooting: contributing/troubleshooting.md
+  - Design:
+    - Promptly: design/promptly.md
+
 extra:
   social:
     - icon: fontawesome/brands/github

--- a/python/dotpromptz/src/dotpromptz/__init__.py
+++ b/python/dotpromptz/src/dotpromptz/__init__.py
@@ -14,13 +14,141 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Dotpromptz implements the .prompt templates for Python."""
+"""Dotpromptz: Executable prompt templates for Python.
+
+Dotpromptz is the Python implementation of the Dotprompt file format—an executable
+prompt template format for Generative AI. It provides a structured way to define,
+manage, and render prompts with metadata, schemas, tools, and templating.
+
+## What is Dotprompt?
+
+Dotprompt files (`.prompt`) combine YAML frontmatter metadata with Handlebars
+templates to create self-contained, executable prompt definitions:
+
+```
++---------------------------+
+|     YAML Frontmatter      |  <- Model config, schemas, tools
+|---------------------------|
+|                           |
+|   Handlebars Template     |  <- Dynamic prompt with variables
+|                           |
++---------------------------+
+```
+
+## Key Concepts
+
+| Concept          | Description                                                      |
+|------------------|------------------------------------------------------------------|
+| **Frontmatter**  | YAML metadata block at the top of `.prompt` files (model,        |
+|                  | schemas, tools, config)                                          |
+| **Template**     | Handlebars template body with variables, helpers, and partials   |
+| **Picoschema**   | Compact schema format that compiles to JSON Schema               |
+| **Partials**     | Reusable template fragments (prefixed with `_` in filenames)     |
+| **Helpers**      | Custom Handlebars functions (`{{role}}`, `{{media}}`, etc.)      |
+| **Resolvers**    | Functions to dynamically resolve tools, schemas, and partials    |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         Dotprompt                               │
+│  (Main entry point - compiles and renders prompt templates)     │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│  │    parse     │  │  picoschema  │  │      resolvers       │  │
+│  │  (YAML +     │  │  (Schema     │  │  (Tools, schemas,    │  │
+│  │   template)  │  │   compiler)  │  │   partials lookup)   │  │
+│  └──────────────┘  └──────────────┘  └──────────────────────┘  │
+│                                                                 │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│  │   helpers    │  │    stores    │  │      handlebarrz     │  │
+│  │  (Built-in   │  │  (Prompt     │  │  (Handlebars engine  │  │
+│  │   functions) │  │   storage)   │  │   via Rust FFI)      │  │
+│  └──────────────┘  └──────────────┘  └──────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+```python
+from dotpromptz import Dotprompt
+
+# Create a Dotprompt instance
+dp = Dotprompt()
+
+# Parse and render a prompt
+source = '''
+---
+model: gemini-pro
+input:
+  schema:
+    name: string
+---
+Hello, {{name}}! How can I help you today?
+'''
+
+rendered = await dp.render(source, data={'input': {'name': 'Alice'}})
+
+# Access rendered messages
+for message in rendered.messages:
+    print(f'{message.role}: {message.content}')
+```
+
+## Example `.prompt` File
+
+```handlebars
+---
+model: googleai/gemini-1.5-pro
+input:
+  schema:
+    topic: string, The topic to explain
+    level: string, Expertise level (beginner, intermediate, advanced)
+output:
+  format: json
+  schema:
+    explanation: string, Clear explanation of the topic
+    examples(array): string, Illustrative examples
+---
+
+{{role "system"}}
+You are an expert educator who adapts explanations to the learner's level.
+
+{{role "user"}}
+Please explain {{topic}} for someone at the {{level}} level.
+Provide clear examples to illustrate key points.
+```
+
+## Module Structure
+
+| Module          | Purpose                                              |
+|-----------------|------------------------------------------------------|
+| `dotprompt`     | Main `Dotprompt` class for compiling/rendering       |
+| `parse`         | YAML frontmatter extraction and message parsing      |
+| `picoschema`    | Picoschema to JSON Schema compilation                |
+| `helpers`       | Built-in Handlebars helpers (`role`, `media`, etc.)  |
+| `resolvers`     | Async resolution of tools, schemas, and partials     |
+| `stores`        | Filesystem-based prompt storage (`DirStore`)         |
+| `typing`        | Pydantic models and type definitions                 |
+| `errors`        | Custom exception classes                             |
+
+## See Also
+
+- Dotprompt specification: https://github.com/google/dotprompt
+- Handlebars templating: https://handlebarsjs.com
+- JSON Schema: https://json-schema.org
+"""
 
 from .dotprompt import Dotprompt
 
 
 def package_name() -> str:
-    """Stub function to test imports."""
+    """Return the package name for smoke testing.
+
+    Returns:
+        The string 'dotpromptz'.
+    """
     return 'dotpromptz'
 
 

--- a/python/dotpromptz/src/dotpromptz/picoschema.py
+++ b/python/dotpromptz/src/dotpromptz/picoschema.py
@@ -14,152 +14,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Picoschema parser and related helpers.
+"""Picoschema parser and JSON Schema compiler.
 
-Picoschema is a compact, YAML-optimized schema definition format specifically
-designed to aid in describing structured data for better understanding by
-generative AI models. Whenever a schema is accepted by dotprompt in its
-frontmatter, the Picoschema format is accepted.
+Picoschema is a compact, YAML-optimized schema definition format designed for
+describing structured data in generative AI prompts. It compiles to JSON Schema.
 
-Picoschema compiles to JSON Schema and is a subset of JSON Schema capabilities.
+Key Features:
+    - Basic types: string, number, integer, boolean, null, any
+    - Optional fields with `?` suffix (e.g., `name?: string`)
+    - Inline descriptions with comma separator (e.g., `age: integer, User's age`)
+    - Arrays: `tags(array): string`
+    - Nested objects: `address(object): ...`
+    - Enums: `status(enum): [PENDING, APPROVED, REJECTED]`
+    - Wildcards: `(*): any` for additional properties
 
-## Example:
+Example:
+    ```yaml
+    product:
+      id: string, Unique identifier
+      price: number, Current price
+      tags(array): string
+      category(enum): [ELECTRONICS, CLOTHING]
+    ```
 
-```yaml
-product:
-  id: string, Unique identifier for the product
-  description?: string, Optional detailed description of the product
-  price: number, Current price of the product
-  inStock: integer, Number of items in stock
-  isActive: boolean, Whether the product is currently available
-  category(enum, Main category of the product): [ELECTRONICS, CLOTHING, BOOKS, HOME]
-  tags(array, List of tags associated with the product): string
-  primaryImage:
-    url: string, URL of the primary product image
-    altText: string, Alternative text for the image
-  attributes(object, Custom attributes of the product):
-    (*): any, Allow any attribute name with any value
-  variants?(array, List of product variant objects):
-    id: string, Unique identifier for the variant
-    name: string, Name of the variant
-    price: number, Price of the variant
-```
-
-## Picoschema Reference
-
-### Basic Types
-
-Picoschema supports the following scalar types:
-
-#### **string**
-- **Syntax:** `fieldName: string[, optional description]`
-- **Description:** Represents a string value.
-- **Example:** `title: string`
-
-#### **number**
-- **Syntax:** `fieldName: number[, optional description]`
-- **Description:** Represents a numeric value (integer or float).
-- **Example:** `price: number`
-
-#### **integer**
-- **Syntax:** `fieldName: integer[, optional description]`
-- **Description:** Represents an integer value.
-- **Example:** `age: integer`
-
-#### **boolean**
-- **Syntax:** `fieldName: boolean[, optional description]`
-- **Description:** Represents a boolean value.
-- **Example:** `isActive: boolean`
-
-#### **null**
-- **Syntax:** `fieldName: null[, optional description]`
-- **Description:** Represents a null value.
-- **Example:** `emptyField: null`
-
-#### **any**
-- **Syntax:** `fieldName: any[, optional description]`
-- **Description:** Represents a value of any type.
-- **Example:** `data: any`
-
-### Optional Fields
-
-- **Syntax:** Add `?` after the field name.
-- **Description:** Marks a field as optional. Optional fields are also automatically nullable.
-- **Example:** `subtitle?: string`
-
-### Field Descriptions
-
-- **Syntax:** Add a comma followed by the description after the type.
-- **Description:** Provides additional information about the field.
-- **Example:** `date: string, the date of publication e.g. '2024-04-09'`
-
-### Arrays
-
-- **Syntax:** `fieldName(array[, optional description]): elementType`
-- **Description:** Defines an array of a specific type.
-- **Example:** `tags(array, string list of tags): string`
-
-### Objects
-
-- **Syntax:** `fieldName(object[, optional description]):`
-- **Description:** Defines a nested object structure.
-- **Example:**
-  ```yaml
-  address(object, the address of the recipient):
-    address1: string, street address
-    address2?: string, optional apartment/unit number etc.
-    city: string
-    state: string
-  ```
-
-### Enums
-
-- **Syntax:** `fieldName(enum[, optional description]): [VALUE1, VALUE2, ...]`
-- **Description:** Defines a field with a fixed set of possible values.
-- **Example:** `status(enum): [PENDING, APPROVED, REJECTED]`
-
-### Wildcard Fields
-
-- **Syntax:** `(*): type[, optional description]`
-- **Description:** Allows additional properties of a specified type in an object.
-- **Example:** `(*): string`
-
-### Additional Notes
-
-1. By default, all fields are required unless marked as optional with `?`.
-2. Objects defined using Picoschema do not allow additional properties unless a wildcard `(*)` is added.
-3. Optional fields are automatically made nullable in the resulting JSON Schema.
-4. The `any` type results in an empty schema `{}` in JSON Schema, allowing any value.
-
-## Eject to JSON Schema
-
-Picoschema automatically detects if a schema is already in JSON Schema format.
-If the top-level schema contains a `type` property with values like "object",
-"array", or any of the scalar types, it's treated as JSON Schema.
-
-You can also explicitly use JSON Schema by defining `{"type": "object"}` at the
-top level. For example:
-
-```handlebars
----
-output:
-  schema:
-    type: object # this is now JSON Schema
-    properties:
-      field1: {type: string, description: A sample field}
----
-```
-
-## Error Handling
-
-Picoschema will throw errors in the following cases:
-
-1. If an unsupported scalar type is used.
-2. If the schema contains values that are neither objects nor strings.
-3. If parenthetical types other than 'object' or 'array' are used (except for 'enum').
-
-These error checks ensure that the Picoschema is well-formed and can be
-correctly translated to JSON Schema.
+See Also:
+    Full Picoschema reference: https://google.github.io/dotprompt/extending/picoschema/
 """
 
 import re

--- a/scripts/add_license
+++ b/scripts/add_license
@@ -38,10 +38,13 @@ fi
 
 # NOTE: If you edit the ignore patterns, make sure to update the ignore patterns
 # in the corresponding check_license script.
+CURRENT_YEAR=$(date +%Y)
+
 $HOME/go/bin/addlicense \
   -c "Google LLC" \
   -s \
   -l apache \
+  -y "$CURRENT_YEAR" \
   -ignore '**/.dist/**/*' \
   -ignore '**/.eggs/**/*' \
   -ignore '**/.idea/**/*' \

--- a/scripts/serve_docs
+++ b/scripts/serve_docs
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Serves the MkDocs documentation locally with live reload.
+# Usage: ./scripts/serve_docs [--build]
+#
+# Options:
+#   --build    Build static site instead of serving (outputs to site/)
+
+set -euo pipefail
+
+if ((EUID == 0)); then
+  echo "Please do not run as root"
+  exit 1
+fi
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+cd "$TOP_DIR"
+
+# Check for D2 (diagramming tool)
+if ! command -v d2 &>/dev/null; then
+  if ! command -v go &>/dev/null; then
+    echo "Error: D2 requires Go. Please install Go first."
+    exit 1
+  fi
+  echo "Installing D2 diagramming tool..."
+  go install oss.terrastruct.com/d2@latest
+fi
+
+# Install mkdocs and plugins if not available
+if ! command -v mkdocs &>/dev/null; then
+  echo "Installing mkdocs and plugins..."
+  uv tool install mkdocs \
+    --with mkdocs-autorefs \
+    --with mkdocs-d2-plugin \
+    --with mkdocs-literate-nav \
+    --with mkdocs-material \
+    --with mkdocs-mermaid2-plugin \
+    --with mkdocs-minify-plugin \
+    --with "mkdocstrings[python]"
+fi
+
+# Parse arguments
+BUILD_ONLY=false
+for arg in "$@"; do
+  case $arg in
+  --build)
+    BUILD_ONLY=true
+    shift
+    ;;
+  esac
+done
+
+if [ "$BUILD_ONLY" = true ]; then
+  echo "Building documentation..."
+  mkdocs build
+  echo "Documentation built in site/"
+else
+  echo "Serving documentation at http://127.0.0.1:8000"
+  echo "Press Ctrl+C to stop"
+  mkdocs serve
+fi


### PR DESCRIPTION
This commit establishes complete API documentation infrastructure and content
for all Dotprompt language implementations.

- Add `.readthedocs.yaml` configuration for ReadTheDocs hosting
- Add `docs/requirements.txt` with MkDocs and mkdocstrings dependencies
- Add `scripts/serve_docs` convenience script for local documentation preview
- Configure `mkdocs.yml` with mkdocstrings plugin for Python API autodocs

- `docs/api/index.md`: Landing page with links to all language implementations
- `docs/api/python/dotpromptz.md`: Python dotpromptz library (auto-generated)
- `docs/api/python/handlebarrz.md`: Python handlebarrz library (auto-generated)
- `docs/api/typescript/index.md`: TypeScript/JavaScript API reference
- `docs/api/go/index.md`: Go package API reference
- `docs/api/rust/index.md`: Rust crate API reference
- `docs/api/java/index.md`: Java package API reference

- `dotpromptz/__init__.py`: Add comprehensive module docstring with architecture
  diagram, key concepts table, and quick start example
- `dotpromptz/util.py`: Document path traversal security validation with
  attack vector table and validation flow diagram
- `dotpromptz/errors.py`: Document exception hierarchy and error handling
  best practices

- Update `docs/contributing/coding_guidelines.md` with enhanced docstring
  requirements including Key Operations, Caveats, and References sections
- Update `scripts/add_license` to use current year dynamically
