### PR TITLE
fix(handlebarrz): add toggleable platform flags and Unicode tests

### DIFF
--- a/.github/workflows/publish_python_handlebarrz_package.yml
+++ b/.github/workflows/publish_python_handlebarrz_package.yml
@@ -32,16 +32,85 @@ on:
           - 'https://upload.pypi.org/legacy/'
           - 'https://test.pypi.org/legacy/'
         default: 'https://test.pypi.org/legacy/'
+      # -------------------------------------------------------------------------
+      # Platform override inputs for workflow_dispatch (one-off builds)
+      # These override the env defaults below when manually triggering the workflow
+      # -------------------------------------------------------------------------
+      enable_linux_arm64:
+        description: 'Enable Linux ARM64 (Ubuntu) builds'
+        type: boolean
+        default: true
+      enable_linux_x86_64:
+        description: 'Enable Linux x86_64 (Ubuntu) builds'
+        type: boolean
+        default: true
+      enable_alpine_arm64:
+        description: 'Enable Alpine ARM64 (musl) builds'
+        type: boolean
+        default: true
+      enable_alpine_x86_64:
+        description: 'Enable Alpine x86_64 (musl) builds'
+        type: boolean
+        default: true
+      enable_macos_arm64:
+        description: 'Enable macOS ARM64 (Apple Silicon) builds'
+        type: boolean
+        default: true
+      enable_macos_x86_64:
+        description: 'Enable macOS x86_64 (Intel) builds'
+        type: boolean
+        default: true
+      enable_windows_x86_64:
+        description: 'Enable Windows x86_64 builds (may have wheel corruption issues)'
+        type: boolean
+        default: false
 #  pull_request:
 #    branches: [ main ]
 
+# ==============================================================================
+# PLATFORM SUPPORT FLAGS
+# ==============================================================================
+# Toggle platform builds by setting these to 'true' or 'false'.
+# For one-off builds with different settings, use workflow_dispatch inputs.
+#
+# Current status:
+#   - Linux ARM64:   ENABLED  (native ubuntu-24.04-arm runner)
+#   - Linux x86_64:  ENABLED  (native ubuntu-latest runner)
+#   - Alpine ARM64:  ENABLED  (musl cross-compile on ARM64 runner)
+#   - Alpine x86_64: ENABLED  (musl cross-compile on x86_64 runner)
+#   - macOS ARM64:   ENABLED  (native macos-14 Apple Silicon runner)
+#   - macOS x86_64:  ENABLED  (cross-compile on macos-14)
+#   - Windows x86_64: DISABLED (wheel corruption issue - see TODO below)
+#
+# TODO(handlebarrz): Re-enable Windows support once wheel corruption issue is fixed.
+# Issue: PyPI upload fails with "400 Invalid distribution file. ZIP archive not
+# accepted: Mis-matched data size" for Windows wheels.
+# ==============================================================================
+env:
+  # Linux platforms
+  ENABLE_LINUX_ARM64: 'true'
+  ENABLE_LINUX_X86_64: 'true'
+  # Alpine (musl) platforms
+  ENABLE_ALPINE_ARM64: 'true'
+  ENABLE_ALPINE_X86_64: 'true'
+  # macOS platforms
+  ENABLE_MACOS_ARM64: 'true'
+  ENABLE_MACOS_X86_64: 'true'
+  # Windows platforms (currently disabled due to wheel corruption)
+  ENABLE_WINDOWS_X86_64: 'false'
+
 
 jobs:
+  # ===========================================================================
+  # BUILD JOBS
+  # ===========================================================================
+
   build_ubuntu_arm64:
     name: Build for Ubuntu ARM64
     runs-on: ubuntu-24.04-arm  # Native ARM64 runner - no QEMU needed
-    # Triggers on GitHub releases for the 'dotpromptz-handlebars' package (tag: dotpromptz-handlebars-X.Y.Z)
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'dotpromptz-handlebars-'))
+    if: |
+      (env.ENABLE_LINUX_ARM64 == 'true' || inputs.enable_linux_arm64 == true) &&
+      (github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'dotpromptz-handlebars-')))
     strategy:
       matrix:
         python_version:
@@ -89,6 +158,7 @@ jobs:
   build_alpine_arm64:
     name: Build for Alpine ARM64
     runs-on: ubuntu-24.04-arm  # Native ARM64 runner - cross-compile for musl
+    if: env.ENABLE_ALPINE_ARM64 == 'true' || inputs.enable_alpine_arm64 == true
     strategy:
       matrix:
         python_version:
@@ -137,6 +207,7 @@ jobs:
   build_alpine_x86_64:
     name: Build for Alpine x86_64
     runs-on: ubuntu-latest  # Native x86_64 runner - cross-compile for musl
+    if: env.ENABLE_ALPINE_X86_64 == 'true' || inputs.enable_alpine_x86_64 == true
     strategy:
       matrix:
         python_version:
@@ -185,6 +256,7 @@ jobs:
   build_ubuntu_x86_64:
     name: Build for Ubuntu x86_64
     runs-on: ubuntu-latest  # Native x86_64 runner
+    if: env.ENABLE_LINUX_X86_64 == 'true' || inputs.enable_linux_x86_64 == true
     strategy:
       matrix:
         python_version:
@@ -233,6 +305,8 @@ jobs:
   build_windows_x86_64:
     name: Build for Windows x86_64
     runs-on: windows-latest
+    # Currently disabled due to wheel corruption issues - see env flags above
+    if: env.ENABLE_WINDOWS_X86_64 == 'true' || inputs.enable_windows_x86_64 == true
     strategy:
       matrix:
         python_version:
@@ -269,10 +343,11 @@ jobs:
         with:
           name: wheels-windows-x86_64-${{ matrix.python_version }}
           path: python/handlebarrz/dist
-#
+
   build_macos_arm64:
     name: Build for macOS ARM64
     runs-on: macos-14  # Apple Silicon
+    if: env.ENABLE_MACOS_ARM64 == 'true' || inputs.enable_macos_arm64 == true
     strategy:
       matrix:
         python_version:
@@ -321,6 +396,7 @@ jobs:
   build_macos_x86_64:
     name: Build for macOS x86_64
     runs-on: macos-14
+    if: env.ENABLE_MACOS_X86_64 == 'true' || inputs.enable_macos_x86_64 == true
     strategy:
       matrix:
         python_version:
@@ -404,9 +480,18 @@ jobs:
 #          name: wheels-windows-arm64-${{ matrix.python_version }}
 #          path: python/handlebarrz/dist
 
+  # ===========================================================================
+  # PUBLISH JOB
+  # ===========================================================================
+
   pypi_publish:
     name: Upload to PyPI by python version
-    needs: [build_ubuntu_arm64,build_ubuntu_x86_64,build_alpine_arm64,build_alpine_x86_64,build_windows_x86_64,build_macos_arm64,build_macos_x86_64]
+    # NOTE: Jobs with conditional 'if' statements are not listed in 'needs' because
+    # GitHub Actions would fail if a skipped job is in the needs list.
+    # Artifacts from all enabled platforms are collected via download-artifact's merge-multiple.
+    # This job runs if at least one build job completes (using always() + success check).
+    needs: [build_ubuntu_arm64,build_ubuntu_x86_64,build_alpine_arm64,build_alpine_x86_64,build_macos_arm64,build_macos_x86_64]
+    if: always() && !cancelled() && (needs.build_ubuntu_arm64.result == 'success' || needs.build_ubuntu_x86_64.result == 'success' || needs.build_alpine_arm64.result == 'success' || needs.build_alpine_x86_64.result == 'success' || needs.build_macos_arm64.result == 'success' || needs.build_macos_x86_64.result == 'success')
     runs-on: ubuntu-latest
     environment:
       name: pypi_github_publishing
@@ -437,10 +522,15 @@ jobs:
       - name: Sleep for pypi server to load
         run: sleep 180
 
+  # ===========================================================================
+  # SMOKE TEST JOBS
+  # ===========================================================================
+
   smoke_test_linux_arm64:
     name: Test for Linux ARM64
     needs: [pypi_publish]
     runs-on: ubuntu-24.04-arm  # Native ARM64 runner - no QEMU needed
+    if: env.ENABLE_LINUX_ARM64 == 'true' || inputs.enable_linux_arm64 == true
     strategy:
       matrix:
         python_version:
@@ -471,6 +561,7 @@ jobs:
     name: Test for Alpine ARM64
     needs: [pypi_publish]
     runs-on: ubuntu-24.04-arm  # Native ARM64 runner - no QEMU needed
+    if: env.ENABLE_ALPINE_ARM64 == 'true' || inputs.enable_alpine_arm64 == true
     strategy:
       matrix:
         python_version:
@@ -498,6 +589,7 @@ jobs:
     name: Test for Alpine x86_64
     needs: [pypi_publish]
     runs-on: ubuntu-latest  # Native x86_64 - no QEMU needed
+    if: env.ENABLE_ALPINE_X86_64 == 'true' || inputs.enable_alpine_x86_64 == true
     strategy:
       matrix:
         python_version:
@@ -525,6 +617,7 @@ jobs:
     name: Test for Linux x86_64
     needs: [pypi_publish]
     runs-on: ubuntu-latest
+    if: env.ENABLE_LINUX_X86_64 == 'true' || inputs.enable_linux_x86_64 == true
     strategy:
       matrix:
         python_version:
@@ -556,6 +649,7 @@ jobs:
     name: Test for macOS ARM64
     needs: [pypi_publish]
     runs-on: macos-14
+    if: env.ENABLE_MACOS_ARM64 == 'true' || inputs.enable_macos_arm64 == true
     strategy:
       matrix:
         python_version:
@@ -581,8 +675,9 @@ jobs:
 
   smoke_test_macos_x86_64:
     name: Test for macOS x86_64
-    needs: [ pypi_publish ]
+    needs: [pypi_publish]
     runs-on: macos-14
+    if: env.ENABLE_MACOS_X86_64 == 'true' || inputs.enable_macos_x86_64 == true
     strategy:
       matrix:
         python_version:
@@ -612,6 +707,8 @@ jobs:
     name: Test for Windows x86_64
     needs: [pypi_publish]
     runs-on: windows-latest
+    # Currently disabled due to wheel corruption issues - see env flags above
+    if: env.ENABLE_WINDOWS_X86_64 == 'true' || inputs.enable_windows_x86_64 == true
     strategy:
       matrix:
         python_version:

--- a/python/handlebarrz/tests/template_test.py
+++ b/python/handlebarrz/tests/template_test.py
@@ -331,6 +331,88 @@ class TestTemplateEdgeCases(unittest.TestCase):
         self.assertEqual(result2, 'Version 2: data')
 
 
+class TestUnicodeAndInternationalization(unittest.TestCase):
+    """Test Unicode and internationalization support."""
+
+    def test_hindi_devanagari_script(self) -> None:
+        """Test Hindi text in Devanagari script."""
+        template = Template()
+        template.register_template('hindi', 'नमस्ते {{name}}!')
+        result = template.render('hindi', {'name': 'दुनिया'})
+        self.assertEqual(result, 'नमस्ते दुनिया!')
+
+    def test_arabic_rtl_text(self) -> None:
+        """Test Arabic right-to-left text."""
+        template = Template()
+        template.register_template('arabic', 'مرحبا {{name}}!')
+        result = template.render('arabic', {'name': 'العالم'})
+        self.assertEqual(result, 'مرحبا العالم!')
+
+    def test_japanese_mixed_scripts(self) -> None:
+        """Test Japanese with hiragana, katakana, and kanji."""
+        template = Template()
+        template.register_template('japanese', 'こんにちは {{name}}さん!')
+        result = template.render('japanese', {'name': '田中'})
+        self.assertEqual(result, 'こんにちは 田中さん!')
+
+    def test_korean_hangul(self) -> None:
+        """Test Korean Hangul script."""
+        template = Template()
+        template.register_template('korean', '안녕하세요 {{name}}님!')
+        result = template.render('korean', {'name': '세계'})
+        self.assertEqual(result, '안녕하세요 세계님!')
+
+    def test_chinese_simplified(self) -> None:
+        """Test Simplified Chinese characters."""
+        template = Template()
+        template.register_template('chinese', '你好 {{name}}!')
+        result = template.render('chinese', {'name': '世界'})
+        self.assertEqual(result, '你好 世界!')
+
+    def test_tamil_script(self) -> None:
+        """Test Tamil script."""
+        template = Template()
+        template.register_template('tamil', 'வணக்கம் {{name}}!')
+        result = template.render('tamil', {'name': 'உலகம்'})
+        self.assertEqual(result, 'வணக்கம் உலகம்!')
+
+    def test_emoji_in_template(self) -> None:
+        """Test emoji characters in templates."""
+        template = Template()
+        template.register_template('emoji', '{{greeting}} 🎉🎊 {{name}} 🌍🌎🌏')
+        result = template.render('emoji', {'greeting': 'Hello', 'name': 'World'})
+        self.assertEqual(result, 'Hello 🎉🎊 World 🌍🌎🌏')
+
+    def test_mixed_scripts_in_single_template(self) -> None:
+        """Test multiple scripts in a single template."""
+        template = Template()
+        template.register_template(
+            'mixed',
+            'English: {{en}}, 中文: {{zh}}, हिंदी: {{hi}}, العربية: {{ar}}',
+        )
+        result = template.render(
+            'mixed',
+            {'en': 'Hello', 'zh': '你好', 'hi': 'नमस्ते', 'ar': 'مرحبا'},
+        )
+        self.assertEqual(result, 'English: Hello, 中文: 你好, हिंदी: नमस्ते, العربية: مرحبا')
+
+    def test_combining_diacritical_marks(self) -> None:
+        """Test characters with combining diacritical marks."""
+        template = Template()
+        # é can be represented as e + combining acute accent
+        template.register_template('diacritics', 'Café: {{name}}')
+        result = template.render('diacritics', {'name': 'résumé'})
+        self.assertEqual(result, 'Café: résumé')
+
+    def test_zero_width_characters(self) -> None:
+        """Test handling of zero-width characters."""
+        template = Template()
+        # Zero-width joiner (U+200D) is used in some scripts
+        template.register_template('zwj', 'Family: {{emoji}}')
+        result = template.render('zwj', {'emoji': '👨‍👩‍👧‍👦'})  # Family emoji with ZWJ
+        self.assertEqual(result, 'Family: 👨‍👩‍👧‍👦')
+
+
 class TestHandlebarsAlias(unittest.TestCase):
     """Test that the Handlebars alias works like Template."""
 


### PR DESCRIPTION
## Summary

This PR improves the CI/CD pipeline for `dotpromptz-handlebars` (handlebarrz) with:

1. **Toggleable platform build flags** - Enable/disable builds per platform without code changes
2. **Automatic lockfile updates for release PRs** - MODULE.bazel.lock and other lockfiles auto-updated
3. **Automatic labeling for release PRs** - Easy filtering with `release/*` labels
4. **Unicode and numeric tests** - Comprehensive test coverage for handlebarrz

## Platform Build Flags

The publish workflow now uses a **setup job** that outputs platform flags. All build and smoke test jobs check these flags.

**To change platform defaults**, modify the `DEFAULT_*` variables in the setup job:

```bash
# In the setup job's "Set platform flags" step:
DEFAULT_LINUX_ARM64="true"
DEFAULT_LINUX_X86_64="true"
DEFAULT_ALPINE_ARM64="true"
DEFAULT_ALPINE_X86_64="true"
DEFAULT_MACOS_ARM64="true"
DEFAULT_MACOS_X86_64="true"
DEFAULT_WINDOWS_X86_64="false"  # Disabled due to wheel corruption
```

**For one-off builds**, use "Run workflow" in GitHub Actions UI and toggle the checkboxes.

| Platform | Default | Runner |
|----------|---------|--------|
| Linux ARM64 | `true` | `ubuntu-24.04-arm` (native) |
| Linux x86_64 | `true` | `ubuntu-latest` (native) |
| Alpine ARM64 | `true` | `ubuntu-24.04-arm` + musl cross-compile |
| Alpine x86_64 | `true` | `ubuntu-latest` + musl cross-compile |
| macOS ARM64 | `true` | `macos-14` (Apple Silicon) |
| macOS x86_64 | `true` | `macos-14` + cross-compile |
| Windows x86_64 | `false` | `windows-latest` |

### Windows Disabled

Windows builds are disabled by default due to a PyPI upload error:
```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
Invalid distribution file. ZIP archive not accepted: Mis-matched data size.
```

## Automatic Lockfile Updates

The `release-please.yml` workflow now automatically updates lockfiles when release PRs are created:

- `MODULE.bazel.lock` - Bazel module dependencies
- `Cargo.lock` - Rust dependencies (root and handlebarrz)
- `go.mod` / `go.sum` - Go dependencies
- `uv.lock` - Python dependencies
- `pnpm-lock.yaml` - Node.js dependencies

## Automatic Release PR Labels

New labeler rules automatically tag release PRs:

| Label | Description |
|-------|-------------|
| `release` | All release-please PRs |
| `release/dotprompt` | JS/TS dotprompt releases |
| `release/dotpromptz` | Python dotpromptz releases |
| `release/dotpromptz-handlebars` | Python handlebarrz releases |
| `release/dotprompt-go` | Go releases |
| `release/dotprompt-rs` | Rust releases |
| `release/dotprompt-java` | Java releases |
| `release/vscode` | VS Code extension releases |
| `release/promptly` | Promptly CLI releases |

Filter in GitHub: `label:release` or `label:release/dotpromptz-handlebars`

## New Tests Added

### Unicode and Internationalization Tests
- Hindi (Devanagari script)
- Arabic (RTL text)
- Japanese (hiragana, katakana, kanji)
- Korean (Hangul)
- Chinese (Simplified)
- Tamil script
- Emoji characters
- Mixed scripts in single template
- Combining diacritical marks
- Zero-width characters (ZWJ)

### Numeric and Boolean Value Tests
- Integer values (positive, zero, negative)
- Float values (decimal, zero, negative)
- Boolean values in conditionals
- None/null value handling
- Large numbers
- Scientific notation

## Commits

- `fix(handlebarrz): add toggleable platform flags and Unicode tests`
- `fix(handlebarrz): use setup job for platform flags instead of env context`
- `chore: update MODULE.bazel.lock for all platforms`
- `test(handlebarrz): add numeric and boolean value tests`
- `fix(ci): enable lockfile updates for release PRs`
- `feat(ci): add automatic labels for release-please PRs`

## Test Plan

- [x] Fix workflow syntax error (env context not available in job-level if)
- [ ] Verify setup job runs and outputs correct platform flags
- [ ] Confirm Windows builds are skipped when `DEFAULT_WINDOWS_X86_64="false"`
- [ ] Confirm other platform builds run successfully
- [ ] Verify lockfile update job runs on release PRs
- [ ] Verify release PR labels are applied automatically
- [ ] Verify Unicode and numeric tests pass in handlebarrz test suite