### PR TITLE
fix(ci): align publish workflow tag filters with release-please config

### DIFF
--- a/.github/workflows/publish_java.yml
+++ b/.github/workflows/publish_java.yml
@@ -36,6 +36,8 @@ on:
 jobs:
   publish-java:
     runs-on: ubuntu-latest
+    # Only run for releases tagged with dotprompt-java- prefix (per release-please config)
+    if: startsWith(github.event.release.tag_name, 'dotprompt-java-')
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish_python_dotpromptz_package.yml
+++ b/.github/workflows/publish_python_dotpromptz_package.yml
@@ -41,7 +41,9 @@ jobs:
   check_and_build:
     name: Dependency Check and Build
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'dotpromptz-v'))
+    # Triggers on GitHub releases for the 'dotpromptz' package (tag: dotpromptz-X.Y.Z)
+    # Excludes 'dotpromptz-handlebars' releases which have their own publish workflow
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'dotpromptz-') && !startsWith(github.event.release.tag_name, 'dotpromptz-handlebars-'))
     permissions:
       contents: write
       actions: write

--- a/.github/workflows/publish_python_handlebarrz_package.yml
+++ b/.github/workflows/publish_python_handlebarrz_package.yml
@@ -40,7 +40,8 @@ jobs:
   build_ubuntu_arm64:
     name: Build for Ubuntu ARM64
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'dotpromptz-handlebars-v'))
+    # Triggers on GitHub releases for the 'dotpromptz-handlebars' package (tag: dotpromptz-handlebars-X.Y.Z)
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'dotpromptz-handlebars-'))
     strategy:
       matrix:
         python_version:

--- a/.github/workflows/publish_rust.yml
+++ b/.github/workflows/publish_rust.yml
@@ -23,8 +23,8 @@ on:
 jobs:
   publish-cargo:
     runs-on: ubuntu-latest
-    # Only run for releases tagged with rs- prefix
-    if: startsWith(github.ref, 'refs/tags/rs-')
+    # Only run for releases tagged with dotprompt-rs- prefix (per release-please config)
+    if: startsWith(github.event.release.tag_name, 'dotprompt-rs-')
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Fix publish workflows to trigger automatically when release-please creates
GitHub releases. The tag format was mismatched.

### Problem

Release-please creates tags with format `component-X.Y.Z` (no `v` prefix),
but the publish workflows were looking for different patterns:

| Workflow | Expected | Actual (release-please) |
|----------|----------|------------------------|
| dotpromptz | `dotpromptz-v*` | `dotpromptz-0.1.5` |
| dotpromptz-handlebars | `dotpromptz-handlebars-v*` | `dotpromptz-handlebars-0.1.4` |
| Rust | `rs-*` | `dotprompt-rs-0.1.1` |
| Java | (no filter) | `dotprompt-java-0.1.1` |

### Solution

Updated tag filters to match release-please config (`include-v-in-tag: false`):

- `publish_python_dotpromptz_package.yml`: `dotpromptz-*` (excluding `dotpromptz-handlebars-*`)
- `publish_python_handlebarrz_package.yml`: `dotpromptz-handlebars-*`
- `publish_rust.yml`: `dotprompt-rs-*`
- `publish_java.yml`: `dotprompt-java-*` (added missing filter)

### Result

After merging:
1. Merge a release PR (e.g., dotpromptz-handlebars)
2. Release-please creates GitHub release with tag `dotpromptz-handlebars-0.1.4`
3. Publish workflow automatically triggers and publishes to PyPI

**One-click release!**

## Test Plan

- [ ] Merge this PR
- [ ] Merge dotpromptz-handlebars release PR (#472)
- [ ] Verify publish workflow triggers automatically
- [ ] Verify package appears on PyPI