### PR TITLE
fix(dotpromptz): silence Pydantic schema field shadowing warnings

### DIFF
--- a/python/dotpromptz/src/dotpromptz/typing.py
+++ b/python/dotpromptz/src/dotpromptz/typing.py
@@ -145,6 +145,7 @@ PromptStoreSync (sync read)
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Awaitable, Callable
 from enum import Enum
 from typing import (
@@ -156,6 +157,14 @@ from typing import (
 )
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+
+# Silence non-actionable import-time UserWarning from Pydantic when "schema" field shadows BaseModel.schema
+warnings.filterwarnings(
+    'ignore',
+    message='Field name "schema" .* shadows an attribute in parent',
+    category=UserWarning,
+    module=r'dotpromptz(\.|$)',
+)
 
 Schema = Any
 """Type alias for a generic schema."""


### PR DESCRIPTION
## Summary
- Silences import-time `UserWarning` emitted by Pydantic when `PromptInputConfig` and `PromptOutputConfig` declare a field named `schema` that shadows `BaseModel.schema`.
- Installs warning filter inside `dotpromptz/typing.py` directly where the models are defined so downstream importers do not receive noisy startup warnings.

## Demo
```bash
python -c "import warnings; warnings.simplefilter('always'); import dotpromptz.typing"
```
Before: two UserWarnings emitted on import.
After: clean import.
