### PR TITLE
fix(docs): updating the deprecating models. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ provided text:
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-pro
+model: googleai/gemini-2.5-pro
 input:
   schema:
     text: string
@@ -130,7 +130,7 @@ Text: {{text}}
 
 This Dotprompt file:
 
-1. Specifies the use of the `googleai/gemini-1.5-pro` model.
+1. Specifies the use of the `googleai/gemini-2.5-pro` model.
 2. Defines an input schema expecting a `text` string.
 3. Specifies that the output should be in JSON format.
 4. Provides a schema for the expected output, including fields for name, age,

--- a/docs/design/promptly.md
+++ b/docs/design/promptly.md
@@ -150,7 +150,7 @@ The parser is responsible for converting `.prompt` file content into an Abstract
 
 ```yaml
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:
@@ -327,7 +327,7 @@ The formatter ensures consistent styling across all `.prompt` files.
 **Before:**
 ```handlebars
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
     temperature: 0.7
 input:
@@ -349,7 +349,7 @@ Hello,{{name}}!
 **After:**
 ```handlebars
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:
@@ -572,18 +572,18 @@ When typing `model:`, the LSP provides intelligent completions with model metada
 
 ```yaml
 model: g|   # Cursor after 'g'
-       ├── gemini-2.0-flash          ✨ Recommended
-       │   Context: 1M tokens | Output: 8K | Cost: $0.075/1M
-       ├── gemini-2.0-flash-lite
-       │   Context: 1M tokens | Output: 8K | Cost: $0.02/1M
-       ├── gemini-1.5-pro
-       │   Context: 2M tokens | Output: 8K | Cost: $1.25/1M
-       ├── gpt-4o
-       │   Context: 128K tokens | Output: 16K | Cost: $2.50/1M
-       ├── gpt-4o-mini
-       │   Context: 128K tokens | Output: 16K | Cost: $0.15/1M
-       └── gpt-4-turbo
-           Context: 128K tokens | Output: 4K | Cost: $10/1M
+       ├── gemini-3-flash          ✨ Recommended
+       │   Context: 1M tokens | Output: 64K | Cost: $0.50/1M
+       ├── gemini-2.5-flash-lite
+       │   Context: 1M tokens | Output: 64K | Cost: $0.10/1M
+       ├── gemini-3.0-pro
+       │   Context: 2M tokens | Output: 64K | Cost: $2.00/1M
+       ├── gpt-5.2
+       │   Context: 400K tokens | Output: 128K | Cost: $1.75/1M
+       ├── gpt-5.2-pro
+       │   Context: 400K tokens | Output: 128K | Cost: $21.00/1M
+       └── gpt-5-mini
+           Context: 128K tokens | Output: 16K | Cost: $.25/1M
 ```
 
 **Model Metadata Shown:**
@@ -638,7 +638,7 @@ offline-mode = false                    # Use bundled models only
 {
   "models": [
     {
-      "id": "gemini-2.0-flash",
+      "id": "gemini-2.5-flash",
       "provider": "google",
       "displayName": "Gemini 2.0 Flash",
       "contextWindow": 1048576,
@@ -740,7 +740,7 @@ tools:
 
 | Field | Hover Shows |
 |-------|-------------|
-| `model: gemini-2.0-flash` | Model info, context size, pricing |
+| `model: gemini-2.5-flash` | Model info, context size, pricing |
 | `config.temperature: 0.7` | Valid range, effect on output |
 | `input.schema.name: string` | Type info, validation rules |
 | `output.format: json` | Format options, when to use each |
@@ -774,9 +774,9 @@ error[unknown-model]: Unknown model 'gemini-3.0-flash'
   --> greeting.prompt:1:8
    |
  1 |   model: gemini-3.0-flash
-   |          ^^^^^^^^^^^^^^^^ did you mean 'gemini-2.0-flash'?
+   |          ^^^^^^^^^^^^^^^^ did you mean 'gemini-2.5-flash'?
    |
-help: available models: gemini-2.0-flash, gemini-1.5-pro, gpt-4o
+help: available models: gemini-2.5-flash, gemini-2.5-pro, gpt-4o
 
 ---
 
@@ -999,7 +999,7 @@ Options:
 ```bash
 # Lint files
 promptly check                      # Check current directory
-promptly check prompts/             # Check specific directory  
+promptly check prompts/             # Check specific directory
 promptly check *.prompt             # Check specific files
 promptly check --fix                # Auto-fix issues
 promptly check --format=json        # JSON output for CI
@@ -1023,7 +1023,7 @@ promptly run greeting.prompt -i '{"name": "Alice"}'    # Run with inline input
 promptly run greeting.prompt -f input.json             # Run with input file
 promptly run greeting.prompt --dry-run                 # Render template only
 promptly run greeting.prompt --stream                  # Stream output tokens
-promptly run greeting.prompt -m gemini-2.0-flash       # Override model
+promptly run greeting.prompt -m gemini-2.5-flash       # Override model
 cat context.json | promptly run summarizer.prompt      # Pipe input
 
 # Evaluate prompts (comparative A/B testing)
@@ -1337,15 +1337,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Promptly
         uses: google/promptly-action@v1
         with:
           version: 'latest'
-      
+
       - name: Lint prompts
         run: promptly check --format=github
-      
+
       - name: Check formatting
         run: promptly fmt --check
 
@@ -1354,13 +1354,13 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Promptly
         uses: google/promptly-action@v1
-      
+
       - name: Install dependencies
         run: promptly store install --frozen
-      
+
       - name: Run evaluations
         run: promptly evaluate tests/evaluation.yaml
         env:
@@ -1383,27 +1383,27 @@ jobs:
     permissions:
       contents: read
       id-token: write  # For OIDC authentication
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Promptly
         uses: google/promptly-action@v1
-      
+
       - name: Validate package
         run: |
           promptly check --strict
           promptly pack --dry-run
-      
+
       - name: Publish to Prompt Store
         uses: google/promptly-publish-action@v1
         with:
           # Option 1: API token
           token: ${{ secrets.PROMPTLY_TOKEN }}
-          
+
           # Option 2: OIDC (recommended for GitHub)
           # oidc: true
-          
+
           # Optional settings
           tag: ${{ github.event.release.prerelease && 'beta' || 'latest' }}
           access: public
@@ -1431,17 +1431,17 @@ jobs:
         with:
           release-type: simple
           package-name: "@google/code-assistant"
-          
+
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Promptly
         uses: google/promptly-action@v1
-      
+
       - name: Publish
         run: promptly publish
         env:
@@ -1471,15 +1471,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: google/promptly-action@v1
         with:
           version: ${{ inputs.promptly-version }}
-      
+
       - run: promptly check --format=github
       - run: promptly fmt --check
       - run: promptly store install --frozen
-      
+
       - if: ${{ secrets.GOOGLE_API_KEY != '' }}
         run: promptly evaluate tests/evaluation.yaml
         env:
@@ -2148,7 +2148,7 @@ For automated evaluation, an LLM judges the outputs:
 ```yaml
 # evaluation-judge.prompt
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0
 input:
@@ -2164,7 +2164,7 @@ output:
     explanation: string
 ---
 
-You are an expert prompt evaluator. Given the original input and multiple 
+You are an expert prompt evaluator. Given the original input and multiple
 prompt variation outputs, score each on the provided criteria.
 
 ## Original Input
@@ -2182,7 +2182,7 @@ prompt variation outputs, score each on the provided criteria.
 - {{ this }}
 {{/each}}
 
-Provide scores (1-5) for each variation on each criterion, explain your 
+Provide scores (1-5) for each variation on each criterion, explain your
 reasoning, and declare a winner.
 ```
 
@@ -2196,7 +2196,7 @@ promptly evaluate experiment.yaml
 promptly evaluate experiment.yaml --output results.json
 
 # Use specific judge model
-promptly evaluate experiment.yaml --judge gemini-2.0-flash
+promptly evaluate experiment.yaml --judge gemini-2.5-flash
 ```
 
 ### Evaluation Manifest (`experiment.yaml`)
@@ -2210,10 +2210,10 @@ base_prompt: prompts/customer-support.prompt
 variations:
   - name: baseline
     file: prompts/customer-support.prompt
-  
+
   - name: friendly
     file: prompts/customer-support-friendly.prompt
-  
+
   - name: concise
     # Inline variation
     template: |
@@ -2227,7 +2227,7 @@ test_cases:
       customer_message: "WHERE IS MY REFUND?!"
       order_id: "12345"
     expected_intent: "acknowledge frustration, provide timeline"
-  
+
   - input:
       customer_message: "How do I return this item?"
       order_id: "67890"
@@ -2239,7 +2239,7 @@ metrics:
   - conciseness
 
 judge:
-  model: gemini-2.0-flash
+  model: gemini-2.5-flash
   temperature: 0
 
 settings:
@@ -2896,42 +2896,42 @@ graph TD
     subgraph "Layer 0: Foundation"
         CORE[promptly-core<br/>AST, Config, Types]
     end
-    
+
     subgraph "Layer 1: Parsing"
         PARSER[promptly-parser<br/>YAML + Handlebars]
     end
-    
+
     subgraph "Layer 2: Analysis"
         LINTER[promptly-linter<br/>Errors, Warnings]
         FORMATTER[promptly-formatter<br/>Indentation, Spacing]
     end
-    
+
     subgraph "Layer 3: IDE Support"
         LSP[promptly-lsp<br/>Language Server]
     end
-    
+
     subgraph "Layer 4: Execution"
         RUNNER[promptly-runner<br/>Model APIs]
         TEST[promptly-test<br/>Assertions, Snapshots]
     end
-    
+
     subgraph "Layer 5: Evaluation"
         EVAL[promptly-evaluate<br/>LLM-as-Judge]
     end
-    
+
     subgraph "Layer 6: Packaging"
         STORE[promptly-store<br/>Registry Client]
         SECURITY[promptly-security<br/>Scanner]
     end
-    
+
     subgraph "Layer 7: Server"
         SERVER[promptly-server<br/>Axum API]
     end
-    
+
     subgraph "Layer 8: CLI"
         CLI[promptly-cli<br/>All Commands]
     end
-    
+
     CORE --> PARSER
     PARSER --> LINTER
     PARSER --> FORMATTER
@@ -2945,7 +2945,7 @@ graph TD
     PARSER --> STORE
     CORE --> STORE
     STORE --> SERVER
-    
+
     LSP --> CLI
     RUNNER --> CLI
     TEST --> CLI
@@ -2990,7 +2990,7 @@ Layer 2: [LINTER]    [FORMATTER]    [RUNNER]    ← Can build in parallel
 Layer 3: [LSP]                       [TEST]     ← Can build in parallel
          │                              │
          │                              ▼
-Layer 4: │                           [EVAL]     
+Layer 4: │                           [EVAL]
          │                              │
          ├──────────────────────────────┤
          │                              │
@@ -3944,18 +3944,18 @@ jobs:
           script: |
             const previewUrl = '${{ steps.firebase-deploy.outputs.details_url }}';
             const expireTime = '${{ steps.firebase-deploy.outputs.expire_time }}';
-            
+
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `## 🚀 Preview Deployment Ready!
-              
+
               | Environment | URL |
               |-------------|-----|
               | **Frontend** | ${previewUrl} |
               | **Expires** | ${expireTime} |
-              
+
               This preview will be automatically deleted 7 days after the last update.
               `
             });
@@ -4009,13 +4009,13 @@ jobs:
         with:
           script: |
             const apiUrl = '${{ steps.deploy.outputs.url }}';
-            
+
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `## 🔌 API Preview Ready!
-              
+
               | Environment | URL |
               |-------------|-----|
               | **API** | ${apiUrl} |
@@ -4271,7 +4271,7 @@ crates/promptly-cli/prompts/
 
 ```handlebars
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.0
 input:
@@ -4322,7 +4322,7 @@ Evaluate both responses against the criteria and return JSON:
 
 ```handlebars
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:
@@ -4368,7 +4368,7 @@ Return:
 
 ```handlebars
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.0
 input:
@@ -4478,7 +4478,7 @@ cat context.json | promptly run summarizer.prompt
 promptly run story-writer.prompt -i '{"topic": "dragons"}' --stream
 
 # A/B test different models
-promptly run analyzer.prompt -f data.json -m gemini-2.0-flash
+promptly run analyzer.prompt -f data.json -m gemini-2.5-flash
 promptly run analyzer.prompt -f data.json -m gpt-4o
 promptly run analyzer.prompt -f data.json -m claude-3-5-sonnet
 
@@ -4499,7 +4499,7 @@ Prompt files can include a shebang header to make them directly executable on Un
 ```bash
 #!/usr/bin/env promptly run
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 ---
@@ -4542,7 +4542,7 @@ When a prompt file is executed directly, bare `--key=value` arguments are automa
 ```bash
 #!/usr/bin/env promptly run                    # Standard
 #!/usr/bin/env promptly run --stream           # Always stream
-#!/usr/bin/env promptly run -m gemini-2.0-flash # Force model
+#!/usr/bin/env promptly run -m gemini-2.5-flash # Force model
 #!/usr/bin/env promptly run --dry-run          # Preview only
 ```
 
@@ -4635,13 +4635,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install promptly
         run: cargo install promptly
-      
+
       - name: Check prompts
         run: promptly check --format=github
-      
+
       - name: Check formatting
         run: promptly fmt --check
 
@@ -4650,13 +4650,13 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install promptly
         run: cargo install promptly
-      
+
       - name: Install dependencies
         run: promptly store install --frozen
-      
+
       - name: Dry run all prompts
         run: |
           for f in prompts/*.prompt; do
@@ -4679,15 +4679,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install promptly
         run: cargo install promptly
-      
+
       - name: Validate package
         run: |
           promptly check --strict
           promptly store publish --dry-run
-      
+
       - name: Publish to Prompt Store
         run: promptly store publish
         env:
@@ -5041,7 +5041,7 @@ CREATE INDEX idx_audit_logs_user ON audit_logs(user_id, created_at DESC);
 CREATE INDEX idx_package_keywords_keyword ON package_keywords(keyword);
 
 -- Full-text search
-CREATE INDEX idx_packages_search ON packages 
+CREATE INDEX idx_packages_search ON packages
     USING GIN (to_tsvector('english', name || ' ' || COALESCE(description, '')));
 ```
 
@@ -5088,7 +5088,7 @@ rs/promptly/tests/
 fn test_lint_missing_partial() {
     let source = r#"
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 {{> nonexistent}}
 "#;
@@ -5117,12 +5117,12 @@ fn test_formatter_idempotent() {
 async fn test_publish_package() {
     let postgres = testcontainers::PostgresContainer::new();
     let pool = setup_test_db(&postgres).await;
-    
+
     let app = create_app(pool);
     let response = app
         .oneshot(Request::put("/api/v1/packages/@test/my-package").body(tarball))
         .await;
-    
+
     assert_eq!(response.status(), StatusCode::CREATED);
 }
 ```
@@ -5328,7 +5328,7 @@ A comprehensive testing framework for validating prompt behavior.
 ```yaml
 # tests/greeting.test.yaml
 prompt: greeting.prompt
-model: gemini-2.0-flash  # Optional: override for testing
+model: gemini-2.5-flash  # Optional: override for testing
 
 cases:
   - name: "basic greeting"
@@ -5337,13 +5337,13 @@ cases:
       contains: ["Hello", "Alice"]
       not_contains: ["error", "undefined"]
       regex: "Hello,? Alice"
-      
+
   - name: "handles empty name gracefully"
     input: { name: "" }
     expect:
       not_contains: ["undefined", "null"]
       min_length: 10
-      
+
   - name: "JSON output validation"
     input: { items: ["a", "b", "c"] }
     expect:
@@ -5352,12 +5352,12 @@ cases:
       json_path:
         "$.items.length": 3
         "$.status": "success"
-      
+
   - name: "golden output comparison"
     input: { name: "Bob" }
     expect:
       snapshot: true  # Compare against saved snapshot
-      
+
   - name: "semantic similarity"
     input: { topic: "weather" }
     expect:
@@ -5412,7 +5412,7 @@ steps:
       code: "{{ inputs.code }}"
       language: "{{ inputs.language }}"
     output: analysis
-    
+
   - id: security-check
     prompt: prompts/security-scan.prompt
     input:
@@ -5420,7 +5420,7 @@ steps:
       analysis: "{{ steps.analyze.output }}"
     output: security_issues
     parallel: true  # Run in parallel with next step
-    
+
   - id: style-check
     prompt: prompts/style-review.prompt
     input:
@@ -5428,7 +5428,7 @@ steps:
       language: "{{ inputs.language }}"
     output: style_issues
     parallel: true
-    
+
   - id: generate-review
     prompt: prompts/generate-review.prompt
     depends_on: [analyze, security-check, style-check]
@@ -5438,7 +5438,7 @@ steps:
       security: "{{ steps.security-check.output }}"
       style: "{{ steps.style-check.output }}"
     output: review
-    
+
   - id: summarize
     prompt: prompts/summarize.prompt
     input:
@@ -5606,8 +5606,8 @@ $ promptly compat-check prompts/
 Checking compatibility...
 
 prompts/greeting.prompt:
-  ✅ gemini-2.0-flash    Compatible
-  ✅ gemini-1.5-pro      Compatible
+  ✅ gemini-2.5-flash    Compatible
+  ✅ gemini-2.5-pro      Compatible
   ✅ gpt-4o              Compatible
   ✅ gpt-4o-mini         Compatible
   ✅ claude-3-5-sonnet   Compatible
@@ -5615,7 +5615,7 @@ prompts/greeting.prompt:
   ❌ llama-3-8b          Missing: Tool calling not supported
 
 prompts/code-review.prompt:
-  ✅ gemini-2.0-flash    Compatible
+  ✅ gemini-2.5-flash    Compatible
   ⚠️  gpt-4o             Warning: Uses {{#media}}, requires vision
   ❌ claude-3-haiku      Missing: JSON mode not supported
 
@@ -5911,7 +5911,7 @@ A dedicated panel in Chrome DevTools for debugging LLM calls:
 │  ┌─ LLM Requests ──────────────────────────────────────────────┐   │
 │  │ # │ Prompt              │ Model        │ Latency │ Tokens   │   │
 │  ├───┼─────────────────────┼──────────────┼─────────┼──────────┤   │
-│  │ 1 │ code-review.prompt  │ gemini-2.0   │ 1.2s    │ 847      │   │
+│  │ 1 │ code-review.prompt  │ gemini-2.5-flash   │ 1.2s    │ 847      │   │
 │  │ 2 │ summarize.prompt    │ gpt-4o       │ 0.8s    │ 423      │   │
 │  │ 3 │ translate.prompt    │ claude-3-5   │ 0.5s    │ 156      │   │
 │  └───┴─────────────────────┴──────────────┴─────────┴──────────┘   │
@@ -5984,15 +5984,15 @@ interface ExtensionSettings {
   // Syntax highlighting
   enableGitHubHighlighting: boolean;
   enableGitLabHighlighting: boolean;
-  
+
   // DevTools
   captureRequests: boolean;
   maxStoredRequests: number;  // Default: 100
-  
+
   // Quick actions
   enableContextMenu: boolean;
-  defaultModel: string;  // e.g., "gemini-2.0-flash"
-  
+  defaultModel: string;  // e.g., "gemini-2.5-flash"
+
   // Authentication
   promptlyToken?: string;
   aiStudioApiKey?: string;
@@ -6088,7 +6088,7 @@ Syntax highlighting and IntelliSense for Monaco-based editors (GitHub.dev, Stack
 import * as monaco from 'monaco-editor';
 
 // Register the language
-monaco.languages.register({ 
+monaco.languages.register({
   id: 'dotprompt',
   extensions: ['.prompt'],
   aliases: ['Dotprompt', 'prompt'],
@@ -6099,39 +6099,39 @@ monaco.languages.register({
 monaco.languages.setMonarchTokensProvider('dotprompt', {
   defaultToken: '',
   tokenPostfix: '.prompt',
-  
+
   brackets: [
     { open: '{{', close: '}}', token: 'delimiter.handlebars' },
     { open: '{{#', close: '}}', token: 'delimiter.block' },
     { open: '{{/', close: '}}', token: 'delimiter.block' },
   ],
-  
+
   tokenizer: {
     root: [
       // YAML frontmatter
       [/^---$/, 'delimiter.yaml', '@yaml'],
-      
+
       // Block helpers
       [/\{\{#(role|if|each|unless|with|section|history)\b/, 'keyword.block'],
       [/\{\{\/(role|if|each|unless|with|section|history)\b/, 'keyword.block'],
-      
+
       // Partials
       [/\{\{>/, 'keyword.partial'],
-      
+
       // Built-in helpers
       [/\{\{(json|media|eq|ne|lt|gt|and|or|not)\b/, 'support.function'],
-      
+
       // Variables
       [/\{\{[^}#/>!]+\}\}/, 'variable'],
-      
+
       // Comments
       [/\{\{!--/, 'comment', '@comment'],
       [/\{\{![^}]+\}\}/, 'comment'],
-      
+
       // Text
       [/./, 'text'],
     ],
-    
+
     yaml: [
       [/^---$/, 'delimiter.yaml', '@pop'],
       [/^\s*[a-zA-Z_][\w-]*:/, 'attribute.name'],
@@ -6141,7 +6141,7 @@ monaco.languages.setMonarchTokensProvider('dotprompt', {
       [/\b\d+(\.\d+)?\b/, 'number'],
       [/#.*$/, 'comment'],
     ],
-    
+
     comment: [
       [/--\}\}/, 'comment', '@pop'],
       [/./, 'comment'],
@@ -6180,7 +6180,7 @@ Embeddable components for any website:
 
 ```html
 <!-- Prompt Viewer - Display a prompt with syntax highlighting -->
-<promptly-viewer 
+<promptly-viewer
   src="@google/code-assistant/review.prompt"
   theme="dark"
   show-frontmatter="true"
@@ -6201,7 +6201,7 @@ Embeddable components for any website:
   prompt="@google/code-assistant/review"
   show-input="true"
   show-output="true"
-  model="gemini-2.0-flash"
+  model="gemini-2.5-flash"
   allow-model-selection="true"
 ></promptly-playground>
 
@@ -6241,7 +6241,7 @@ editor.addEventListener('validate', (e) => {
 const playground = document.querySelector('promptly-playground');
 const result = await playground.run({
   input: { name: 'Alice' },
-  model: 'gemini-2.0-flash'
+  model: 'gemini-2.5-flash'
 });
 ```
 
@@ -6337,19 +6337,19 @@ graph TD
     PKG --> SCHEMAS["📁 schemas/"]
     PKG --> TESTS["📁 tests/"]
     PKG --> RES["📁 resources/"]
-    
+
     PROMPTS --> P1["greeting.prompt"]
     PROMPTS --> P2["customer-support.prompt"]
     PROMPTS --> PARTIALS["📁 _partials/"]
     PARTIALS --> H["_header.prompt"]
     PARTIALS --> F["_footer.prompt"]
-    
+
     SCHEMAS --> S1["user.schema.json"]
     SCHEMAS --> S2["product.schema.json"]
-    
+
     TESTS --> T1["greeting.test.yaml"]
     TESTS --> SNAP["📁 snapshots/"]
-    
+
     RES --> IMG["📁 images/"]
     RES --> DATA["📁 data/"]
 ```
@@ -6388,10 +6388,10 @@ multilingual = ["translations"]
 
 [models]
 # Default model configurations
-default = "gemini-2.0-flash"
+default = "gemini-2.5-flash"
 fallback = ["gpt-4o", "claude-3-5-sonnet"]
 
-[models.gemini-2.0-flash]
+[models.gemini-2.5-flash]
 temperature = 0.7
 max_tokens = 1024
 

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -16,7 +16,7 @@ variable-interpolated UTF-8 encoded text templates, which can optionally use
 
     ```handlebars
     ---
-    model: googleai/gemini-1.5-pro
+    model: googleai/gemini-2.5-pro
     input:
       schema:
         text: string
@@ -39,7 +39,7 @@ variable-interpolated UTF-8 encoded text templates, which can optionally use
 
     This Dotprompt file:
 
-    1. Specifies the use of the `googleai/gemini-1.5-pro` model.
+    1. Specifies the use of the `googleai/gemini-2.5-pro` model.
     2. Defines an input schema expecting a `text` string.
     3. Specifies that the output should be in JSON format.
     4. Provides a schema for the expected output, including fields for name, age,
@@ -56,7 +56,7 @@ variable-interpolated UTF-8 encoded text templates, which can optionally use
 
     ```handlebars
     ---
-    model: googleai/gemini-1.5-flash
+    model: googleai/gemini-2.5-flash
     config:
       temperature: 0.9
     input:
@@ -75,7 +75,7 @@ variable-interpolated UTF-8 encoded text templates, which can optionally use
 
     This Dotprompt file:
 
-    1. Specifies the use of the `googleai/gemini-1.5-flash` model.
+    1. Specifies the use of the `googleai/gemini-2.5-flash` model.
     2. Defines a config block with a `temperature` of 0.9.
     3. Specifies an input schema with a `location` string and optional `style` and
       `name` strings.
@@ -90,7 +90,7 @@ configuration values for your prompt.
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 1.4
   topK: 50
@@ -109,7 +109,7 @@ front matter section:
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     theme?: string
@@ -315,7 +315,7 @@ You may refer to it in the `.dotprompt` file as follows:
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-flash-latest
+model: googleai/gemini-2.5-flash
 output:
   schema: MenuItemSchema
 ---
@@ -339,7 +339,7 @@ The `{{role}}` helper provides a simple way to construct multi-message prompts:
 
 ```handlebars
 ---
-model: vertexai/gemini-1.5-flash
+model: vertexai/gemini-2.5-flash
 input:
   schema:
     userQuestion: string
@@ -358,7 +358,7 @@ can use the `{{media}}` helper:
 
 ```handlebars
 ---
-model: vertexai/gemini-1.5-flash
+model: vertexai/gemini-2.5-flash
 input:
   schema:
     photoUrl: string
@@ -397,7 +397,7 @@ Once the helper has been defined you can use it in any prompt:
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     name: string
@@ -426,7 +426,7 @@ This can then be included in other prompts:
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     name: string
@@ -459,7 +459,7 @@ members of a list.
 
     ```handlebars
     ---
-    model: googleai/gemini-1.5-flash-latest
+    model: googleai/gemini-2.5-flash
     input:
       schema:
         destinations(array):
@@ -542,18 +542,18 @@ side-by-side with existing versions. Dotprompt supports this through its
 variants feature.
 
 To create a variant, create a `[name].[variant].prompt` file. For instance, if
-you were using Gemini 1.5 Flash in your prompt but wanted to see if Gemini 1.5
+you were using Gemini 2.5 Flash in your prompt but wanted to see if Gemini 2.5
 Pro would perform better, you might create two files:
 
 - `my_prompt.prompt`: the "baseline" prompt
-- `my_prompt.gemini15pro.prompt`: a variant named `gemini15pro`
+- `my_prompt.gemini25pro.prompt`: a variant named `gemini25pro`
 
 To use a prompt variant, specify the variant option when loading:
 
 === "TypeScript"
 
     ```typescript
-    const myPrompt = ai.prompt('my_prompt', { variant: 'gemini15pro' });
+    const myPrompt = ai.prompt('my_prompt', { variant: 'gemini25pro' });
     ```
 
 === "Go"

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ provided text:
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-pro
+model: googleai/gemini-2.5-pro
 input:
   schema:
     text: string
@@ -76,7 +76,7 @@ Text: {{text}}
 
 This Dotprompt file:
 
-1. Specifies the use of the `googleai/gemini-1.5-pro` model.
+1. Specifies the use of the `googleai/gemini-2.5-pro` model.
 2. Defines an input schema expecting a `text` string.
 3. Specifies that the output should be in JSON format.
 4. Provides a schema for the expected output, including fields for name, age,

--- a/examples/error-invalid-yaml.prompt
+++ b/examples/error-invalid-yaml.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
   maxOutputTokens: 1024

--- a/examples/error-multiple-issues.prompt
+++ b/examples/error-multiple-issues.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.5
 input:

--- a/examples/error-unbalanced-brace.prompt
+++ b/examples/error-unbalanced-brace.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 ---

--- a/examples/error-unclosed-block.prompt
+++ b/examples/error-unclosed-block.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:

--- a/examples/error-unmatched-closing-block.prompt
+++ b/examples/error-unmatched-closing-block.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 ---

--- a/examples/partials/circular-partial-a.prompt
+++ b/examples/partials/circular-partial-a.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 This partial includes another partial that creates a cycle.
 

--- a/examples/partials/circular-partial-b.prompt
+++ b/examples/partials/circular-partial-b.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 This partial includes the first partial, creating a cycle.
 

--- a/examples/valid-blog-generator.prompt
+++ b/examples/valid-blog-generator.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.9
 input:

--- a/examples/valid-comments-and-partials.prompt
+++ b/examples/valid-comments-and-partials.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:

--- a/examples/valid-customer-support.prompt
+++ b/examples/valid-customer-support.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:

--- a/examples/valid-greeting.prompt
+++ b/examples/valid-greeting.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
   maxOutputTokens: 1024

--- a/examples/warning-undefined-variable.prompt
+++ b/examples/warning-undefined-variable.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:

--- a/examples/warning-unused-variable.prompt
+++ b/examples/warning-unused-variable.prompt
@@ -1,5 +1,5 @@
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:

--- a/go/dotprompt/parse_test.go
+++ b/go/dotprompt/parse_test.go
@@ -1703,13 +1703,13 @@ Template content`
 	})
 
 	t.Run("should handle shebang and license header before frontmatter", func(t *testing.T) {
-		source := "#!/usr/bin/env promptly\n# Copyright 2025 Google\n# SPDX: Apache-2.0\n---\nmodel: gemini-2.0\n---\nHello combined!"
+		source := "#!/usr/bin/env promptly\n# Copyright 2025 Google\n# SPDX: Apache-2.0\n---\nmodel: gemini-2.5-flash\n---\nHello combined!"
 		result, err := ParseDocument(source)
 		if err != nil {
 			t.Errorf("ParseDocument() returned error: %v", err)
 		}
-		if result.Model != "gemini-2.0" {
-			t.Errorf("Model = %q, want \"gemini-2.0\"", result.Model)
+		if result.Model != "gemini-2.5-flash" {
+			t.Errorf("Model = %q, want \"gemini-2.5-flash\"", result.Model)
 		}
 		if result.Template != "Hello combined!" {
 			t.Errorf("Template = %q, want \"Hello combined!\"", result.Template)

--- a/go/dotprompt/types.go
+++ b/go/dotprompt/types.go
@@ -109,7 +109,7 @@ type PromptMetadata struct {
 	Version string `json:"version,omitempty"`
 	// A description of the prompt.
 	Description string `json:"description,omitempty"`
-	// The name of the model to use for this prompt, e.g. `vertexai/gemini-1.0-pro`
+	// The name of the model to use for this prompt, e.g. `vertexai/gemini-3.0-pro`
 	Model string `json:"model,omitempty"`
 	// Number of tool max turns
 	MaxTurns int `json:"maxTurns,omitempty"`

--- a/go/example/doc.md
+++ b/go/example/doc.md
@@ -30,7 +30,7 @@ When you run the program, the metadata from the `.prompt` file and the messages 
 
 ```text
 --- Metadata ---
-Model: gemini-1.5-flash
+Model: gemini-2.5-flash
 Description: Summarize the input text.
 
 --- Messages ---

--- a/go/example/example.prompt
+++ b/go/example/example.prompt
@@ -1,5 +1,5 @@
 ---
-model: "gemini-1.5-flash"
+model: "gemini-2.5-flash"
 description: "Summarize the input text."
 input:
   schema:

--- a/java/com/google/dotprompt/DotpromptOptions.java
+++ b/java/com/google/dotprompt/DotpromptOptions.java
@@ -37,7 +37,7 @@ import java.util.Map;
  *
  * <pre>{@code
  * DotpromptOptions options = DotpromptOptions.builder()
- *     .setDefaultModel("gemini-1.5-pro")
+ *     .setDefaultModel("gemini-2.5-pro")
  *     .setToolResolver(name -> toolMap.get(name))
  *     .setSchemaResolver(name -> schemaMap.get(name))
  *     .addTool(myToolDefinition)

--- a/java/com/google/dotprompt/DotpromptOptionsTest.java
+++ b/java/com/google/dotprompt/DotpromptOptionsTest.java
@@ -52,9 +52,9 @@ public class DotpromptOptionsTest {
 
   @Test
   public void testBuilder_setDefaultModel() {
-    DotpromptOptions options = DotpromptOptions.builder().setDefaultModel("gemini-1.5-pro").build();
+    DotpromptOptions options = DotpromptOptions.builder().setDefaultModel("gemini-2.5-pro").build();
 
-    assertThat(options.getDefaultModel()).isEqualTo("gemini-1.5-pro");
+    assertThat(options.getDefaultModel()).isEqualTo("gemini-2.5-pro");
   }
 
   @Test
@@ -204,13 +204,13 @@ public class DotpromptOptionsTest {
   public void testBuilder_methodChaining() {
     DotpromptOptions options =
         DotpromptOptions.builder()
-            .setDefaultModel("gemini-1.5-pro")
+            .setDefaultModel("gemini-2.5-pro")
             .addModelConfig("gpt-4", Map.of("temp", 0.5))
             .addPartial("intro", "Hello")
             .addSchema("User", Map.of("type", "object"))
             .build();
 
-    assertThat(options.getDefaultModel()).isEqualTo("gemini-1.5-pro");
+    assertThat(options.getDefaultModel()).isEqualTo("gemini-2.5-pro");
     assertThat(options.getModelConfigs()).hasSize(1);
     assertThat(options.getPartials()).hasSize(1);
     assertThat(options.getSchemas()).hasSize(1);

--- a/java/com/google/dotprompt/DotpromptTest.java
+++ b/java/com/google/dotprompt/DotpromptTest.java
@@ -49,7 +49,7 @@ public class DotpromptTest {
   public void constructor_initializesWithCustomModelConfigs() {
     Map<String, Object> modelConfigs =
         Map.of(
-            "gemini-1.5-pro", Map.of("temperature", 0.7), "gemini-2.0-flash", Map.of("top_p", 0.9));
+            "gemini-2.5-pro", Map.of("temperature", 0.7), "gemini-2.5-flash", Map.of("top_p", 0.9));
     DotpromptOptions options = DotpromptOptions.builder().setModelConfigs(modelConfigs).build();
     Dotprompt dp = new Dotprompt(options);
     assertThat(dp).isNotNull();
@@ -57,7 +57,7 @@ public class DotpromptTest {
 
   @Test
   public void constructor_initializesWithDefaultModel() {
-    DotpromptOptions options = DotpromptOptions.builder().setDefaultModel("gemini-1.5-pro").build();
+    DotpromptOptions options = DotpromptOptions.builder().setDefaultModel("gemini-2.5-pro").build();
     Dotprompt dp = new Dotprompt(options);
     assertThat(dp).isNotNull();
   }
@@ -300,17 +300,17 @@ public class DotpromptTest {
     Dotprompt dp = new Dotprompt(DotpromptOptions.builder().build());
 
     Map<String, Object> promptConfig = new HashMap<>();
-    promptConfig.put("model", "gemini-1.5-pro");
+    promptConfig.put("model", "gemini-2.5-pro");
     promptConfig.put("config", Map.of("temperature", 0.7));
     ParsedPrompt source = ParsedPrompt.fromMetadata("", PromptMetadata.fromConfig(promptConfig));
 
     Map<String, Object> additionalConfig = new HashMap<>();
-    additionalConfig.put("model", "gemini-2.0-flash");
+    additionalConfig.put("model", "gemini-2.5-flash");
     additionalConfig.put("config", Map.of("max_tokens", 2000));
 
     PromptMetadata result = dp.renderMetadata(source, additionalConfig).get();
 
-    assertThat(result.model()).isEqualTo("gemini-2.0-flash");
+    assertThat(result.model()).isEqualTo("gemini-2.5-flash");
     assertThat(result.config()).containsEntry("temperature", 0.7);
     assertThat(result.config()).containsEntry("max_tokens", 2000);
   }
@@ -348,12 +348,12 @@ public class DotpromptTest {
   public void renderMetadata_usesModelConfigs() throws Exception {
     DotpromptOptions options =
         DotpromptOptions.builder()
-            .addModelConfig("gemini-1.5-pro", Map.of("temperature", 0.7))
+            .addModelConfig("gemini-2.5-pro", Map.of("temperature", 0.7))
             .build();
     Dotprompt dp = new Dotprompt(options);
 
     Map<String, Object> config = new HashMap<>();
-    config.put("model", "gemini-1.5-pro");
+    config.put("model", "gemini-2.5-pro");
     ParsedPrompt source = ParsedPrompt.fromMetadata("content", PromptMetadata.fromConfig(config));
 
     PromptMetadata metadata = dp.renderMetadata(source).get();

--- a/java/com/google/dotprompt/models/ParsedPrompt.java
+++ b/java/com/google/dotprompt/models/ParsedPrompt.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * <pre>{@code
  * String source = """
  *     ---
- *     model: gemini-1.5-pro
+ *     model: gemini-2.5-pro
  *     config:
  *       temperature: 0.7
  *     ---
@@ -40,7 +40,7 @@ import java.util.Map;
  *     """;
  * ParsedPrompt parsed = Parser.parseDocument(source);
  * // parsed.template() -> "Hello {{name}}!"
- * // parsed.model() -> "gemini-1.5-pro"
+ * // parsed.model() -> "gemini-2.5-pro"
  * }</pre>
  *
  * @param template The source of the template with metadata/frontmatter already removed.

--- a/java/com/google/dotprompt/models/PromptMetadata.java
+++ b/java/com/google/dotprompt/models/PromptMetadata.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * @param variant The variant name for the prompt.
  * @param version The version of the prompt.
  * @param description A description of the prompt.
- * @param model The name of the model to use (e.g., "vertexai/gemini-1.0-pro").
+ * @param model The name of the model to use (e.g., "vertexai/gemini-3.0-pro").
  * @param tools Names of tools (registered separately) to allow use of in this prompt.
  * @param toolDefs Definitions of tools to allow use of in this prompt.
  * @param config Model configuration. Not all models support all options.

--- a/java/com/google/dotprompt/package-info.java
+++ b/java/com/google/dotprompt/package-info.java
@@ -66,7 +66,7 @@
  * // Define a prompt template
  * String template = """
  *     ---
- *     model: gemini-1.5-pro
+ *     model: gemini-2.5-pro
  *     ---
  *     Hello, {{name}}! How can I help you today?
  *     """;

--- a/java/com/google/dotprompt/parser/ParserTest.java
+++ b/java/com/google/dotprompt/parser/ParserTest.java
@@ -618,11 +618,11 @@ public class ParserTest {
 
   @Test
   public void testParseDocument_withModelConfig() throws IOException {
-    String source = "---\nmodel: gemini-1.5-pro\n---\nTemplate content";
+    String source = "---\nmodel: gemini-2.5-pro\n---\nTemplate content";
 
     var result = Parser.parseDocument(source);
 
-    assertThat(result.model()).isEqualTo("gemini-1.5-pro");
+    assertThat(result.model()).isEqualTo("gemini-2.5-pro");
     assertThat(result.template()).isEqualTo("Template content");
   }
 
@@ -660,12 +660,12 @@ public class ParserTest {
             + "# Copyright 2025 Google\n"
             + "# SPDX: Apache-2.0\n"
             + "---\n"
-            + "model: gemini-2.0\n"
+            + "model: gemini-2.5-flash\n"
             + "---\n"
             + "Hello combined!";
     Prompt prompt = Parser.parse(content);
     assertThat(prompt.template()).isEqualTo("Hello combined!");
-    assertThat(prompt.config()).containsEntry("model", "gemini-2.0");
+    assertThat(prompt.config()).containsEntry("model", "gemini-2.5-flash");
   }
 
   @Test

--- a/js/examples/adapters.ts
+++ b/js/examples/adapters.ts
@@ -25,7 +25,7 @@ const prompts = new Dotprompt();
 async function main() {
   const rendered = await prompts.render(
     `---
-model: gemini-1.5-flash
+model: gemini-2.5-flash
 input:
   schema:
     subject: string

--- a/js/src/dotprompt.test.ts
+++ b/js/src/dotprompt.test.ts
@@ -31,15 +31,15 @@ describe('Dotprompt', () => {
 
     it('should initialize with custom model configs', () => {
       const modelConfigs = {
-        'gemini-1.5-pro': { temperature: 0.7 },
-        'gemini-2.0-flash': { top_p: 0.9 },
+        'gemini-2.5-pro': { temperature: 0.7 },
+        'gemini-2.5-flash': { top_p: 0.9 },
       };
       const dp = new Dotprompt({ modelConfigs });
       expect(dp).toBeInstanceOf(Dotprompt);
     });
 
     it('should initialize with default model', () => {
-      const defaultModel = 'gemini-1.5-pro';
+      const defaultModel = 'gemini-2.5-pro';
       const dp = new Dotprompt({ defaultModel });
       expect(dp).toBeInstanceOf(Dotprompt);
     });
@@ -170,7 +170,7 @@ describe('Dotprompt', () => {
       const parseDocumentMock = vi.spyOn(parse, 'parseDocument');
       parseDocumentMock.mockReturnValue({
         template: 'Template content',
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
       });
 
       const dp = new Dotprompt();
@@ -179,7 +179,7 @@ describe('Dotprompt', () => {
       expect(parseDocumentMock).toHaveBeenCalledWith('Source template');
       expect(result).toEqual({
         template: 'Template content',
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
       });
     });
   });
@@ -459,7 +459,7 @@ describe('Dotprompt', () => {
       const dp = new Dotprompt();
 
       const metadata: PromptMetadata = {
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
       };
 
       // @ts-ignore Accessing private method for testing.
@@ -525,7 +525,7 @@ describe('Dotprompt', () => {
       const dp = new Dotprompt();
 
       const base: PromptMetadata = {
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
         config: {
           temperature: 0.7,
         },
@@ -539,7 +539,7 @@ describe('Dotprompt', () => {
       };
 
       const merge2: PromptMetadata = {
-        model: 'gemini-2.0-flash',
+        model: 'gemini-2.5-flash',
         config: {
           max_tokens: 2000,
         },
@@ -558,7 +558,7 @@ describe('Dotprompt', () => {
       // @ts-ignore Accessing private method for testing.
       const result = await dp.resolveMetadata(base, merge1, merge2);
 
-      expect(result.model).toBe('gemini-2.0-flash');
+      expect(result.model).toBe('gemini-2.5-flash');
       expect(result.config).toEqual({
         temperature: 0.7,
         top_p: 0.9,
@@ -576,7 +576,7 @@ describe('Dotprompt', () => {
       const dp = new Dotprompt();
 
       const base: PromptMetadata = {
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
         config: {
           temperature: 0.7,
         },
@@ -595,7 +595,7 @@ describe('Dotprompt', () => {
       // @ts-ignore Accessing private method for testing.
       const result = await dp.resolveMetadata(base, undefined);
 
-      expect(result.model).toBe('gemini-1.5-pro');
+      expect(result.model).toBe('gemini-2.5-pro');
       expect(result.config).toEqual({
         temperature: 0.7,
       });
@@ -721,11 +721,11 @@ describe('Dotprompt', () => {
 
       const parsedSource = {
         template: 'Template content',
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
       };
 
       const resolveMetadataMock = vi.fn().mockResolvedValue({
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
         processed: true,
       });
 
@@ -741,7 +741,7 @@ describe('Dotprompt', () => {
       );
 
       expect(result).toEqual({
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
         processed: true,
       });
     });
@@ -773,14 +773,14 @@ describe('Dotprompt', () => {
 
     it('should use model configs when available', async () => {
       const modelConfigs = {
-        'gemini-1.5-pro': { temperature: 0.7 },
+        'gemini-2.5-pro': { temperature: 0.7 },
       };
 
       const dp = new Dotprompt({ modelConfigs });
 
       const parsedSource = {
         template: 'Template content',
-        model: 'gemini-1.5-pro',
+        model: 'gemini-2.5-pro',
       };
 
       const resolveMetadataMock = vi

--- a/js/src/parse.test.ts
+++ b/js/src/parse.test.ts
@@ -932,11 +932,11 @@ Hello shebang!`;
 # Copyright 2025 Google
 # SPDX: Apache-2.0
 ---
-model: gemini-2.0
+model: gemini-2.5-flash
 ---
 Hello combined!`;
     const result = parseDocument(source);
-    expect(result.model).toBe('gemini-2.0');
+    expect(result.model).toBe('gemini-2.5-flash');
     expect(result.template).toBe('Hello combined!');
   });
 });

--- a/packages/codemirror/samples/01-basic.prompt
+++ b/packages/codemirror/samples/01-basic.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 
 You are a helpful assistant. Answer the user's question.

--- a/packages/codemirror/samples/02-schema-and-config.prompt
+++ b/packages/codemirror/samples/02-schema-and-config.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.7
   maxOutputTokens: 2048

--- a/packages/codemirror/samples/03-multimodal-media.prompt
+++ b/packages/codemirror/samples/03-multimodal-media.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     images: string[], Array of image URLs to analyze

--- a/packages/codemirror/samples/04-tools.prompt
+++ b/packages/codemirror/samples/04-tools.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 tools:
   - getWeather
   - searchWeb

--- a/packages/codemirror/samples/05-handlebars-helpers.prompt
+++ b/packages/codemirror/samples/05-handlebars-helpers.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     userName: string

--- a/packages/codemirror/samples/06-partials.prompt
+++ b/packages/codemirror/samples/06-partials.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     customerName: string

--- a/packages/codemirror/samples/07-multi-turn-history.prompt
+++ b/packages/codemirror/samples/07-multi-turn-history.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     newMessage: string

--- a/packages/codemirror/samples/08-sections-thinking.prompt
+++ b/packages/codemirror/samples/08-sections-thinking.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.5
 input:

--- a/packages/codemirror/samples/09-complex-schema.prompt
+++ b/packages/codemirror/samples/09-complex-schema.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     type: object

--- a/packages/codemirror/samples/10-kitchen-sink.prompt
+++ b/packages/codemirror/samples/10-kitchen-sink.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.8
   maxOutputTokens: 4096

--- a/packages/codemirror/samples/11-multilingual-unicode.prompt
+++ b/packages/codemirror/samples/11-multilingual-unicode.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.7
 input:

--- a/packages/codemirror/src/completions.ts
+++ b/packages/codemirror/src/completions.ts
@@ -198,34 +198,69 @@ const FRONTMATTER_FIELDS: Completion[] = [
  * Model name completions.
  */
 const MODEL_NAMES: Completion[] = [
+  // Gemini 3 Series (Preview)
   {
-    label: 'gemini-2.0-flash',
+    label: 'gemini-3-pro-preview',
     type: 'constant',
-    info: 'Fast Gemini 2.0 model',
+    info: 'Most capable model for complex tasks (Preview)',
   },
   {
-    label: 'gemini-2.0-flash-lite',
+    label: 'gemini-3-flash-preview',
     type: 'constant',
-    info: 'Lightweight Gemini 2.0',
+    info: 'Fast and intelligent model for high-volume tasks (Preview)',
+  },
+  // Gemini 2.5 Series (Stable)
+  {
+    label: 'gemini-2.5-pro',
+    type: 'constant',
+    info: 'Most capable stable model for complex tasks',
   },
   {
-    label: 'gemini-1.5-pro',
+    label: 'gemini-2.5-flash',
     type: 'constant',
-    info: 'Gemini 1.5 Pro (2M context)',
+    info: 'Fast and efficient for most use cases',
   },
   {
-    label: 'gemini-1.5-flash',
+    label: 'gemini-2.5-flash-lite',
     type: 'constant',
-    info: 'Fast Gemini 1.5 model',
+    info: 'Lightweight version for simple tasks',
   },
+  // Gemma 3 Series
+  {
+    label: 'gemma-3-27b-it',
+    type: 'constant',
+    info: 'Large instruction-tuned Gemma 3',
+  },
+  {
+    label: 'gemma-3-12b-it',
+    type: 'constant',
+    info: 'Medium instruction-tuned Gemma 3',
+  },
+  // OpenAI
   { label: 'gpt-4o', type: 'constant', info: 'OpenAI GPT-4o' },
   { label: 'gpt-4o-mini', type: 'constant', info: 'OpenAI GPT-4o Mini' },
+  // Anthropic
   {
     label: 'claude-3-5-sonnet',
     type: 'constant',
     info: 'Anthropic Claude 3.5 Sonnet',
   },
-  { label: 'claude-3-opus', type: 'constant', info: 'Anthropic Claude 3 Opus' },
+  // Deprecated / Older Models
+  {
+    label: 'gemini-2.0-flash',
+    type: 'constant',
+    info: '(Deprecated) Fast Gemini 2.0 model',
+  },
+  {
+    label: 'gemini-1.5-pro',
+    type: 'constant',
+    info: '(Deprecated) Gemini 1.5 Pro',
+  },
+  {
+    label: 'gemini-1.5-flash',
+    type: 'constant',
+    info: '(Deprecated) Fast Gemini 1.5 model',
+  },
 ];
 
 /**

--- a/packages/jetbrains/src/main/resources/liveTemplates/Dotprompt.xml
+++ b/packages/jetbrains/src/main/resources/liveTemplates/Dotprompt.xml
@@ -155,7 +155,7 @@
 
     <!-- Full template -->
     <template name="prompt" value="---&#10;model: $MODEL$&#10;config:&#10;  temperature: $TEMPERATURE$&#10;input:&#10;  schema:&#10;    $VARIABLE$: string&#10;---&#10;&#10;{{#role &quot;system&quot;}}&#10;$SYSTEM_PROMPT$&#10;{{/role}}&#10;&#10;{{#role &quot;user&quot;}}&#10;$USER_PROMPT$&#10;{{/role}}" description="Complete prompt template" toReformat="false" toShortenFQNames="true">
-        <variable name="MODEL" expression="" defaultValue="&quot;gemini-2.0-flash&quot;" alwaysStopAt="true"/>
+        <variable name="MODEL" expression="" defaultValue="&quot;gemini-2.5-flash&quot;" alwaysStopAt="true"/>
         <variable name="TEMPERATURE" expression="" defaultValue="&quot;0.7&quot;" alwaysStopAt="true"/>
         <variable name="VARIABLE" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true"/>
         <variable name="SYSTEM_PROMPT" expression="" defaultValue="&quot;You are a helpful assistant.&quot;" alwaysStopAt="true"/>
@@ -167,7 +167,7 @@
 
     <!-- Frontmatter -->
     <template name="frontmatter" value="---&#10;model: $MODEL$&#10;config:&#10;  temperature: $TEMPERATURE$&#10;---" description="YAML frontmatter" toReformat="false" toShortenFQNames="true">
-        <variable name="MODEL" expression="" defaultValue="&quot;gemini-2.0-flash&quot;" alwaysStopAt="true"/>
+        <variable name="MODEL" expression="" defaultValue="&quot;gemini-2.5-flash&quot;" alwaysStopAt="true"/>
         <variable name="TEMPERATURE" expression="" defaultValue="&quot;0.7&quot;" alwaysStopAt="true"/>
         <context>
             <option name="OTHER" value="true"/>

--- a/packages/monaco/README.md
+++ b/packages/monaco/README.md
@@ -33,7 +33,7 @@ registerDotpromptLanguage(monaco);
 // Create an editor
 const editor = monaco.editor.create(document.getElementById('container')!, {
   value: `---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 ---

--- a/packages/monaco/samples/01-basic.prompt
+++ b/packages/monaco/samples/01-basic.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 
 You are a helpful assistant. Answer the user's question.

--- a/packages/monaco/samples/02-schema-and-config.prompt
+++ b/packages/monaco/samples/02-schema-and-config.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.7
   maxOutputTokens: 2048

--- a/packages/monaco/samples/03-multimodal-media.prompt
+++ b/packages/monaco/samples/03-multimodal-media.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     images: string[], Array of image URLs to analyze

--- a/packages/monaco/samples/04-tools.prompt
+++ b/packages/monaco/samples/04-tools.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 tools:
   - getWeather
   - searchWeb

--- a/packages/monaco/samples/05-handlebars-helpers.prompt
+++ b/packages/monaco/samples/05-handlebars-helpers.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     userName: string

--- a/packages/monaco/samples/06-partials.prompt
+++ b/packages/monaco/samples/06-partials.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     customerName: string

--- a/packages/monaco/samples/07-multi-turn-history.prompt
+++ b/packages/monaco/samples/07-multi-turn-history.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     newMessage: string

--- a/packages/monaco/samples/08-sections-thinking.prompt
+++ b/packages/monaco/samples/08-sections-thinking.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.5
 input:

--- a/packages/monaco/samples/09-complex-schema.prompt
+++ b/packages/monaco/samples/09-complex-schema.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 input:
   schema:
     type: object

--- a/packages/monaco/samples/10-kitchen-sink.prompt
+++ b/packages/monaco/samples/10-kitchen-sink.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.8
   maxOutputTokens: 4096

--- a/packages/monaco/samples/11-multilingual-unicode.prompt
+++ b/packages/monaco/samples/11-multilingual-unicode.prompt
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-model: googleai/gemini-2.0-flash
+model: googleai/gemini-2.5-flash
 config:
   temperature: 0.7
 input:

--- a/packages/monaco/src/completions.ts
+++ b/packages/monaco/src/completions.ts
@@ -166,7 +166,7 @@ const FRONTMATTER_FIELDS = [
   {
     label: 'model',
     kind: 5, // Field
-    insertText: 'model: ${1:gemini-2.0-flash}',
+    insertText: 'model: ${1:gemini-2.5-flash}',
     insertTextRules: 4,
     documentation: 'The AI model to use for this prompt.',
   },
@@ -218,21 +218,59 @@ const FRONTMATTER_FIELDS = [
  * Model name completions.
  */
 const MODEL_NAMES = [
+  // Gemini 3 Series (Preview)
   {
-    label: 'gemini-2.0-flash',
-    documentation: 'Fast Gemini 2.0 model (1M context)',
+    label: 'gemini-3-pro-preview',
+    documentation: 'Most capable model for complex tasks (Preview)',
   },
   {
-    label: 'gemini-2.0-flash-lite',
-    documentation: 'Lightweight Gemini 2.0 model',
+    label: 'gemini-3-flash-preview',
+    documentation: 'Fast and intelligent model for high-volume tasks (Preview)',
   },
-  { label: 'gemini-1.5-pro', documentation: 'Gemini 1.5 Pro (2M context)' },
-  { label: 'gemini-1.5-flash', documentation: 'Fast Gemini 1.5 model' },
+  {
+    label: 'gemini-3-pro-image-preview',
+    documentation: 'Supports image generation outputs (Preview)',
+  },
+  // Gemini 2.5 Series (Stable)
+  {
+    label: 'gemini-2.5-pro',
+    documentation: 'Most capable stable model for complex tasks',
+  },
+  {
+    label: 'gemini-2.5-flash',
+    documentation: 'Fast and efficient for most use cases',
+  },
+  {
+    label: 'gemini-2.5-flash-lite',
+    documentation: 'Lightweight version for simple tasks',
+  },
+  {
+    label: 'gemini-2.5-flash-image',
+    documentation: 'Supports image generation outputs',
+  },
+  // Gemma 3 Series
+  { label: 'gemma-3-27b-it', documentation: 'Large instruction-tuned Gemma 3' },
+  { label: 'gemma-3-12b-it', documentation: 'Medium instruction-tuned Gemma 3' },
+  { label: 'gemma-3-4b-it', documentation: 'Small instruction-tuned Gemma 3' },
+  { label: 'gemma-3-1b-it', documentation: 'Tiny instruction-tuned Gemma 3' },
+  // OpenAI
   { label: 'gpt-4o', documentation: 'OpenAI GPT-4o (128K context)' },
   { label: 'gpt-4o-mini', documentation: 'OpenAI GPT-4o Mini' },
-  { label: 'gpt-4-turbo', documentation: 'OpenAI GPT-4 Turbo' },
+  // Anthropic
   { label: 'claude-3-5-sonnet', documentation: 'Anthropic Claude 3.5 Sonnet' },
-  { label: 'claude-3-opus', documentation: 'Anthropic Claude 3 Opus' },
+  // Deprecated / Older Models
+  {
+    label: 'gemini-2.0-flash',
+    documentation: '(Deprecated) Fast Gemini 2.0 model',
+  },
+  {
+    label: 'gemini-1.5-pro',
+    documentation: '(Deprecated) Gemini 1.5 Pro',
+  },
+  {
+    label: 'gemini-1.5-flash',
+    documentation: '(Deprecated) Fast Gemini 1.5 model',
+  },
 ].map((m) => ({
   ...m,
   kind: 12, // Value

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -32,7 +32,7 @@
  *
  * // Create an editor with Dotprompt support
  * const editor = monaco.editor.create(container, {
- *   value: '---\nmodel: gemini-2.0-flash\n---\nHello {{ name }}!',
+ *   value: '---\nmodel: gemini-2.5-flash\n---\nHello {{ name }}!',
  *   language: 'dotprompt',
  * });
  * ```

--- a/packages/treesitter/README.md
+++ b/packages/treesitter/README.md
@@ -37,7 +37,7 @@ const parser = new Parser();
 parser.setLanguage(Dotprompt);
 
 const source = `---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 Hello {{ name }}!`;
 

--- a/packages/treesitter/test/corpus/basic.txt
+++ b/packages/treesitter/test/corpus/basic.txt
@@ -3,7 +3,7 @@ DOCUMENT
 ================================================================================
 
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 Hello world!
 
@@ -133,7 +133,7 @@ FRONTMATTER WITH CONFIG
 ================================================================================
 
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 input:
@@ -177,7 +177,7 @@ LICENSE HEADER
 # Copyright 2026 Google LLC
 # Some license text
 ---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 Hello
 

--- a/packages/vscode/snippets/dotprompt.snippets.json
+++ b/packages/vscode/snippets/dotprompt.snippets.json
@@ -3,7 +3,7 @@
     "prefix": ["frontmatter", "---"],
     "body": [
       "---",
-      "model: ${1:gemini-2.0-flash}",
+      "model: ${1:gemini-2.5-flash}",
       "config:",
       "  temperature: ${2:0.7}",
       "input:",
@@ -144,7 +144,7 @@
     "prefix": ["prompt", "newprompt"],
     "body": [
       "---",
-      "model: ${1:gemini-2.0-flash}",
+      "model: ${1:gemini-2.5-flash}",
       "config:",
       "  temperature: ${2:0.7}",
       "input:",

--- a/python/dotpromptz/README.md
+++ b/python/dotpromptz/README.md
@@ -44,7 +44,7 @@ Here's an example of a Dotprompt file that extracts structured data from provide
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-pro
+model: googleai/gemini-2.5-pro
 input:
   schema:
     text: string
@@ -62,7 +62,7 @@ present, omit that field from the output. Text:
 
 This Dotprompt file:
 
-1. Specifies the use of the `googleai/gemini-1.5-pro` model.
+1. Specifies the use of the `googleai/gemini-2.5-pro` model.
 2. Defines an input schema expecting a `text` string.
 3. Specifies that the output should be in JSON format.
 4. Provides a schema for the expected output, including fields for name, age, and occupation.

--- a/python/dotpromptz/src/dotpromptz/__init__.py
+++ b/python/dotpromptz/src/dotpromptz/__init__.py
@@ -100,7 +100,7 @@ for message in rendered.messages:
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-pro
+model: googleai/gemini-2.5-pro
 input:
   schema:
     topic: string, The topic to explain

--- a/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
+++ b/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
@@ -388,7 +388,7 @@ class TestRenderPicoSchema(IsolatedAsyncioTestCase):
             'output': {
                 'schema': {'type': 'number'},
             },
-            'model': 'gemini-1.5-pro',
+            'model': 'gemini-2.5-pro',
         })
         result: PromptMetadata[dict[str, Any]] = await dotprompt._render_picoschema(metadata)
         assert result == metadata
@@ -443,7 +443,7 @@ class TestResolveMetaData(IsolatedAsyncioTestCase):
         dotprompt = Dotprompt()
 
         base: PromptMetadata[dict[str, Any]] = PromptMetadata.model_validate({
-            'model': 'gemini-1.5-pro',
+            'model': 'gemini-2.5-pro',
             'config': {
                 'temperature': 0.7,
             },
@@ -457,7 +457,7 @@ class TestResolveMetaData(IsolatedAsyncioTestCase):
         })
 
         merge2: PromptMetadata[dict[str, Any]] = PromptMetadata.model_validate({
-            'model': 'gemini-2.0-flash',
+            'model': 'gemini-2.5-flash',
             'config': {
                 'max_tokens': 2000,
             },
@@ -469,7 +469,7 @@ class TestResolveMetaData(IsolatedAsyncioTestCase):
             patch.object(dotprompt, '_render_picoschema', render_pico_mock),
         ):
             result = await dotprompt._resolve_metadata(base, merge1, merge2)
-            self.assertEqual(result.model, 'gemini-2.0-flash')
+            self.assertEqual(result.model, 'gemini-2.5-flash')
             self.assertEqual(
                 result.config,
                 {
@@ -488,7 +488,7 @@ class TestResolveMetaData(IsolatedAsyncioTestCase):
         dotprompt = Dotprompt()
 
         base: PromptMetadata[dict[str, Any]] = PromptMetadata[dict[str, Any]].model_validate({
-            'model': 'gemini-1.5-pro',
+            'model': 'gemini-2.5-pro',
             'config': {
                 'temperature': 0.7,
             },
@@ -503,7 +503,7 @@ class TestResolveMetaData(IsolatedAsyncioTestCase):
         ):
             result = await dotprompt._resolve_metadata(base)
 
-            self.assertEqual(result.model, 'gemini-1.5-pro')
+            self.assertEqual(result.model, 'gemini-2.5-pro')
             self.assertEqual(
                 result.config,
                 {
@@ -517,11 +517,11 @@ def test_render_metadata() -> None:
     dotprompt = Dotprompt()
 
     parsed_source: ParsedPrompt[dict[str, Any]] = ParsedPrompt[dict[str, Any]](
-        template='Template content', model='gemini-1.5-pro'
+        template='Template content', model='gemini-2.5-pro'
     )
     resolve_metadata_mock = AsyncMock(
         return_value=PromptMetadata(
-            model='gemini-1.5-pro',
+            model='gemini-2.5-pro',
         )
     )
 
@@ -531,12 +531,12 @@ def test_render_metadata() -> None:
         resolve_metadata_mock.assert_called_with(
             PromptMetadata(),
             ParsedPrompt(
-                model='gemini-1.5-pro',
+                model='gemini-2.5-pro',
                 template='Template content',
             ),
             None,
         )
-        assert result == PromptMetadata(model='gemini-1.5-pro')
+        assert result == PromptMetadata(model='gemini-2.5-pro')
 
 
 def test_default_model_when_null() -> None:
@@ -564,13 +564,13 @@ def test_default_model_when_null() -> None:
 def test_use_available_model_config() -> None:
     """Should use model configs when available."""
     model_configs = {
-        'gemini-1.5-pro': {'temperature': 0.7},
+        'gemini-2.5-pro': {'temperature': 0.7},
     }
     dotprompt = Dotprompt(model_configs=model_configs)
 
     parsed_source: ParsedPrompt[dict[str, Any]] = ParsedPrompt[dict[str, Any]](
         template='Template content',
-        model='gemini-1.5-pro',
+        model='gemini-2.5-pro',
     )
 
     def wrapper(

--- a/python/dotpromptz/tests/dotpromptz/parse_test.py
+++ b/python/dotpromptz/tests/dotpromptz/parse_test.py
@@ -806,7 +806,7 @@ Hello shebang!"""
 # Copyright 2025 Google
 # SPDX: Apache-2.0
 ---
-model: gemini-2.0
+model: gemini-2.5-flash
 ---
 Hello combined!"""
 
@@ -815,5 +815,5 @@ Hello combined!"""
         self.assertIsInstance(result, ParsedPrompt)
         self.assertIsNotNone(result.raw)
         assert result.raw is not None  # Type narrowing for pyrefly
-        self.assertEqual(result.raw.get('model'), 'gemini-2.0')
+        self.assertEqual(result.raw.get('model'), 'gemini-2.5-flash')
         self.assertEqual(result.template, 'Hello combined!')

--- a/python/samples/streamlit-monaco-demo/app.py
+++ b/python/samples/streamlit-monaco-demo/app.py
@@ -29,7 +29,7 @@ This example demonstrates syntax highlighting for **Dotprompt** files using the 
 
 # Sample Dotprompt content
 DEFAULT_CONTENT = """---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
   topP: 0.95

--- a/rs/dotprompt/src/parse.rs
+++ b/rs/dotprompt/src/parse.rs
@@ -486,9 +486,9 @@ mod tests {
 
     #[test]
     fn test_extract_with_shebang_and_license() {
-        let source = "#!/usr/bin/env promptly\n# Copyright 2025 Google\n# SPDX: Apache-2.0\n---\nmodel: gemini-2.0\n---\nHello combined!";
+        let source = "#!/usr/bin/env promptly\n# Copyright 2025 Google\n# SPDX: Apache-2.0\n---\nmodel: gemini-2.5-flash\n---\nHello combined!";
         let (yaml, template) = extract_frontmatter_and_body(source).expect("parse should succeed");
-        assert!(yaml.contains("model: gemini-2.0"));
+        assert!(yaml.contains("model: gemini-2.5-flash"));
         assert_eq!(template, "Hello combined!");
     }
 

--- a/rs/promptly/src/formatter.rs
+++ b/rs/promptly/src/formatter.rs
@@ -265,7 +265,7 @@ mod tests {
         let formatter = Formatter::default();
 
         let input = r"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 ---

--- a/rs/promptly/src/linter.rs
+++ b/rs/promptly/src/linter.rs
@@ -668,7 +668,7 @@ mod tests {
     #[test]
     fn test_lint_valid_prompt() {
         let source = r"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 ---
@@ -689,7 +689,7 @@ Hello {{name}}!
     #[test]
     fn test_lint_invalid_yaml() {
         let source = r#"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: "not a number
 ---
@@ -712,7 +712,7 @@ Hello world!
     #[test]
     fn test_lint_unclosed_block() {
         let source = r#"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 {{#role "user"}}
 Hello world!

--- a/rs/promptly/src/lsp.rs
+++ b/rs/promptly/src/lsp.rs
@@ -143,7 +143,7 @@ fn get_frontmatter_field_docs(field: &str) -> Option<&'static str> {
             Specifies the AI model to use.\n\n\
             **Example:**\n\
             ```yaml\n\
-            model: googleai/gemini-2.0-flash\n\
+            model: googleai/gemini-2.5-flash\n\
             ```",
         ),
         "input" => Some(

--- a/rs/promptly/tests/cli_tests.rs
+++ b/rs/promptly/tests/cli_tests.rs
@@ -36,7 +36,7 @@ fn setup_test_dir() -> TempDir {
     fs::write(
         dir.path().join("valid.prompt"),
         r"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: 0.7
 ---
@@ -49,7 +49,7 @@ Hello {{name}}!
     fs::write(
         dir.path().join("invalid_yaml.prompt"),
         r#"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 config:
   temperature: "unclosed string
 ---
@@ -62,7 +62,7 @@ Hello world!
     fs::write(
         dir.path().join("unclosed_block.prompt"),
         r#"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 {{#role "user"}}
 Hello world!
@@ -253,7 +253,7 @@ fn setup_unformatted_dir() -> TempDir {
     fs::write(
         dir.path().join("unformatted.prompt"),
         r"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 Hello {{name}}!   
 Goodbye {{friend}}",
@@ -264,7 +264,7 @@ Goodbye {{friend}}",
     fs::write(
         dir.path().join("formatted.prompt"),
         r"---
-model: gemini-2.0-flash
+model: gemini-2.5-flash
 ---
 
 Hello {{ name }}!

--- a/third_party/docsite/src/content/docs/getting-started.mdx
+++ b/third_party/docsite/src/content/docs/getting-started.mdx
@@ -30,7 +30,7 @@ Here's an example of a Dotprompt file that extracts structured data from the pro
 
 ```handlebars
 ---
-model: googleai/gemini-1.5-pro
+model: googleai/gemini-2.5-pro
 input:
   schema:
     text: string
@@ -49,7 +49,7 @@ Text: {{text}}
 
 This Dotprompt file:
 
-1. Specifies the use of the `googleai/gemini-1.5-pro` model.
+1. Specifies the use of the `googleai/gemini-2.5-pro` model.
 2. Defines an input schema expecting a `text` string.
 3. Specifies that the output should be in JSON format.
 4. Provides a schema for the expected output, including fields for name, age, and occupation.

--- a/third_party/docsite/src/content/docs/reference/frontmatter.mdx
+++ b/third_party/docsite/src/content/docs/reference/frontmatter.mdx
@@ -25,11 +25,11 @@ Here's an example of a Dotprompt frontmatter:
 ---
 name: greetingPrompt
 variant: formal
-model: googleai/gemini-1.5-flash
+model: googleai/gemini-2.5-flash
 tools:
   - timeOfDay
 config:
-  version: gemini-1.5-flash-latest
+  version: gemini-2.5-flash
   temperature: 0.7
   topK: 20
   topP 0.8
@@ -67,7 +67,7 @@ metadata:
 ### `model`
 
 - **Type:** `string` or `ModelArgument<Options>`
-- **Description:** The name of the model to use for this prompt, e.g., `googleai/gemini-1.5-flash-latest`. The Dotprompt implementation is responsible for resolving a string model name to an executable model.
+- **Description:** The name of the model to use for this prompt, e.g., `googleai/gemini-2.5-flash`. The Dotprompt implementation is responsible for resolving a string model name to an executable model.
 
 ### `tools`
 
@@ -81,8 +81,8 @@ metadata:
 - **Common Config:** Model implementations should respect the following config properties where applicable:
   - `version`:
     - **Type:** `string`
-    - **Description:** While `model` specifies a model "family" (e.g. Gemini 1.5 Flash, Claude 3.5 Sonnet), `version` specifies a particular version/checkpoint of the model to use. This allows for version pinning and reproducibility of results.
-    - **Example:**  `"gemini-1.5-pro-0801"` or `"v2"`
+    - **Description:** While `model` specifies a model "family" (e.g. Gemini 2.5 Flash, Claude 3.5 Sonnet), `version` specifies a particular version/checkpoint of the model to use. This allows for version pinning and reproducibility of results.
+    - **Example:**  `"gemini-2.5-pro"` or `"v2"`
 
   - `temperature`:
     - **Type:** `number`


### PR DESCRIPTION
Updates outdated references to Gemini 1.5 and 2.0 models with the latest
stable Gemini 2.5 and preview Gemini 3 series across the codebase.
tests passed in python/go, wasn't successful with rust/javascript. 

Also, updated some context on tokens and prices and gemini/gpt models based on current docs. 