### PR TITLE
docs(dotpromptz-handlebars): improve PyPI package description

### DIFF
--- a/python/handlebarrz/README.md
+++ b/python/handlebarrz/README.md
@@ -11,6 +11,8 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10359/badge)](https://www.bestpractices.dev/projects/10359)
 
 [![GitHub stars](https://img.shields.io/github/stars/google/dotprompt?style=social)](https://github.com/google/dotprompt)
+[![OSS Insight](https://img.shields.io/badge/OSS%20Insight-google%2Fdotprompt-blue?logo=github)](https://ossinsight.io/analyze/google/dotprompt)
+
 [![Star History Chart](https://api.star-history.com/svg?repos=google/dotprompt&type=Date)](https://star-history.com/#google/dotprompt&Date)
 
 A high-performance [Handlebars](https://handlebarsjs.com/) template engine for Python, powered by Rust.


### PR DESCRIPTION
## Summary

Replace the minimal README with comprehensive documentation for better PyPI visibility.

## Before

```markdown
# dotpromptz-handlebars

**DISCLAIMER**: Project only intended to be used for dotprompt package. Support for other use cases is not guaranteed. 
```

## After

The new README includes:

### Badges
- **Package info** - PyPI version, Python versions, License, Downloads
- **CI/Quality** - CI status, Codecov coverage, OpenSSF Scorecard, OpenSSF Best Practices
- **Community** - GitHub stars badge, OSS Insight analytics, Star history chart

### Documentation
- **Feature highlights** - Fast, compatible, safe, extensible, type-safe
- **Installation instructions**
- **Quick start example**
- **Detailed usage examples**:
  - Basic templating
  - Built-in helpers (if/else, each, with)
  - Custom helpers
  - Partials
  - HTML escaping
- **API reference table**
- **Project context** - Part of Dotprompt

## Why

The current PyPI page shows almost no information about what the package does or how to use it. This update provides:

1. Clear explanation of what the package is (Handlebars for Python, powered by Rust)
2. Code quality indicators (CI, coverage, security scores)
3. Community metrics (stars, OSS Insight analytics, star history)
4. Installation and usage examples
5. API documentation
6. Context about its relationship to Dotprompt

## Test Plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify badges display correctly
- [ ] Verify star history chart renders
- [ ] Verify OSS Insight badge links correctly
- [ ] After next release, verify PyPI page shows the new description