### PR TITLE
fix(ci): remove explicit pnpm version to avoid conflict with packageManager

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -62,9 +62,7 @@ jobs:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Check if this is a release-please PR
         id: check-release-please
@@ -115,9 +113,7 @@ jobs:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm -C js install
@@ -143,9 +139,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm -C js install

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,8 +92,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@v4
     - name: Set up node v21
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/vscode_extension.yml
+++ b/.github/workflows/vscode_extension.yml
@@ -53,9 +53,7 @@ jobs:
           node-version: 20
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm -C packages/vscode install

--- a/.github/workflows/vscode_publish.yml
+++ b/.github/workflows/vscode_publish.yml
@@ -37,9 +37,7 @@ jobs:
           node-version: 20
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: pnpm -C packages/vscode install


### PR DESCRIPTION
## Summary

Fixes the CI failure in the `update-lockfiles` job caused by conflicting pnpm version specifications.

## Problem

The `pnpm/action-setup@v4` action reads the pnpm version from **both**:
1. The GitHub Action config (`version` key)
2. `package.json`'s `packageManager` field

When both are specified, it fails with:
```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.25.0 in the package.json with the key "packageManager"
```

## Solution

Remove the explicit `version` parameter from all `pnpm/action-setup` uses, allowing the action to read the version from `package.json`'s `packageManager` field as the **single source of truth**.

## Changes

- **`.github/workflows/release-please.yml`**: Remove `version: 10` from pnpm setup
- **`.github/workflows/js.yml`**: Remove `version: 10` from 3 pnpm setup steps
- **`.github/workflows/vscode_extension.yml`**: Remove `version: 10` 
- **`.github/workflows/vscode_publish.yml`**: Remove `version: 10`
- **`.github/workflows/release.yml`**: Upgrade to v4 for consistency

All workflows now use `pnpm/action-setup@v4` without explicit version, inheriting the version from `package.json`.

## Testing

CI will validate the fix by running the updated workflows.