### PR TITLE
fix(dotprompt-dart,dotprompt-java,dotprompt-rs): support dotted partial names 

### DIFF
--- a/dart/dotprompt/lib/src/dotprompt.dart
+++ b/dart/dotprompt/lib/src/dotprompt.dart
@@ -200,7 +200,7 @@ class Dotprompt {
 
   /// Resolves partial references in a template.
   Future<void> _resolvePartials(String template) async {
-    final partialPattern = RegExp(r"\{\{>\s*([a-zA-Z0-9_-]+)");
+    final partialPattern = RegExp(r"\{\{>\s*([a-zA-Z0-9_.-]+)");
     final matches = partialPattern.allMatches(template);
 
     for (final match in matches) {

--- a/java/com/google/dotprompt/Dotprompt.java
+++ b/java/com/google/dotprompt/Dotprompt.java
@@ -674,7 +674,7 @@ public class Dotprompt {
   private Set<String> identifyPartials(String template) {
     Set<String> partials = new HashSet<>();
     // Match {{> partialName}} or {{> partialName context}}
-    Pattern pattern = Pattern.compile("\\{\\{>\\s*([a-zA-Z0-9_-]+)");
+    Pattern pattern = Pattern.compile("\\{\\{>\\s*([a-zA-Z0-9_.-]+)");
     Matcher matcher = pattern.matcher(template);
     while (matcher.find()) {
       partials.add(matcher.group(1));

--- a/rs/dotprompt/src/dotprompt.rs
+++ b/rs/dotprompt/src/dotprompt.rs
@@ -552,7 +552,7 @@ impl Dotprompt {
     pub fn identify_partials(&self, template: &str) -> std::collections::HashSet<String> {
         let mut partials = std::collections::HashSet::new();
         // Simple regex-based partial detection: {{> partialName}}
-        let re = regex::Regex::new(r"\{\{>\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+        let re = regex::Regex::new(r"\{\{>\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*\}\}")
             .expect("internal regex pattern should compile");
         for cap in re.captures_iter(template) {
             if let Some(name) = cap.get(1) {

--- a/spec/partials.yaml
+++ b/spec/partials.yaml
@@ -38,9 +38,9 @@
 # underscores, hyphens, and dots (e.g., topic-2.sub_topic).
 - name: partial_name_with_full_regex
   template: |
-    {{> topic-2.sub_topic}} This is the main template.
+    {{> Topic-2.sub_topic}} This is the main template.
   partials:
-    topic-2.sub_topic: "Hello from a complex-named partial!"
+    Topic-2.sub_topic: "Hello from a complex-named partial!"
   tests:
     - desc: renders a partial whose name contains letters, digits, dots, underscores, and hyphens
       data:

--- a/spec/partials.yaml
+++ b/spec/partials.yaml
@@ -34,6 +34,22 @@
             content:
               [{ text: "Hello from a partial! This is the main template.\n" }]
 
+# Tests partial inclusion with a dotted name (e.g., file.variant).
+- name: dotted_partial_name
+  template: |
+    {{> greeting.in_french}} This is the main template.
+  partials:
+    greeting.in_french: "Bonjour d'un partial!"
+  tests:
+    - desc: renders a partial with a dotted name
+      data:
+        input: {}
+      expect:
+        messages:
+          - role: user
+            content:
+              [{ text: "Bonjour d'un partial! This is the main template.\n" }]
+
 # Tests partial rendering with context variables passed from the main template.
 - name: partial_with_context
   template: |
@@ -101,24 +117,6 @@
         messages:
           - role: user
             content: [{ text: "Hello, World!\n" }]
-
-# Tests that regular `#` comments in partials are NOT stripped and appear in
-# the output (this is intentional - use Handlebars comments for license headers).
-# Tests partial inclusion with a dotted name (e.g., topic.subtopic).
-- name: dotted_partial_name
-  template: |
-    {{> greeting.in_french}} This is the main template.
-  partials:
-    greeting.in_french: "Bonjour d'un partial!"
-  tests:
-    - desc: renders a partial with a dotted name
-      data:
-        input: {}
-      expect:
-        messages:
-          - role: user
-            content:
-              [{ text: "Bonjour d'un partial! This is the main template.\n" }]
 
 # Tests that regular `#` comments in partials are NOT stripped and appear in
 # the output (this is intentional - use Handlebars comments for license headers).

--- a/spec/partials.yaml
+++ b/spec/partials.yaml
@@ -104,6 +104,24 @@
 
 # Tests that regular `#` comments in partials are NOT stripped and appear in
 # the output (this is intentional - use Handlebars comments for license headers).
+# Tests partial inclusion with a dotted name (e.g., topic.subtopic).
+- name: dotted_partial_name
+  template: |
+    {{> greeting.in_french}} This is the main template.
+  partials:
+    greeting.in_french: "Bonjour d'un partial!"
+  tests:
+    - desc: renders a partial with a dotted name
+      data:
+        input: {}
+      expect:
+        messages:
+          - role: user
+            content:
+              [{ text: "Bonjour d'un partial! This is the main template.\n" }]
+
+# Tests that regular `#` comments in partials are NOT stripped and appear in
+# the output (this is intentional - use Handlebars comments for license headers).
 - name: partial_with_hash_comment
   template: |
     {{> hashPartial}}

--- a/spec/partials.yaml
+++ b/spec/partials.yaml
@@ -34,21 +34,22 @@
             content:
               [{ text: "Hello from a partial! This is the main template.\n" }]
 
-# Tests partial inclusion with a dotted name (e.g., file.variant).
-- name: dotted_partial_name
+# Tests that partial names support the full filename regex: letters, digits,
+# underscores, hyphens, and dots (e.g., topic-2.sub_topic).
+- name: partial_name_with_full_regex
   template: |
-    {{> greeting.in_french}} This is the main template.
+    {{> topic-2.sub_topic}} This is the main template.
   partials:
-    greeting.in_french: "Bonjour d'un partial!"
+    topic-2.sub_topic: "Hello from a complex-named partial!"
   tests:
-    - desc: renders a partial with a dotted name
+    - desc: renders a partial whose name contains letters, digits, dots, underscores, and hyphens
       data:
         input: {}
       expect:
         messages:
           - role: user
             content:
-              [{ text: "Bonjour d'un partial! This is the main template.\n" }]
+              [{ text: "Hello from a complex-named partial! This is the main template.\n" }]
 
 # Tests partial rendering with context variables passed from the main template.
 - name: partial_with_context


### PR DESCRIPTION
Support for dots in partial names (e.g., `{{> greeting.in_french}}`) is currently inconsistent across SDKs:                                                     
                                                                                                                                                                  
  | SDK | Status |                                                                                                                                                
  |-----|--------|                                                                                                                                                
  | Python | Supported — regex allows `.` via `[a-zA-Z0-9_.-]+` |
  | JS/Go | Supported — AST-based parsing naturally allows dots |
  | **Dart** | **Not supported** |
  | **Java** | **Not supported** |
  | **Rust** | **Not supported** |

  This PR adds `.` to the partial name regex character class in Dart, Java, and Rust, and adds a shared `partial_name_with_full_regex` spec test case to `spec/partials.yaml` to validate partial name regex consistency across all SDKs.

