### PR TITLE
fix(ci): use PR author identity for lockfile commits

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -97,8 +97,9 @@ jobs:
       - name: Commit maven_install.json updates for release-please PR
         if: steps.check-release-please.outputs.is_release_please == 'true' && matrix.java-version == 17
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Use the PR author's identity (from the last commit) for CLA compliance
+          git config user.name "$(git log -1 --format='%an')"
+          git config user.email "$(git log -1 --format='%ae')"
           if ! git diff --quiet maven_install.json; then
             git add maven_install.json
             git commit -m "chore: update maven_install.json"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,8 +78,9 @@ jobs:
       - name: Commit go.sum updates
         if: steps.check-release-please.outputs.is_release_please == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Use the PR author's identity (from the last commit) for CLA compliance
+          git config user.name "$(git log -1 --format='%an')"
+          git config user.email "$(git log -1 --format='%ae')"
           if ! git diff --quiet go/go.sum go/go.mod; then
             git add go/go.sum go/go.mod
             git commit -m "chore: update go.mod and go.sum"

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -84,8 +84,9 @@ jobs:
       - name: Commit lockfile updates
         if: steps.check-release-please.outputs.is_release_please == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Use the PR author's identity (from the last commit) for CLA compliance
+          git config user.name "$(git log -1 --format='%an')"
+          git config user.email "$(git log -1 --format='%ae')"
           if ! git diff --quiet pnpm-lock.yaml js/pnpm-lock.yaml; then
             git add pnpm-lock.yaml js/pnpm-lock.yaml 2>/dev/null || true
             git commit -m "chore: update pnpm lockfiles" || echo "No changes to commit"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,8 +78,9 @@ jobs:
       - name: Commit lockfile updates
         if: steps.check-release-please.outputs.is_release_please == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Use the PR author's identity (from the last commit) for CLA compliance
+          git config user.name "$(git log -1 --format='%an')"
+          git config user.email "$(git log -1 --format='%ae')"
           if ! git diff --quiet python/uv.lock python/requirements.txt; then
             git add python/uv.lock python/requirements.txt
             git commit -m "chore: update Python lockfiles"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,8 +110,9 @@ jobs:
       - name: Commit changes
         if: steps.changes.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Use the PR author's identity (from the last commit) for CLA compliance
+          git config user.name "$(git log -1 --format='%an')"
+          git config user.email "$(git log -1 --format='%ae')"
           git add python/uv.lock python/requirements.txt Cargo.lock python/handlebarrz/Cargo.lock MODULE.bazel.lock go/go.mod go/go.sum pnpm-lock.yaml js/pnpm-lock.yaml maven_install.json
           git commit -m "chore: update lockfiles"
           git push

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,8 +76,9 @@ jobs:
       - name: Commit Cargo.lock updates
         if: steps.check-release-please.outputs.is_release_please == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Use the PR author's identity (from the last commit) for CLA compliance
+          git config user.name "$(git log -1 --format='%an')"
+          git config user.email "$(git log -1 --format='%ae')"
           if ! git diff --quiet Cargo.lock; then
             git add Cargo.lock
             git commit -m "chore: update Cargo.lock"


### PR DESCRIPTION
## Summary

Fix CLA compliance issue for auto-committed lockfile updates by using the
PR author's identity instead of `github-actions[bot]`.

### Problem

When CI workflows auto-commit lockfile updates (e.g., `uv.lock`, `Cargo.lock`,
`pnpm-lock.yaml`), they were using `github-actions[bot]` as the commit author.
This caused CLA checks to fail because the bot doesn't have a signed CLA.

### Solution

Use the PR author's name and email (extracted from the last commit on the branch)
for lockfile update commits:

```bash
git config user.name "$(git log -1 --format='%an')"
git config user.email "$(git log -1 --format='%ae')"
```

This ensures CLA compliance since the PR author has already signed the CLA.

### Workflows Updated

- `.github/workflows/python.yml`
- `.github/workflows/bazel.yml`
- `.github/workflows/rust.yml`
- `.github/workflows/js.yml`
- `.github/workflows/go.yml`
- `.github/workflows/release-please.yml`

## Test Plan

- [ ] Merge this PR
- [ ] Update release PR branches to pick up the new workflow
- [ ] Verify lockfile commits use the PR author's identity
- [ ] Verify CLA check passes for auto-committed lockfile updates