### PR TITLE
fix(docs): restore broken star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![View Code Wiki](https://www.gstatic.com/_/boq-sdlc-agents-ui/_/r/YUi5dj2UWvE.svg)](https://codewiki.google/github.com/google/dotprompt)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/google/dotprompt)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=google/dotprompt&type=Date)](https://star-history.com/#google/dotprompt&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=google/dotprompt&type=Date)](https://star-history.dera.page/#google/dotprompt&Date)
 
 # Dotprompt: Executable GenAI Prompt Templates
 

--- a/python/handlebarrz/README.md
+++ b/python/handlebarrz/README.md
@@ -12,7 +12,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/google/dotprompt?style=social)](https://github.com/google/dotprompt)
 [![OSS Insight](https://img.shields.io/badge/OSS%20Insight-google%2Fdotprompt-blue?logo=github)](https://ossinsight.io/analyze/google/dotprompt)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=google/dotprompt&type=Date)](https://star-history.com/#google/dotprompt&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=google/dotprompt&type=Date)](https://star-history.dera.page/#google/dotprompt&Date)
 
 A high-performance [Handlebars](https://handlebarsjs.com/) template engine for Python, powered by Rust.
 


### PR DESCRIPTION
The star history charts in the main README and the dotpromptz-handlebars README are currently broken and no longer render. This happens because the original star history service is blocked by GitHub stargazer API restrictions.

This change points both charts at a working replacement that serves the chart from a different data source, so the star history chart displays correctly again.

Please take a look, this fix is needed to keep the project badges and charts functional.