### PR TITLE
fix(go): make Bazel build work with jsonschema v0.14 dependency swap

### DIFF
--- a/go.MODULE.bazel
+++ b/go.MODULE.bazel
@@ -16,7 +16,7 @@
 
 """Configuration for Bazel with Go dependencies."""
 
-GO_VERSION = "1.24.11"
+GO_VERSION = "1.25.12"
 
 bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "io_bazel_rules_go")
 

--- a/go.MODULE.bazel
+++ b/go.MODULE.bazel
@@ -38,7 +38,7 @@ use_repo(
     "com_github_google_go_cmp",
     "com_github_invopop_jsonschema",
     "com_github_mbleigh_raymond",
+    "com_github_pb33f_ordered_map_v2",
     "com_github_smacker_go_tree_sitter",
-    "com_github_wk8_go_ordered_map_v2",
     "org_golang_x_text",
 )

--- a/go/dotprompt/BUILD.bazel
+++ b/go/dotprompt/BUILD.bazel
@@ -35,7 +35,7 @@ go_library(
         "@com_github_goccy_go_yaml//:go-yaml",
         "@com_github_invopop_jsonschema//:jsonschema",
         "@com_github_mbleigh_raymond//:raymond",
-        "@com_github_wk8_go_ordered_map_v2//:go-ordered-map",
+        "@com_github_pb33f_ordered_map_v2//:ordered-map",
         "@org_golang_x_text//unicode/norm",
     ],
 )
@@ -59,6 +59,6 @@ go_test(
         "@com_github_google_go_cmp//cmp/cmpopts",
         "@com_github_invopop_jsonschema//:jsonschema",
         "@com_github_mbleigh_raymond//:raymond",
-        "@com_github_wk8_go_ordered_map_v2//:go-ordered-map",
+        "@com_github_pb33f_ordered_map_v2//:ordered-map",
     ],
 )


### PR DESCRIPTION
## Problem

[#561](https://github.com/google/dotprompt/pull/561) fixed [#560](https://github.com/google/dotprompt/issues/560) by swapping `github.com/wk8/go-ordered-map/v2` → `github.com/pb33f/ordered-map/v2` in `go/go.mod` (for `invopop/jsonschema` v0.14.0 compatibility) and bumping several transitive deps. It updated the Go sources and `go.mod`/`go.sum`, but did **not** update the Bazel side of the monorepo. Because Bazel evaluates the full module graph before building any target, this broke every Bazel build in the repo, which is what blocked the `Build and Test (Java …)` checks on release PR [#578](https://github.com/google/dotprompt/pull/578) (dotprompt-go 0.2.1).

Three distinct Bazel breakages, uncovered in sequence:

1. **Stale `use_repo`** in `go.MODULE.bazel` — `com_github_wk8_go_ordered_map_v2` is no longer generated by the gazelle `go_deps` extension.
2. **Stale generated `deps`** in `go/dotprompt/BUILD.bazel` — both `go_library` and `go_test` still referenced `@com_github_wk8_go_ordered_map_v2//:go-ordered-map`.
3. **Go SDK too old** — #561's incidental `golang.org/x/text` bump to v0.36.0 declares `go 1.25.0`, but the Bazel `go_sdk` was pinned at `1.24.11`, so `rules_go`'s `fetch_repo` failed with `requires go >= 1.25.0`.

## Fix

1. `go.MODULE.bazel`: swap the `use_repo` entry to `com_github_pb33f_ordered_map_v2` (matches `bazel mod tidy`).
2. `go/dotprompt/BUILD.bazel`: point both `deps` lists at `@com_github_pb33f_ordered_map_v2//:ordered-map` (matches `bazel run //:gazelle`).
3. `go.MODULE.bazel`: bump `GO_VERSION` `1.24.11` → `1.25.12` (latest 1.25 patch), matching the `go 1.25.0` directive already in `go/go.mod` and the 1.25.x CI test matrix.

`MODULE.bazel.lock` is content-hash based with no repo-name entries for this dep, so no lockfile edit was required.

## Testing

Bazel was unavailable in the authoring environment, so edits were hand-matched to `bazel mod tidy` / gazelle output. Verified via CI on this PR: `Build and Test (Java 17/21)`, `Go 1.25.x Tests`, `Go 1.26.x Tests`, and all format/lint checks pass.