### PR TITLE
fix(docs): remove incorrect OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <!-- Code Quality & Security -->
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/google/dotprompt/badge)](https://scorecard.dev/viewer/?uri=github.com/google/dotprompt)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10359/badge)](https://www.bestpractices.dev/projects/10359)
 [![codecov](https://codecov.io/gh/google/dotprompt/graph/badge.svg)](https://codecov.io/gh/google/dotprompt)
 [![License](https://img.shields.io/github/license/google/dotprompt)](https://github.com/google/dotprompt/blob/main/LICENSE)
 

--- a/python/handlebarrz/README.md
+++ b/python/handlebarrz/README.md
@@ -8,7 +8,6 @@
 [![CI](https://github.com/google/dotprompt/actions/workflows/handlebarrz-tests.yml/badge.svg)](https://github.com/google/dotprompt/actions/workflows/handlebarrz-tests.yml)
 [![codecov](https://codecov.io/gh/google/dotprompt/graph/badge.svg?flag=handlebarrz)](https://codecov.io/gh/google/dotprompt)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/google/dotprompt/badge)](https://scorecard.dev/viewer/?uri=github.com/google/dotprompt)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10359/badge)](https://www.bestpractices.dev/projects/10359)
 
 [![GitHub stars](https://img.shields.io/github/stars/google/dotprompt?style=social)](https://github.com/google/dotprompt)
 [![OSS Insight](https://img.shields.io/badge/OSS%20Insight-google%2Fdotprompt-blue?logo=github)](https://ossinsight.io/analyze/google/dotprompt)


### PR DESCRIPTION
## Summary

Remove the incorrect OpenSSF Best Practices badge from both READMEs.

## Problem

The OpenSSF Best Practices badge with project ID `10359` belongs to a different project (`chaturbate_poller`), not `google/dotprompt`.

## Solution

Remove the badge from:
- `README.md`
- `python/handlebarrz/README.md`

The OpenSSF Scorecard badge remains - it works automatically for any GitHub repository without registration.

## Next Steps

To get a proper OpenSSF Best Practices badge for dotprompt, the project needs to be registered at https://www.bestpractices.dev/en/projects/new

## Test Plan

- [ ] Verify badge is removed from both READMEs
- [ ] Verify OpenSSF Scorecard badge still works