### PR TITLE
chore(dart): bump dotprompt and handlebars_dart to 1.0.0

### DIFF
--- a/dart/dotprompt/pubspec.yaml
+++ b/dart/dotprompt/pubspec.yaml
@@ -19,7 +19,7 @@ description: >-
   Dart implementation of Dotprompt, an executable prompt template file format
   for Generative AI. This library provides parsing, rendering, and management
   of .prompt files with YAML frontmatter and Handlebars templating.
-version: 0.0.1
+version: 1.0.0
 license: Apache-2.0
 homepage: https://github.com/google/dotprompt
 repository: https://github.com/google/dotprompt
@@ -30,7 +30,7 @@ environment:
 
 dependencies:
   # Handlebars templating (our pure Dart implementation)
-  handlebars_dart: ^0.0.1
+  handlebars_dart: ^1.0.0
   # Meta annotations
   meta: ^1.15.0
   # YAML parsing for frontmatter


### PR DESCRIPTION
Update dotprompt version from 0.0.1 to 1.0.0 and upgrade the handlebars_dart dependency constraint to ^1.0.0 for the stable release.