### PR TITLE
fix(release-please): add rs/dotprompt/Cargo.toml to extra-files

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -64,6 +64,11 @@
       "extra-files": [
         {
           "type": "toml",
+          "path": "dotprompt/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
           "path": "smoke/Cargo.toml",
           "jsonpath": "$.package.version"
         }


### PR DESCRIPTION
## Summary

Fix release-please config to update the main Rust crate version.

### Problem

The Rust crate is in `rs/dotprompt/` subdirectory, but release-please was only
updating `rs/smoke/Cargo.toml`. The main crate at `rs/dotprompt/Cargo.toml` was
not being updated.

### Solution

Add `dotprompt/Cargo.toml` to the `extra-files` list for the `rs` package.

### Files Updated by Release-Please (after this fix)

| Package | Files |
|---------|-------|
| `rs` | `rs/dotprompt/Cargo.toml` ✅ (added), `rs/smoke/Cargo.toml` |

## Test Plan

- [ ] Merge this PR
- [ ] Update the Rust release PR (#465) branch
- [ ] Verify `rs/dotprompt/Cargo.toml` is included in the release PR changes