### PR TITLE
test(spec): add whitespace control spec tests for tilde (~) syntax

### DIFF
--- a/java/com/google/dotprompt/BUILD.bazel
+++ b/java/com/google/dotprompt/BUILD.bazel
@@ -134,6 +134,11 @@ java_spec_test(
     spec_file = "//spec:helpers/unlessEquals.yaml",
 )
 
+java_spec_test(
+    name = "SpecTest_whitespace",
+    spec_file = "//spec:whitespace.yaml",
+)
+
 java_test(
     name = "ResolveToolsConcurrencyTest",
     srcs = ["ResolveToolsConcurrencyTest.java"],

--- a/python/dotpromptz/tests/dotpromptz/spec_test.py
+++ b/python/dotpromptz/tests/dotpromptz/spec_test.py
@@ -138,10 +138,11 @@ ALLOWLISTED_FILES = [
     'spec/helpers/role.yaml',
     'spec/helpers/unlessEquals.yaml',
     'spec/helpers/section.yaml',
-    'spec/variables.yaml',
+    'spec/metadata.yaml',
     'spec/partials.yaml',
     'spec/picoschema.yaml',
-    'spec/metadata.yaml',
+    'spec/variables.yaml',
+    'spec/whitespace.yaml',
 ]
 
 # Counters for test class and test method names.

--- a/rs/dotprompt/BUILD.bazel
+++ b/rs/dotprompt/BUILD.bazel
@@ -111,3 +111,9 @@ rust_spec_test(
     spec_file = "//spec:helpers/unlessEquals.yaml",
     deps = [":dotprompt"],
 )
+
+rust_spec_test(
+    name = "SpecTest_whitespace",
+    spec_file = "//spec:whitespace.yaml",
+    deps = [":dotprompt"],
+)

--- a/spec/whitespace.yaml
+++ b/spec/whitespace.yaml
@@ -1,0 +1,124 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Tests for Handlebars whitespace control using the tilde (~) syntax.
+# The tilde character can be placed inside mustaches to strip whitespace
+# from the adjacent side of the mustache.
+#
+# Syntax:
+#   {{~ expr }}  - strips whitespace BEFORE the expression
+#   {{ expr ~}}  - strips whitespace AFTER the expression
+#   {{~ expr ~}} - strips whitespace on BOTH sides
+
+- name: whitespace_tilde_basic
+  template: |
+    Hello   {{~name~}}   World
+  tests:
+    - desc: strips whitespace on both sides of variable
+      data:
+        input: { name: "Beautiful" }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "HelloBeautifulWorld\n" }]
+
+- name: whitespace_tilde_left
+  template: |
+    Hello   {{~name}} World
+  tests:
+    - desc: strips whitespace before variable only
+      data:
+        input: { name: "Beautiful" }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "HelloBeautiful World\n" }]
+
+- name: whitespace_tilde_right
+  template: |
+    Hello {{name~}}   World
+  tests:
+    - desc: strips whitespace after variable only
+      data:
+        input: { name: "Beautiful" }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Hello BeautifulWorld\n" }]
+
+- name: whitespace_tilde_multiline
+  template: |
+    <div>
+        {{~value~}}
+    </div>
+  tests:
+    - desc: strips whitespace in multiline context
+      data:
+        input: { value: "Content" }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "<div>Content</div>\n" }]
+
+- name: whitespace_tilde_block_each
+  template: |
+    Items:{{#each items~}}
+    - {{this}}
+    {{~/each}}Done
+  tests:
+    - desc: strips whitespace in each block
+      data:
+        input: { items: ["one", "two", "three"] }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Items:- one- two- threeDone\n" }]
+
+- name: whitespace_tilde_block_if
+  template: |
+    Start
+    {{~#if show~}}
+    Content
+    {{~/if~}}
+    End
+  tests:
+    - desc: strips whitespace around if block when true
+      data:
+        input: { show: true }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "StartContentEnd\n" }]
+
+    - desc: strips whitespace around if block when false
+      data:
+        input: { show: false }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "StartEnd\n" }]
+
+- name: whitespace_no_tilde
+  template: |
+    Hello {{ name }} World
+  tests:
+    - desc: preserves whitespace without tilde
+      data:
+        input: { name: "Beautiful" }
+      expect:
+        messages:
+          - role: user
+            content: [{ text: "Hello Beautiful World\n" }]


### PR DESCRIPTION
Add comprehensive spec tests for Handlebars whitespace trimming using
the tilde (~) syntax. The tilde character can be placed inside mustaches
to strip whitespace from the adjacent side.

New spec/whitespace.yaml covers:
- Basic tilde on both sides: {{~name~}} strips whitespace before/after
- Left-side tilde only: {{~name}} strips whitespace before
- Right-side tilde only: {{name~}} strips whitespace after
- Multiline whitespace stripping in div context
- Block helpers (#each, #if) with whitespace control
- Preserve whitespace without tilde (baseline behavior)

Extension fields (ext) already tested in metadata.yaml with test case
"extension fields are parsed and added to 'ext'" which verifies that
frontmatter like `myext.foo: 123` becomes accessible as
`ext['myext']['foo']`. Verified across all language implementations.

All 8 whitespace tests pass across:
- JavaScript/TypeScript (76 spec tests total)
- Python dotpromptz (79 spec tests total)
- Go (spec_test.go)
- Rust (SpecTest_whitespace)
- Java (SpecTest_whitespace)

Files changed:
- spec/whitespace.yaml (new)
- java/com/google/dotprompt/BUILD.bazel
- python/dotpromptz/tests/dotpromptz/spec_test.py
- rs/dotprompt/BUILD.bazel
