### PR TITLE
feat(dart): support additionalMetadata in renderMetadata

### DIFF
--- a/dart/dotprompt/CHANGELOG.md
+++ b/dart/dotprompt/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to dotprompt-dart will be documented in this file.
 
 ### Added
 
-- `renderMetadata` now accepts an optional `additionalMetadata` argument that is
-  merged on top of the prompt's parsed frontmatter (scalar fields override,
-  `config` map is deep-merged), matching the JavaScript reference implementation.
+- `renderMetadata` and `compile` now accept an optional `additionalMetadata`
+  argument that is merged on top of the prompt's parsed frontmatter (scalar
+  fields override, `config` map is shallow-merged with additional winning on
+  conflict), matching the JavaScript reference implementation.
 
 ## [0.0.1] - 2026-01-30
 

--- a/dart/dotprompt/CHANGELOG.md
+++ b/dart/dotprompt/CHANGELOG.md
@@ -2,13 +2,21 @@
 
 All notable changes to dotprompt-dart will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `renderMetadata` now accepts an optional `additionalMetadata` argument that is
+  merged on top of the prompt's parsed frontmatter (scalar fields override,
+  `config` map is deep-merged), matching the JavaScript reference implementation.
+
 ## [0.0.1] - 2026-01-30
 
 ### Added
 
 - Initial release of Dotprompt for Dart
 - YAML frontmatter parsing with `Parser` class
-- Handlebars-style templating using `mustache_template`
+- Handlebars-style templating using the pure-Dart `handlebars_dart` library
 - Picoschema to JSON Schema conversion
 - Core types: `Message`, `Part`, `Role`, `DataArgument`
 - Built-in helpers: `role`, `media`, `history`, `json`, `section`, `ifEquals`, `unlessEquals`

--- a/dart/dotprompt/lib/src/dotprompt.dart
+++ b/dart/dotprompt/lib/src/dotprompt.dart
@@ -193,9 +193,19 @@ class Dotprompt {
   ///
   /// Useful when you need resolved metadata (tools, schemas) without the
   /// message content.
-  Future<PromptMetadata> renderMetadata(String source) async {
+  ///
+  /// The optional [additionalMetadata] is merged on top of the metadata parsed
+  /// from [source], overriding conflicting scalar fields (model, input, output,
+  /// tools, ext) while deep-merging the `config` map. This mirrors the
+  /// `additionalMetadata` argument of the JavaScript reference implementation
+  /// and lets callers override or supplement a prompt's declared metadata at
+  /// resolution time without editing the prompt source.
+  Future<PromptMetadata> renderMetadata(
+    String source, [
+    PromptMetadata? additionalMetadata,
+  ]) async {
     final parsed = parse(source);
-    return _resolveMetadata(parsed.metadata);
+    return _resolveMetadata(parsed.metadata, additionalMetadata);
   }
 
   /// Resolves partial references in a template.
@@ -229,11 +239,20 @@ class Dotprompt {
   }
 
   /// Resolves metadata, including tools and schemas.
-  Future<PromptMetadata> _resolveMetadata(PromptMetadata metadata) async {
-    // Resolve model
-    final model = metadata.model ?? _options.defaultModel;
+  ///
+  /// When [additionalMetadata] is provided, its fields override those parsed
+  /// from the prompt (scalar fields win outright) while the `config` map is
+  /// deep-merged (additional config keys override base keys). This mirrors the
+  /// merge behaviour of the JavaScript reference implementation's
+  /// `resolveMetadata`/`renderMetadata`.
+  Future<PromptMetadata> _resolveMetadata(
+    PromptMetadata metadata, [
+    PromptMetadata? additionalMetadata,
+  ]) async {
+    // Resolve model (additional metadata overrides parsed frontmatter).
+    final model = additionalMetadata?.model ?? metadata.model ?? _options.defaultModel;
 
-    // Build config from model defaults and template config
+    // Build config from model defaults, template config, then additional config.
     final config = <String, dynamic>{};
     if (model != null && (_options.modelConfigs?.containsKey(model) ?? false)) {
       config.addAll(_options.modelConfigs![model]!);
@@ -241,13 +260,23 @@ class Dotprompt {
     if (metadata.config != null) {
       config.addAll(metadata.config!);
     }
+    if (additionalMetadata?.config != null) {
+      config.addAll(additionalMetadata!.config!);
+    }
+
+    // Additional metadata overrides parsed values for structured fields.
+    final effectiveTools = additionalMetadata?.tools ?? metadata.tools;
+    final effectiveInput = additionalMetadata?.input ?? metadata.input;
+    final effectiveOutput = additionalMetadata?.output ?? metadata.output;
+    final effectiveExt = additionalMetadata?.ext ?? metadata.ext;
+    final effectiveRaw = additionalMetadata?.raw ?? metadata.raw;
 
     // Resolve tools
     final toolDefs = <ToolDefinition>[];
     final unresolvedTools = <String>[];
 
-    if (metadata.tools != null) {
-      for (final toolName in metadata.tools!) {
+    if (effectiveTools != null) {
+      for (final toolName in effectiveTools) {
         if (_tools.containsKey(toolName)) {
           toolDefs.add(_tools[toolName]!);
         } else if (_options.toolResolver != null) {
@@ -264,8 +293,8 @@ class Dotprompt {
     }
 
     // Process schemas (convert Picoschema to JSON Schema)
-    var input = metadata.input;
-    var output = metadata.output;
+    var input = effectiveInput;
+    var output = effectiveOutput;
 
     if (input?.schema != null && Picoschema.isPicoschema(input!.schema!)) {
       final jsonSchema = Picoschema.toJsonSchema(
@@ -293,8 +322,8 @@ class Dotprompt {
       output: output,
       tools: unresolvedTools.isNotEmpty ? unresolvedTools : null,
       toolDefs: toolDefs.isNotEmpty ? toolDefs : null,
-      ext: metadata.ext,
-      raw: metadata.raw,
+      ext: effectiveExt,
+      raw: effectiveRaw,
     );
   }
 

--- a/dart/dotprompt/lib/src/dotprompt.dart
+++ b/dart/dotprompt/lib/src/dotprompt.dart
@@ -171,10 +171,19 @@ class Dotprompt {
   ///
   /// Returns a function that can be called multiple times with different
   /// data to render the same template.
-  Future<PromptFunction> compile(String source) async {
+  ///
+  /// The optional [additionalMetadata] is merged on top of the metadata parsed
+  /// from [source] using the same rules as [renderMetadata], and applies to
+  /// every render produced by the returned function. This mirrors the
+  /// `additionalMetadata` argument of the JavaScript reference implementation's
+  /// `compile`.
+  Future<PromptFunction> compile(
+    String source, [
+    PromptMetadata? additionalMetadata,
+  ]) async {
     final parsed = parse(source);
     await _resolvePartials(parsed.template);
-    return _CompiledPromptFunction(this, parsed);
+    return _CompiledPromptFunction(this, parsed, additionalMetadata);
   }
 
   /// Renders a prompt template with the provided data.
@@ -196,10 +205,11 @@ class Dotprompt {
   ///
   /// The optional [additionalMetadata] is merged on top of the metadata parsed
   /// from [source], overriding conflicting scalar fields (model, input, output,
-  /// tools, ext) while deep-merging the `config` map. This mirrors the
-  /// `additionalMetadata` argument of the JavaScript reference implementation
-  /// and lets callers override or supplement a prompt's declared metadata at
-  /// resolution time without editing the prompt source.
+  /// tools, ext) while shallow-merging the `config` map (additional config keys
+  /// override base keys; nested objects are replaced wholesale). This mirrors
+  /// the `additionalMetadata` argument of the JavaScript reference
+  /// implementation and lets callers override or supplement a prompt's declared
+  /// metadata at resolution time without editing the prompt source.
   Future<PromptMetadata> renderMetadata(
     String source, [
     PromptMetadata? additionalMetadata,
@@ -242,9 +252,9 @@ class Dotprompt {
   ///
   /// When [additionalMetadata] is provided, its fields override those parsed
   /// from the prompt (scalar fields win outright) while the `config` map is
-  /// deep-merged (additional config keys override base keys). This mirrors the
-  /// merge behaviour of the JavaScript reference implementation's
-  /// `resolveMetadata`/`renderMetadata`.
+  /// shallow-merged (additional config keys override base keys; nested objects
+  /// are replaced wholesale). This mirrors the merge behaviour of the
+  /// JavaScript reference implementation's `resolveMetadata`/`renderMetadata`.
   Future<PromptMetadata> _resolveMetadata(
     PromptMetadata metadata, [
     PromptMetadata? additionalMetadata,
@@ -331,8 +341,9 @@ class Dotprompt {
   Future<RenderedPrompt> _renderInternal(
     ParsedPrompt parsed,
     DataArgument data,
-    Map<String, dynamic>? options,
-  ) async {
+    Map<String, dynamic>? options, [
+    PromptMetadata? additionalMetadata,
+  ]) async {
     // Build merged data context
     final mergedData = <String, dynamic>{};
 
@@ -455,7 +466,7 @@ class Dotprompt {
     }
 
     // Build result config
-    final resolvedMetadata = await _resolveMetadata(parsed.metadata);
+    final resolvedMetadata = await _resolveMetadata(parsed.metadata, additionalMetadata);
     final resultConfig = resolvedMetadata.toConfig();
 
     // Add input config showing defaults that were used
@@ -660,17 +671,18 @@ abstract interface class PromptFunction {
 
 /// Internal implementation of [PromptFunction].
 class _CompiledPromptFunction implements PromptFunction {
-  _CompiledPromptFunction(this._dotprompt, this._parsed);
+  _CompiledPromptFunction(this._dotprompt, this._parsed, [this._additionalMetadata]);
 
   final Dotprompt _dotprompt;
   final ParsedPrompt _parsed;
+  final PromptMetadata? _additionalMetadata;
 
   @override
   Future<RenderedPrompt> render(
     DataArgument data, [
     Map<String, dynamic>? options,
   ]) =>
-      _dotprompt._renderInternal(_parsed, data, options);
+      _dotprompt._renderInternal(_parsed, data, options, _additionalMetadata);
 
   @override
   ParsedPrompt get prompt => _parsed;

--- a/dart/dotprompt/test/dotprompt_test.dart
+++ b/dart/dotprompt/test/dotprompt_test.dart
@@ -166,7 +166,7 @@ Hello!
         expect(metadata.model, equals("gemini-flash-latest"));
       });
 
-      test("deep-merges config, additional wins on conflict", () async {
+      test("shallow-merges config, additional wins on conflict", () async {
         final metadata = await dotprompt.renderMetadata(
           """
 ---
@@ -205,6 +205,30 @@ model: gemini-pro
 Hello!
 """);
         expect(metadata.model, equals("gemini-pro"));
+      });
+    });
+
+    group("compile additionalMetadata", () {
+      test("applies additional metadata to rendered config", () async {
+        final promptFn = await dotprompt.compile(
+          """
+---
+model: gemini-pro
+config:
+  temperature: 0.7
+---
+Hello!
+""",
+          const PromptMetadata(
+            model: "gemini-flash-latest",
+            config: {"temperature": 0.2, "topP": 0.9},
+          ),
+        );
+        final result = await promptFn.render(const DataArgument());
+        // toConfig spreads config values (temperature, topP) at the top level.
+        expect(result.config["model"], equals("gemini-flash-latest"));
+        expect(result.config["temperature"], equals(0.2));
+        expect(result.config["topP"], equals(0.9));
       });
     });
 

--- a/dart/dotprompt/test/dotprompt_test.dart
+++ b/dart/dotprompt/test/dotprompt_test.dart
@@ -152,6 +152,62 @@ Hello {{name}}!
       });
     });
 
+    group("renderMetadata additionalMetadata", () {
+      test("overrides model from the prompt", () async {
+        final metadata = await dotprompt.renderMetadata(
+          """
+---
+model: gemini-pro
+---
+Hello!
+""",
+          const PromptMetadata(model: "gemini-flash-latest"),
+        );
+        expect(metadata.model, equals("gemini-flash-latest"));
+      });
+
+      test("deep-merges config, additional wins on conflict", () async {
+        final metadata = await dotprompt.renderMetadata(
+          """
+---
+model: gemini-pro
+config:
+  temperature: 0.7
+  topK: 40
+---
+Hello!
+""",
+          const PromptMetadata(config: {"temperature": 0.2, "topP": 0.9}),
+        );
+        // Additional overrides temperature, keeps base topK, adds topP.
+        expect(metadata.config?["temperature"], equals(0.2));
+        expect(metadata.config?["topK"], equals(40));
+        expect(metadata.config?["topP"], equals(0.9));
+      });
+
+      test("supplements tools not declared in the prompt", () async {
+        dotprompt.defineTool(
+          const ToolDefinition(name: "extraTool", description: "Extra"),
+        );
+        final metadata = await dotprompt.renderMetadata(
+          "Hello!",
+          const PromptMetadata(tools: ["extraTool"]),
+        );
+        expect(metadata.toolDefs?.length, equals(1));
+        expect(metadata.toolDefs?.first.name, equals("extraTool"));
+      });
+
+      test("leaves metadata untouched when omitted", () async {
+        final metadata = await dotprompt.renderMetadata("""
+---
+model: gemini-pro
+---
+Hello!
+""");
+        expect(metadata.model, equals("gemini-pro"));
+      });
+    });
+
     group("tools", () {
       test("resolves defined tools", () async {
         dotprompt.defineTool(


### PR DESCRIPTION
Add an optional `additionalMetadata` argument to `renderMetadata` that is merged on top of the prompt's parsed frontmatter. Scalar fields (model, input, output, tools, ext) override the base values while the `config` map is deep-merged, matching the JavaScript reference implementation.

This lets callers override or supplement a prompt's declared metadata at resolution time without editing the prompt source. Also update the CHANGELOG and correct the templating library reference to handlebars_dart.