### PR TITLE
fix(ci): use MAINTAINERS.yaml for CLA-covered commit identity

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Commit maven_install.json updates for release-please PR
         if: steps.check-release-please.outputs.is_release_please == 'true' && matrix.java-version == 17
         run: |
-          # Use the PR author's identity (from the last commit) for CLA compliance
-          git config user.name "$(git log -1 --format='%an')"
-          git config user.email "$(git log -1 --format='%ae')"
+          # Use CLA-covered maintainer identity from MAINTAINERS.yaml
+          git config user.name "$(yq '.ci.commit_author.name' MAINTAINERS.yaml)"
+          git config user.email "$(yq '.ci.commit_author.email' MAINTAINERS.yaml)"
           if ! git diff --quiet maven_install.json; then
             git add maven_install.json
             git commit -m "chore: update maven_install.json"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,9 +78,9 @@ jobs:
       - name: Commit go.sum updates
         if: steps.check-release-please.outputs.is_release_please == 'true'
         run: |
-          # Use the PR author's identity (from the last commit) for CLA compliance
-          git config user.name "$(git log -1 --format='%an')"
-          git config user.email "$(git log -1 --format='%ae')"
+          # Use CLA-covered maintainer identity from MAINTAINERS.yaml
+          git config user.name "$(yq '.ci.commit_author.name' MAINTAINERS.yaml)"
+          git config user.email "$(yq '.ci.commit_author.email' MAINTAINERS.yaml)"
           if ! git diff --quiet go/go.sum go/go.mod; then
             git add go/go.sum go/go.mod
             git commit -m "chore: update go.mod and go.sum"

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -84,9 +84,9 @@ jobs:
       - name: Commit lockfile updates
         if: steps.check-release-please.outputs.is_release_please == 'true'
         run: |
-          # Use the PR author's identity (from the last commit) for CLA compliance
-          git config user.name "$(git log -1 --format='%an')"
-          git config user.email "$(git log -1 --format='%ae')"
+          # Use CLA-covered maintainer identity from MAINTAINERS.yaml
+          git config user.name "$(yq '.ci.commit_author.name' MAINTAINERS.yaml)"
+          git config user.email "$(yq '.ci.commit_author.email' MAINTAINERS.yaml)"
           if ! git diff --quiet pnpm-lock.yaml js/pnpm-lock.yaml; then
             git add pnpm-lock.yaml js/pnpm-lock.yaml 2>/dev/null || true
             git commit -m "chore: update pnpm lockfiles" || echo "No changes to commit"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,9 +78,9 @@ jobs:
       - name: Commit lockfile updates
         if: steps.check-release-please.outputs.is_release_please == 'true'
         run: |
-          # Use the PR author's identity (from the last commit) for CLA compliance
-          git config user.name "$(git log -1 --format='%an')"
-          git config user.email "$(git log -1 --format='%ae')"
+          # Use CLA-covered maintainer identity from MAINTAINERS.yaml
+          git config user.name "$(yq '.ci.commit_author.name' MAINTAINERS.yaml)"
+          git config user.email "$(yq '.ci.commit_author.email' MAINTAINERS.yaml)"
           if ! git diff --quiet python/uv.lock python/requirements.txt; then
             git add python/uv.lock python/requirements.txt
             git commit -m "chore: update Python lockfiles"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,9 +110,9 @@ jobs:
       - name: Commit changes
         if: steps.changes.outputs.changed == 'true'
         run: |
-          # Use the PR author's identity (from the last commit) for CLA compliance
-          git config user.name "$(git log -1 --format='%an')"
-          git config user.email "$(git log -1 --format='%ae')"
+          # Use CLA-covered maintainer identity from MAINTAINERS.yaml
+          git config user.name "$(yq '.ci.commit_author.name' MAINTAINERS.yaml)"
+          git config user.email "$(yq '.ci.commit_author.email' MAINTAINERS.yaml)"
           git add python/uv.lock python/requirements.txt Cargo.lock python/handlebarrz/Cargo.lock MODULE.bazel.lock go/go.mod go/go.sum pnpm-lock.yaml js/pnpm-lock.yaml maven_install.json
           git commit -m "chore: update lockfiles"
           git push

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,9 +76,9 @@ jobs:
       - name: Commit Cargo.lock updates
         if: steps.check-release-please.outputs.is_release_please == 'true'
         run: |
-          # Use the PR author's identity (from the last commit) for CLA compliance
-          git config user.name "$(git log -1 --format='%an')"
-          git config user.email "$(git log -1 --format='%ae')"
+          # Use CLA-covered maintainer identity from MAINTAINERS.yaml
+          git config user.name "$(yq '.ci.commit_author.name' MAINTAINERS.yaml)"
+          git config user.email "$(yq '.ci.commit_author.email' MAINTAINERS.yaml)"
           if ! git diff --quiet Cargo.lock; then
             git add Cargo.lock
             git commit -m "chore: update Cargo.lock"

--- a/MAINTAINERS.yaml
+++ b/MAINTAINERS.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Project maintainers configuration
+#
+# This file is used by CI workflows to attribute automated commits
+# (e.g., lockfile updates) to a CLA-covered maintainer identity.
+
+maintainers:
+  # Primary maintainer - used for automated commits
+  - name: Yesudeep Mangalapilly
+    email: yesudeep@google.com
+    github: yesudeep
+    primary: true
+
+# CI configuration
+ci:
+  # Identity used for automated commits (lockfile updates, etc.)
+  # Must be a CLA-covered maintainer
+  commit_author:
+    name: Yesudeep Mangalapilly
+    email: yesudeep@google.com


### PR DESCRIPTION
## Summary

Add `MAINTAINERS.yaml` to centralize maintainer configuration and use it
in CI workflows for automated commits (lockfile updates, etc.).

### Benefits

- **Centralized** - one place to update if maintainers change
- **Transparent** - clearly documents who the project maintainers are
- **Reusable** - can be used by other workflows or scripts
- **CLA Compliant** - ensures automated commits use a CLA-covered identity

### New File: `MAINTAINERS.yaml`

```yaml
maintainers:
  - name: Yesudeep Mangalapilly
    email: yesudeep@google.com
    github: yesudeep
    primary: true

ci:
  commit_author:
    name: Yesudeep Mangalapilly
    email: yesudeep@google.com
```

### Workflow Changes

All workflows now read the commit author from `MAINTAINERS.yaml` using `yq`:

```bash
git config user.name "$(yq '.ci.commit_author.name' MAINTAINERS.yaml)"
git config user.email "$(yq '.ci.commit_author.email' MAINTAINERS.yaml)"
```

### Workflows Updated

- `.github/workflows/python.yml`
- `.github/workflows/bazel.yml`
- `.github/workflows/rust.yml`
- `.github/workflows/js.yml`
- `.github/workflows/go.yml`
- `.github/workflows/release-please.yml`

## Test Plan

- [ ] Merge this PR
- [ ] Update release PR branches to pick up the new workflow
- [ ] Verify lockfile commits are authored by the maintainer from MAINTAINERS.yaml
- [ ] Verify CLA check passes