### PR TITLE
fix(ci): use default checkout for non-release-please PRs in uv-lock-check

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,12 +46,16 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - if: startsWith(github.head_ref, 'release-please--')
+        uses: actions/checkout@v6
         with:
           # Use the PR head ref to allow pushing back to the branch
           ref: ${{ github.head_ref }}
           # Use a token that can push to the branch (for release-please PRs)
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+
+      - if: "!startsWith(github.head_ref, 'release-please--')"
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
In `.github/workflows/python.yml`, the `uv-lock-check` job previously fetched `ref: ${{ github.head_ref }}` from the base repository (`google/dotprompt`). For pull requests originating from forks (such as PR #589), the head branch does not exist in the base repository, causing `actions/checkout` to fail during `git fetch` with `The process '/usr/bin/git' failed with exit code 1`.

This change splits the checkout step in `uv-lock-check` into two conditional checkouts:
1. `if: startsWith(github.head_ref, 'release-please--')`: Uses `ref: ${{ github.head_ref }}` and `token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}` to preserve lockfile push-back behavior on release-please branches.
2. `if: "!startsWith(github.head_ref, 'release-please--')"`: Uses default `actions/checkout@v6` with merge-ref checkout, which works for fork PRs.

Observed failure: PR #589 (`uv-lock-check` failed in checkout step with exit code 1).
Note: After this fix is merged, PR #589 can be rebased or closed/reopened to re-run CI.