### PR TITLE
fix(ci): correct matrix reference and update Genkit branding

### DIFF
--- a/.github/workflows/handlebarrz-tests.yml
+++ b/.github/workflows/handlebarrz-tests.yml
@@ -87,17 +87,18 @@ jobs:
 
   handlebarrz_native:
     name: Build Handlebarrz Native
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.config.os }}
     env:
-      # Enable sccache for Rust builds
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
+      # Enable sccache for Rust builds (disabled on macos-15-intel due to missing binaries)
+      SCCACHE_GHA_ENABLED: ${{ matrix.config.os != 'macos-15-intel' && 'true' || 'false' }}
+      RUSTC_WRAPPER: ${{ matrix.config.os != 'macos-15-intel' && 'sccache' || '' }}
     strategy:
       matrix:
         python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         config:
           - { os: "macos-14", target: "aarch64-apple-darwin", name: "macOS ARM64", python_arch: "arm64" }
-          - { os: "macos-14", target: "x86_64-apple-darwin", name: "macOS x86_64", python_arch: "x64" }
+          # Use macos-15-intel for x86_64 builds - macos-13 is retired, macos-14 (ARM64) has issues with x64 Python
+          - { os: "macos-15-intel", target: "x86_64-apple-darwin", name: "macOS x86_64", python_arch: "x64" }
           - { os: "windows-latest", target: "x86_64-pc-windows-msvc", name: "Windows x86_64", python_arch: "x64" }
 #          - { os: "windows-latest", target: "aarch64-pc-windows-msvc", name: "Windows ARM64", python_arch: "arm64" }
     steps:
@@ -113,6 +114,7 @@ jobs:
         env:
           RUSTUP_MAX_RETRIES: 3
       - name: Setup sccache
+        if: matrix.config.os != 'macos-15-intel'
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: pip install maturin
       - name: Build wheel
@@ -130,8 +132,8 @@ jobs:
         shell: bash
         run: |
           pip install dist/*.whl
-          pip install pytest
+          pip install pytest pytest-cov
       - name: Run tests
         working-directory: ./python/handlebarrz
         shell: bash
-        run: pytest
+        run: pytest --cov=handlebarrz --cov-report=term-missing

--- a/.github/workflows/promptly-npm.yml
+++ b/.github/workflows/promptly-npm.yml
@@ -39,9 +39,9 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     env:
-      # Enable sccache for Rust builds
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
+      # Enable sccache for Rust builds (disabled on macos-15-intel due to missing binaries)
+      SCCACHE_GHA_ENABLED: ${{ matrix.os != 'macos-15-intel' && 'true' || 'false' }}
+      RUSTC_WRAPPER: ${{ matrix.os != 'macos-15-intel' && 'sccache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +50,7 @@ jobs:
             os: macos-14
             npm_package: promptly-darwin-arm64
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel  # macos-13 is retired
             npm_package: promptly-darwin-x64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm  # Native ARM64 runner - no cross-compilation needed
@@ -74,6 +74,7 @@ jobs:
           RUSTUP_MAX_RETRIES: 3
 
       - name: Setup sccache
+        if: matrix.os != 'macos-15-intel'
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Build

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ information.
 ## Installation
 
 The remainder of this getting started guide will use the reference Dotprompt
-implementation included as part of the [Firebase
-Genkit](https://github.com/firebase/genkit) GenAI SDK. To use other
+implementation included as part of [Genkit](https://github.com/firebase/genkit),
+the GenAI SDK for app developers. To use other
 implementations of Dotprompt, see the [list of
 Implementations](third_party/docsite/src/content/docs/implementations.mdx).
 

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -288,8 +288,8 @@ output:
 ### Code-defined schemas
 
 In additional to defining schemas in the `.prompt` file, you can reference a
-schema in code. You can read more about how [Firebase Genkit handles
-it](https://firebase.google.com/docs/genkit/dotprompt#zod_schemas_defined_in_code).
+schema in code. You can read more about how [Genkit handles
+it](https://genkit.dev/docs/dotprompt#zod_schemas_defined_in_code).
 
 Dotprompt allows you to refer to a registered code-defined schema by name. For
 example, when you define a schema using

--- a/third_party/docsite/src/content/docs/getting-started.mdx
+++ b/third_party/docsite/src/content/docs/getting-started.mdx
@@ -59,7 +59,7 @@ When executed, this prompt would take a text input, analyze it using the specifi
 
 ## Install and set up
 
-The remainder of this getting started guide will use the reference Dotprompt implementation included as part of the [Firebase Genkit](https://github.com/firebase/genkit) GenAI framework. To use other implementations of Dotprompt, see the [list of Implementations](/implementations).
+The remainder of this getting started guide will use the reference Dotprompt implementation included as part of [Genkit](https://github.com/firebase/genkit), the GenAI SDK for app developers. To use other implementations of Dotprompt, see the [list of Implementations](/implementations).
 
 First, install the necessary packages using NPM. Here we'll be using the [Gemini API](https://ai.google.dev/gemini-api) from Google as our model implementation:
 

--- a/third_party/docsite/src/content/docs/implementations.mdx
+++ b/third_party/docsite/src/content/docs/implementations.mdx
@@ -8,13 +8,13 @@ The following is a community-curated list of Dotprompt implementations in variou
 
 | Name | Description | Links |
 | --- | --- | --- |
-| [Firebase Genkit](https://github.com/firebase/genkit) | The GenAI SDK for app developers. | [Docs](https://firebase.google.com/docs/genkit) [NPM](https://npmjs.com/packages/genkit) |
+| [Genkit](https://github.com/firebase/genkit) | The GenAI SDK for app developers. | [Docs](https://genkit.dev) [NPM](https://npmjs.com/packages/genkit) |
 
 ## Go
 
 | Name | Description | Links |
 | --- | --- | --- |
-| [Firebase Genkit](https://github.com/firebase/genkit) | The GenAI SDK for app developers. | [Docs](https://firebase.google.com/docs/genkit) [GoDoc](https://pkg.go.dev/github.com/firebase/genkit/go/genkit) |
+| [Genkit](https://github.com/firebase/genkit) | The GenAI SDK for app developers. | [Docs](https://genkit.dev) [GoDoc](https://pkg.go.dev/github.com/firebase/genkit/go/genkit) |
 
 ## Dart
 

--- a/third_party/docsite/src/content/docs/reference/model.mdx
+++ b/third_party/docsite/src/content/docs/reference/model.mdx
@@ -3,7 +3,7 @@ title: Common Model Interface
 sort_order: 4
 ---
 
-Dotprompt implementations are not required to conform to any specific structured interface for interacting with GenAI models. However, the Dotprompt reference implementation in [Firebase Genkit](https://github.com/firebase/genkit) leverages a common model interface that may be useful for other implementors to follow.
+Dotprompt implementations are not required to conform to any specific structured interface for interacting with GenAI models. However, the Dotprompt reference implementation in [Genkit](https://github.com/firebase/genkit) leverages a common model interface that may be useful for other implementors to follow.
 
 In the future, a Dotprompt "spec test" will be made available that exercises the various parts of Dotprompt and compares the results to this common model request format.
 


### PR DESCRIPTION
## Summary

This PR fixes the handlebarrz-tests workflow failures, updates retired macOS runners, and updates Genkit branding throughout the repo.

## Workflow Fixes

### 1. Matrix Reference Bug (Line 90)

**Problem:**
```
Error when evaluating 'runs-on' for job 'handlebarrz_native'. 
.github/workflows/handlebarrz-tests.yml (Line: 90, Col: 14): Unexpected value ''
```

**Cause:** `runs-on: ${{ matrix.os }}` but `os` is inside the `config` object.

**Fix:** Changed to `runs-on: ${{ matrix.config.os }}`

### 2. Retired macOS-13 Runner Migration

**Problem:** `macos-13` runner is retired (see [actions/runner-images#13046](https://github.com/actions/runner-images/issues/13046)).

**Fix:** Updated all workflows using `macos-13` to use `macos-15-intel`:
- `.github/workflows/handlebarrz-tests.yml`
- `.github/workflows/promptly-npm.yml`

### 3. sccache Not Available on macos-15-intel

**Problem:**
```
Setup sccache: Unexpected HTTP response: 404
Post Setup sccache: Unable to locate executable file: undefined
```

**Cause:** `mozilla-actions/sccache-action` doesn't have pre-built binaries for `macos-15-intel` yet.

**Fix:** Made sccache conditional - disabled on `macos-15-intel` in both affected workflows:
- `.github/workflows/handlebarrz-tests.yml`
- `.github/workflows/promptly-npm.yml`

Changes:
- Added `if: matrix.os != 'macos-15-intel'` (or `matrix.config.os`) to sccache setup steps
- Made `SCCACHE_GHA_ENABLED` and `RUSTC_WRAPPER` env vars conditional

### 4. Missing pytest-cov Dependency

**Problem:**
```
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov
```

**Cause:** The workflow installed `pytest` but not `pytest-cov`, while `pyproject.toml` has `addopts = ["--cov", ...]`.

**Fix:** Added `pytest-cov` to the pip install and explicitly run with coverage flags.

## Documentation Updates

Replaced all "Firebase Genkit" references with "Genkit" to reflect current branding:
- `README.md`
- `docs/extending/index.md`
- `third_party/docsite/src/content/docs/getting-started.mdx`
- `third_party/docsite/src/content/docs/implementations.mdx`
- `third_party/docsite/src/content/docs/reference/model.mdx`

Also updated documentation URLs from `firebase.google.com/docs/genkit` to `genkit.dev`.

## Test Plan

- [ ] Verify handlebarrz_native jobs pass on macOS ARM64 (macos-14)
- [ ] Verify handlebarrz_native jobs pass on macOS x86_64 (macos-15-intel, without sccache)
- [ ] Verify handlebarrz_native jobs pass on Windows
- [ ] Verify all Genkit references are updated correctly