### PR TITLE
fix(python): fill omitted template variables from prompt input.default

### DIFF
--- a/docs/api/python/dotpromptz.md
+++ b/docs/api/python/dotpromptz.md
@@ -13,6 +13,7 @@ pip install dotpromptz
 
 ```python
 from dotpromptz import Dotprompt
+from dotpromptz.typing import DataArgument
 
 # Create a Dotprompt instance
 dp = Dotprompt()
@@ -28,7 +29,7 @@ input:
 Hello, {{name}}!
 '''
 
-rendered = await dp.render(source, data={'input': {'name': 'World'}})
+rendered = await dp.render(source, data=DataArgument(input={'name': 'World'}))
 ```
 
 ## Core Classes

--- a/python/dotpromptz/src/dotpromptz/__init__.py
+++ b/python/dotpromptz/src/dotpromptz/__init__.py
@@ -74,6 +74,7 @@ templates to create self-contained, executable prompt definitions:
 
 ```python
 from dotpromptz import Dotprompt
+from dotpromptz.typing import DataArgument
 
 # Create a Dotprompt instance
 dp = Dotprompt()
@@ -89,7 +90,7 @@ input:
 Hello, {{name}}! How can I help you today?
 '''
 
-rendered = await dp.render(source, data={'input': {'name': 'Alice'}})
+rendered = await dp.render(source, data=DataArgument(input={'name': 'Alice'}))
 
 # Access rendered messages
 for message in rendered.messages:

--- a/python/dotpromptz/src/dotpromptz/dotprompt.py
+++ b/python/dotpromptz/src/dotpromptz/dotprompt.py
@@ -40,6 +40,7 @@ Key features include:
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from typing import Any
 
 import anyio
@@ -72,6 +73,15 @@ from handlebarrz import Context, EscapeFunction, Handlebars, HelperFn, RuntimeOp
 # to walk the AST to find partial nodes, we're using a crude regular expression
 # to find partials.
 _PARTIAL_PATTERN = re.compile(r'{{\s*>\s*([a-zA-Z0-9_.-]+)\s*}}')
+
+
+def _coerce_data_argument(
+    data: DataArgument[VariablesT] | Mapping[str, Any],
+) -> DataArgument[VariablesT]:
+    """Validate mapping inputs against the public runtime data shape."""
+    if isinstance(data, DataArgument):
+        return data
+    return DataArgument[VariablesT].model_validate(data)
 
 
 def _merge_metadata(
@@ -140,7 +150,9 @@ class RenderFunc(PromptFunction[ModelConfigT]):
         self.prompt = prompt
 
     async def __call__(
-        self, data: DataArgument[VariablesT], options: PromptMetadata[ModelConfigT] | None = None
+        self,
+        data: DataArgument[VariablesT] | Mapping[str, Any],
+        options: PromptMetadata[ModelConfigT] | None = None,
     ) -> RenderedPrompt[ModelConfigT]:
         """Render the prompt.
 
@@ -151,11 +163,17 @@ class RenderFunc(PromptFunction[ModelConfigT]):
         Returns:
             The rendered prompt.
         """
+        data = _coerce_data_argument(data)
         merged_metadata: PromptMetadata[ModelConfigT] = await self._dotprompt.render_metadata(self.prompt, options)
 
-        # Prepare input data, merging defaults from options if available.
+        # Prompt defaults apply regardless of whether they came from the
+        # template or a per-call override.
         context: Context = {
-            **((options.input.default or {}) if options and options.input else {}),
+            **(
+                (merged_metadata.input.default or {})
+                if merged_metadata.input and merged_metadata.input.default is not None
+                else {}
+            ),
             **(data.input if data.input is not None else {}),
         }
 
@@ -283,7 +301,10 @@ class Dotprompt:
         return parse_document(source)
 
     async def render(
-        self, source: str, data: DataArgument[VariablesT], options: PromptMetadata[ModelConfigT] | None = None
+        self,
+        source: str,
+        data: DataArgument[VariablesT] | Mapping[str, Any],
+        options: PromptMetadata[ModelConfigT] | None = None,
     ) -> RenderedPrompt[ModelConfigT]:
         """Render a prompt.
 
@@ -338,7 +359,11 @@ class Dotprompt:
         prompt = self.parse(source) if isinstance(source, str) else source
 
         default_model = prompt.model or self._default_model
-        model = additional_metadata.model if additional_metadata else default_model
+        model = (
+            additional_metadata.model
+            if additional_metadata and additional_metadata.model is not None
+            else default_model
+        )
 
         config: ModelConfigT | None = None
         if model is not None and self._model_configs.get(model) is not None:
@@ -374,9 +399,9 @@ class Dotprompt:
             if merge:
                 out = _merge_metadata(out, merge)
 
-        # Remove the template attribute if it exists (TS does this).
+        # Template source is an authoring detail, not model request metadata.
         if hasattr(out, 'template'):
-            delattr(out, 'template')
+            del out.template
 
         out = remove_undefined_fields(out)
         # TODO(#493): can this be done concurrently?

--- a/python/dotpromptz/src/dotpromptz/dotprompt.py
+++ b/python/dotpromptz/src/dotpromptz/dotprompt.py
@@ -40,7 +40,6 @@ Key features include:
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
 from typing import Any
 
 import anyio
@@ -73,15 +72,6 @@ from handlebarrz import Context, EscapeFunction, Handlebars, HelperFn, RuntimeOp
 # to walk the AST to find partial nodes, we're using a crude regular expression
 # to find partials.
 _PARTIAL_PATTERN = re.compile(r'{{\s*>\s*([a-zA-Z0-9_.-]+)\s*}}')
-
-
-def _coerce_data_argument(
-    data: DataArgument[VariablesT] | Mapping[str, Any],
-) -> DataArgument[VariablesT]:
-    """Validate mapping inputs against the public runtime data shape."""
-    if isinstance(data, DataArgument):
-        return data
-    return DataArgument[VariablesT].model_validate(data)
 
 
 def _merge_metadata(
@@ -150,9 +140,7 @@ class RenderFunc(PromptFunction[ModelConfigT]):
         self.prompt = prompt
 
     async def __call__(
-        self,
-        data: DataArgument[VariablesT] | Mapping[str, Any],
-        options: PromptMetadata[ModelConfigT] | None = None,
+        self, data: DataArgument[VariablesT], options: PromptMetadata[ModelConfigT] | None = None
     ) -> RenderedPrompt[ModelConfigT]:
         """Render the prompt.
 
@@ -163,7 +151,6 @@ class RenderFunc(PromptFunction[ModelConfigT]):
         Returns:
             The rendered prompt.
         """
-        data = _coerce_data_argument(data)
         merged_metadata: PromptMetadata[ModelConfigT] = await self._dotprompt.render_metadata(self.prompt, options)
 
         # Prompt defaults apply regardless of whether they came from the
@@ -301,10 +288,7 @@ class Dotprompt:
         return parse_document(source)
 
     async def render(
-        self,
-        source: str,
-        data: DataArgument[VariablesT] | Mapping[str, Any],
-        options: PromptMetadata[ModelConfigT] | None = None,
+        self, source: str, data: DataArgument[VariablesT], options: PromptMetadata[ModelConfigT] | None = None
     ) -> RenderedPrompt[ModelConfigT]:
         """Render a prompt.
 

--- a/python/dotpromptz/src/dotpromptz/dotprompt.py
+++ b/python/dotpromptz/src/dotpromptz/dotprompt.py
@@ -175,14 +175,14 @@ class RenderFunc(PromptFunction[ModelConfigT]):
 
         merged_metadata: PromptMetadata[ModelConfigT] = await self._dotprompt.render_metadata(self.prompt, options)
 
-        # Prompt defaults apply regardless of whether they came from the
-        # template or a per-call override.
+        # {{name}} is this call only: options.input.default then DataArgument.input.
+        # A default on the .prompt file (or compile metadata) stays on the
+        # returned prompt config; it does not fill a variable the caller omitted.
+        call_defaults: dict[str, Any] = {}
+        if options is not None and options.input is not None and options.input.default is not None:
+            call_defaults = options.input.default
         context: Context = {
-            **(
-                (merged_metadata.input.default or {})
-                if merged_metadata.input and merged_metadata.input.default is not None
-                else {}
-            ),
+            **call_defaults,
             **(data.input if data.input is not None else {}),
         }
 

--- a/python/dotpromptz/src/dotpromptz/dotprompt.py
+++ b/python/dotpromptz/src/dotpromptz/dotprompt.py
@@ -74,6 +74,40 @@ from handlebarrz import Context, EscapeFunction, Handlebars, HelperFn, RuntimeOp
 _PARTIAL_PATTERN = re.compile(r'{{\s*>\s*([a-zA-Z0-9_.-]+)\s*}}')
 
 
+def _merged_metadata_dict(
+    current: PromptMetadata[ModelConfigT],
+    merge: PromptMetadata[ModelConfigT],
+) -> dict[str, Any]:
+    # Convert Pydantic models to raw dicts by alias first. Skip None values.
+    merge_dict = merge.model_dump(exclude_none=True, by_alias=True)
+    current_dict = current.model_dump(exclude_none=True, by_alias=True)
+
+    original_config = current_dict.get('config', {})
+    new_config = merge_dict.get('config', {})
+    original_input = current_dict.get('input')
+    new_input = merge_dict.get('input')
+
+    if merge_dict.get('model') == '':
+        merge_dict.pop('model')
+
+    current_dict.update(merge_dict)
+
+    current_dict['config'] = {**original_config, **new_config}
+    if original_input is not None and new_input is not None:
+        merged_input = {
+            **original_input,
+            **new_input,
+        }
+        if 'default' in original_input or 'default' in new_input:
+            merged_input['default'] = {
+                **(original_input.get('default') or {}),
+                **(new_input.get('default') or {}),
+            }
+        current_dict['input'] = merged_input
+
+    return current_dict
+
+
 def _merge_metadata(
     current: PromptMetadata[ModelConfigT],
     merge: PromptMetadata[ModelConfigT],
@@ -87,22 +121,7 @@ def _merge_metadata(
     Returns:
         The merged metadata object.
     """
-    # Convert Pydantic models to raw dicts by alias first. Skip None values.
-    merge_dict = merge.model_dump(exclude_none=True, by_alias=True)
-    current_dict = current.model_dump(exclude_none=True, by_alias=True)
-
-    # Keep a reference to the original config.
-    original_config = current_dict.get('config', {})
-    new_config = merge_dict.get('config', {})
-
-    # Merge the new metadata.
-    current_dict.update(merge_dict)
-
-    # Merge the configs and set the resulting config.
-    current_dict['config'] = {**original_config, **new_config}
-
-    # Recreate the Pydantic model from the merged dict and validate it.
-    return PromptMetadata[ModelConfigT].model_validate(current_dict)
+    return PromptMetadata[ModelConfigT].model_validate(_merged_metadata_dict(current, merge))
 
 
 def _identify_partials(template: str) -> set[str]:
@@ -151,6 +170,9 @@ class RenderFunc(PromptFunction[ModelConfigT]):
         Returns:
             The rendered prompt.
         """
+        if not isinstance(data, DataArgument):
+            raise TypeError('data must be a DataArgument')
+
         merged_metadata: PromptMetadata[ModelConfigT] = await self._dotprompt.render_metadata(self.prompt, options)
 
         # Prompt defaults apply regardless of whether they came from the
@@ -317,10 +339,7 @@ class Dotprompt:
         """
         prompt: ParsedPrompt[ModelConfigT] = self.parse(source) if isinstance(source, str) else source
         if additional_metadata is not None:
-            prompt = prompt.model_copy(
-                deep=True,
-                update=additional_metadata.model_dump(exclude_none=True, by_alias=True),
-            )
+            prompt = ParsedPrompt[ModelConfigT].model_validate(_merged_metadata_dict(prompt, additional_metadata))
 
         # Resolve partials before compiling.
         await self._resolve_partials(prompt.template)
@@ -342,12 +361,8 @@ class Dotprompt:
         """
         prompt = self.parse(source) if isinstance(source, str) else source
 
-        default_model = prompt.model or self._default_model
-        model = (
-            additional_metadata.model
-            if additional_metadata and additional_metadata.model is not None
-            else default_model
-        )
+        default_model = prompt.model or self._default_model or None
+        model = additional_metadata.model if additional_metadata and additional_metadata.model else default_model
 
         config: ModelConfigT | None = None
         if model is not None and self._model_configs.get(model) is not None:
@@ -355,9 +370,10 @@ class Dotprompt:
 
         return await self._resolve_metadata(
             PromptMetadata[ModelConfigT](
+                model=model,
                 config=config,
             )
-            if config is not None
+            if model is not None or config is not None
             else PromptMetadata[ModelConfigT](),
             prompt,
             additional_metadata,

--- a/python/dotpromptz/src/dotpromptz/dotprompt.py
+++ b/python/dotpromptz/src/dotpromptz/dotprompt.py
@@ -175,14 +175,13 @@ class RenderFunc(PromptFunction[ModelConfigT]):
 
         merged_metadata: PromptMetadata[ModelConfigT] = await self._dotprompt.render_metadata(self.prompt, options)
 
-        # {{name}} is this call only: options.input.default then DataArgument.input.
-        # A default on the .prompt file (or compile metadata) stays on the
-        # returned prompt config; it does not fill a variable the caller omitted.
-        call_defaults: dict[str, Any] = {}
-        if options is not None and options.input is not None and options.input.default is not None:
-            call_defaults = options.input.default
+        # YAML input.default is what {{name}} uses when the caller left that
+        # key out. Call defaults overlay the file; runtime input wins.
+        metadata_defaults: dict[str, Any] = {}
+        if merged_metadata.input is not None and merged_metadata.input.default is not None:
+            metadata_defaults = merged_metadata.input.default
         context: Context = {
-            **call_defaults,
+            **metadata_defaults,
             **(data.input if data.input is not None else {}),
         }
 

--- a/python/dotpromptz/src/dotpromptz/parse.py
+++ b/python/dotpromptz/src/dotpromptz/parse.py
@@ -253,6 +253,7 @@ def parse_document(source: str) -> ParsedPrompt[T]:
                 description=raw.get('description'),
                 variant=raw.get('variant'),
                 version=raw.get('version'),
+                model=raw.get('model'),
                 input=raw.get('input'),
                 output=raw.get('output'),
                 tool_defs=raw.get('toolDefs'),

--- a/python/dotpromptz/src/dotpromptz/typing.py
+++ b/python/dotpromptz/src/dotpromptz/typing.py
@@ -146,7 +146,7 @@ PromptStoreSync (sync read)
 from __future__ import annotations
 
 import warnings
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from enum import Enum
 from typing import (
     Any,
@@ -575,13 +575,13 @@ class PromptFunction(Protocol[ModelConfigT]):
 
     async def __call__(
         self,
-        data: DataArgument[Any],
+        data: DataArgument[Any] | Mapping[str, Any],
         options: PromptMetadata[ModelConfigT] | None = None,
     ) -> RenderedPrompt[ModelConfigT]:
         """Asynchronously renders the prompt.
 
         Args:
-            data: The runtime `DataArgument`.
+            data: Runtime data as a `DataArgument` or mapping.
             options: Optional `PromptMetadata` to merge/override.
 
         Returns:
@@ -602,13 +602,13 @@ class PromptRefFunction(Protocol[ModelConfigT]):
 
     async def __call__(
         self,
-        data: DataArgument[Any],
+        data: DataArgument[Any] | Mapping[str, Any],
         options: PromptMetadata[ModelConfigT] | None = None,
     ) -> RenderedPrompt[ModelConfigT]:
         """Asynchronously loads and renders the referenced prompt.
 
         Args:
-            data: The runtime `DataArgument`.
+            data: Runtime data as a `DataArgument` or mapping.
             options: Optional `PromptMetadata` to merge/override.
 
         Returns:

--- a/python/dotpromptz/src/dotpromptz/typing.py
+++ b/python/dotpromptz/src/dotpromptz/typing.py
@@ -146,7 +146,7 @@ PromptStoreSync (sync read)
 from __future__ import annotations
 
 import warnings
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from enum import Enum
 from typing import (
     Any,
@@ -575,13 +575,13 @@ class PromptFunction(Protocol[ModelConfigT]):
 
     async def __call__(
         self,
-        data: DataArgument[Any] | Mapping[str, Any],
+        data: DataArgument[Any],
         options: PromptMetadata[ModelConfigT] | None = None,
     ) -> RenderedPrompt[ModelConfigT]:
         """Asynchronously renders the prompt.
 
         Args:
-            data: Runtime data as a `DataArgument` or mapping.
+            data: The runtime `DataArgument`.
             options: Optional `PromptMetadata` to merge/override.
 
         Returns:
@@ -602,13 +602,13 @@ class PromptRefFunction(Protocol[ModelConfigT]):
 
     async def __call__(
         self,
-        data: DataArgument[Any] | Mapping[str, Any],
+        data: DataArgument[Any],
         options: PromptMetadata[ModelConfigT] | None = None,
     ) -> RenderedPrompt[ModelConfigT]:
         """Asynchronously loads and renders the referenced prompt.
 
         Args:
-            data: Runtime data as a `DataArgument` or mapping.
+            data: The runtime `DataArgument`.
             options: Optional `PromptMetadata` to merge/override.
 
         Returns:

--- a/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
+++ b/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
@@ -37,7 +37,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pydantic import ValidationError
 
 from dotpromptz.dotprompt import Dotprompt, _identify_partials
 from dotpromptz.typing import (
@@ -153,96 +152,6 @@ def test_define_tool(mock_handlebars: Mock) -> None:
 
 
 class TestCompileRender(IsolatedAsyncioTestCase):
-    async def test_render_accepts_mapping_data_without_mutating_it(self) -> None:
-        """Plain mappings are validated and rendered as runtime data."""
-        data = {
-            'input': {'name': 'Ada'},
-            'context': {'state': 'ready'},
-        }
-
-        result = await Dotprompt().render(
-            'Hello, {{name}} ({{@state}})!',
-            data,
-        )
-
-        assert result.messages[0].content == [TextPart(text='Hello, Ada (ready)!')]
-        assert data == {
-            'input': {'name': 'Ada'},
-            'context': {'state': 'ready'},
-        }
-
-    async def test_compiled_renderer_accepts_mapping_data(self) -> None:
-        """Compiled prompt functions expose the same mapping-friendly API."""
-        renderer = await Dotprompt().compile('Hello, {{name}}!')
-
-        result = await renderer({'input': {'name': 'Ada'}})
-
-        assert result.messages[0].content == [TextPart(text='Hello, Ada!')]
-
-    async def test_mapping_data_is_validated_before_rendering(self) -> None:
-        """Invalid nested runtime data fails with a validation error."""
-        with pytest.raises(ValidationError):
-            await Dotprompt().render(
-                'Hello',
-                {
-                    'messages': [
-                        {
-                            'role': 'not-a-role',
-                            'content': [],
-                        }
-                    ]
-                },
-            )
-
-    async def test_mapping_and_data_argument_render_identically(self) -> None:
-        """Both public input shapes have the same rendering semantics."""
-        source = """---
-model: gemini-2.5-flash
-input:
-  default:
-    greeting: Hello
----
-{{history}}{{greeting}}, {{name}} ({{@state}})"""
-        options = PromptMetadata(config={'temperature': 0.25})
-        cases = (
-            {
-                'input': {'name': 'Ada'},
-                'context': {'state': 'ready'},
-            },
-            {
-                'input': {'greeting': 'Welcome', 'name': 'Grace'},
-                'context': {'state': 'testing'},
-                'messages': [
-                    {
-                        'role': 'user',
-                        'content': [{'text': 'Earlier question'}],
-                    }
-                ],
-                'docs': [
-                    {
-                        'content': [{'text': 'Reference material'}],
-                    }
-                ],
-            },
-            {
-                'input': None,
-                'context': None,
-                'messages': None,
-                'docs': None,
-            },
-        )
-
-        for mapping_data in cases:
-            with self.subTest(mapping_data=mapping_data):
-                mapping_result = await Dotprompt().render(source, mapping_data, options)
-                model_result = await Dotprompt().render(
-                    source,
-                    DataArgument.model_validate(mapping_data),
-                    options,
-                )
-
-                assert mapping_result == model_result
-
     async def test_render_preserves_model_and_applies_prompt_input_defaults(self) -> None:
         """Render metadata and input defaults declared by the prompt."""
         source = """---

--- a/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
+++ b/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
@@ -37,12 +37,15 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from dotpromptz.dotprompt import Dotprompt, _identify_partials
 from dotpromptz.typing import (
+    DataArgument,
     ModelConfigT,
     ParsedPrompt,
     PromptMetadata,
+    TextPart,
     ToolDefinition,
 )
 from handlebarrz import HelperFn, HelperOptions
@@ -150,6 +153,124 @@ def test_define_tool(mock_handlebars: Mock) -> None:
 
 
 class TestCompileRender(IsolatedAsyncioTestCase):
+    async def test_render_accepts_mapping_data_without_mutating_it(self) -> None:
+        """Plain mappings are validated and rendered as runtime data."""
+        data = {
+            'input': {'name': 'Ada'},
+            'context': {'state': 'ready'},
+        }
+
+        result = await Dotprompt().render(
+            'Hello, {{name}} ({{@state}})!',
+            data,
+        )
+
+        assert result.messages[0].content == [TextPart(text='Hello, Ada (ready)!')]
+        assert data == {
+            'input': {'name': 'Ada'},
+            'context': {'state': 'ready'},
+        }
+
+    async def test_compiled_renderer_accepts_mapping_data(self) -> None:
+        """Compiled prompt functions expose the same mapping-friendly API."""
+        renderer = await Dotprompt().compile('Hello, {{name}}!')
+
+        result = await renderer({'input': {'name': 'Ada'}})
+
+        assert result.messages[0].content == [TextPart(text='Hello, Ada!')]
+
+    async def test_mapping_data_is_validated_before_rendering(self) -> None:
+        """Invalid nested runtime data fails with a validation error."""
+        with pytest.raises(ValidationError):
+            await Dotprompt().render(
+                'Hello',
+                {
+                    'messages': [
+                        {
+                            'role': 'not-a-role',
+                            'content': [],
+                        }
+                    ]
+                },
+            )
+
+    async def test_mapping_and_data_argument_render_identically(self) -> None:
+        """Both public input shapes have the same rendering semantics."""
+        source = """---
+model: gemini-2.5-flash
+input:
+  default:
+    greeting: Hello
+---
+{{history}}{{greeting}}, {{name}} ({{@state}})"""
+        options = PromptMetadata(config={'temperature': 0.25})
+        cases = (
+            {
+                'input': {'name': 'Ada'},
+                'context': {'state': 'ready'},
+            },
+            {
+                'input': {'greeting': 'Welcome', 'name': 'Grace'},
+                'context': {'state': 'testing'},
+                'messages': [
+                    {
+                        'role': 'user',
+                        'content': [{'text': 'Earlier question'}],
+                    }
+                ],
+                'docs': [
+                    {
+                        'content': [{'text': 'Reference material'}],
+                    }
+                ],
+            },
+            {
+                'input': None,
+                'context': None,
+                'messages': None,
+                'docs': None,
+            },
+        )
+
+        for mapping_data in cases:
+            with self.subTest(mapping_data=mapping_data):
+                mapping_result = await Dotprompt().render(source, mapping_data, options)
+                model_result = await Dotprompt().render(
+                    source,
+                    DataArgument.model_validate(mapping_data),
+                    options,
+                )
+
+                assert mapping_result == model_result
+
+    async def test_render_preserves_model_and_applies_prompt_input_defaults(self) -> None:
+        """Render metadata and input defaults declared by the prompt."""
+        source = """---
+model: gemini-2.5-flash
+input:
+  default:
+    name: World
+---
+Hello, {{name}}!"""
+
+        result = await Dotprompt().render(source, DataArgument(input={}))
+
+        assert result.model == 'gemini-2.5-flash'
+        assert result.messages[0].content == [TextPart(text='Hello, World!')]
+
+    async def test_runtime_input_overrides_prompt_input_defaults(self) -> None:
+        """Runtime input takes precedence over prompt defaults."""
+        source = """---
+input:
+  default:
+    name: World
+---
+Hello, {{name}}!"""
+
+        result = await Dotprompt().render(source, DataArgument(input={'name': 'Ada'}))
+
+        assert result.messages[0].content == [TextPart(text='Hello, Ada!')]
+
     async def test_compile_render_mock(self) -> None:
         """Test that handlebarrz compile produces a working render function.
 
@@ -585,6 +706,26 @@ def test_use_available_model_config() -> None:
         resolve_metadata_mock.assert_called_with(PromptMetadata(config={'temperature': 0.7}), parsed_source, None)
 
         assert result.config == {'temperature': 0.7}
+
+
+def test_metadata_override_without_model_keeps_model_config() -> None:
+    """Metadata overrides do not disable defaults for the selected model."""
+    dotprompt = Dotprompt(model_configs={'gemini-2.5-pro': {'temperature': 0.7}})
+    parsed_source: ParsedPrompt[dict[str, Any]] = ParsedPrompt(
+        template='Template content',
+        model='gemini-2.5-pro',
+    )
+
+    result = asyncio.run(
+        dotprompt.render_metadata(
+            parsed_source,
+            PromptMetadata(description='A useful prompt'),
+        )
+    )
+
+    assert result.model == 'gemini-2.5-pro'
+    assert result.description == 'A useful prompt'
+    assert result.config == {'temperature': 0.7}
 
 
 class TestResolvePartialsCycleDetection(IsolatedAsyncioTestCase):

--- a/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
+++ b/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
@@ -152,8 +152,8 @@ def test_define_tool(mock_handlebars: Mock) -> None:
 
 
 class TestCompileRender(IsolatedAsyncioTestCase):
-    async def test_render_preserves_model_and_does_not_fill_prompt_input_defaults(self) -> None:
-        """Prompt model is kept; file input defaults do not fill {{name}}."""
+    async def test_render_preserves_model_and_applies_prompt_input_defaults(self) -> None:
+        """Prompt model is kept; file input defaults fill {{name}}."""
         source = """---
 model: gemini-2.5-flash
 input:
@@ -165,7 +165,7 @@ Hello, {{name}}!"""
         result = await Dotprompt().render(source, DataArgument(input={}))
 
         assert result.model == 'gemini-2.5-flash'
-        assert result.messages[0].content == [TextPart(text='Hello, !')]
+        assert result.messages[0].content == [TextPart(text='Hello, World!')]
 
     async def test_runtime_input_fills_template_variables(self) -> None:
         source = """---

--- a/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
+++ b/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
@@ -152,8 +152,8 @@ def test_define_tool(mock_handlebars: Mock) -> None:
 
 
 class TestCompileRender(IsolatedAsyncioTestCase):
-    async def test_render_preserves_model_and_applies_prompt_input_defaults(self) -> None:
-        """Render metadata and input defaults declared by the prompt."""
+    async def test_render_preserves_model_and_does_not_fill_prompt_input_defaults(self) -> None:
+        """Prompt model is kept; file input defaults do not fill {{name}}."""
         source = """---
 model: gemini-2.5-flash
 input:
@@ -165,10 +165,9 @@ Hello, {{name}}!"""
         result = await Dotprompt().render(source, DataArgument(input={}))
 
         assert result.model == 'gemini-2.5-flash'
-        assert result.messages[0].content == [TextPart(text='Hello, World!')]
+        assert result.messages[0].content == [TextPart(text='Hello, !')]
 
-    async def test_runtime_input_overrides_prompt_input_defaults(self) -> None:
-        """Runtime input takes precedence over prompt defaults."""
+    async def test_runtime_input_fills_template_variables(self) -> None:
         source = """---
 input:
   default:

--- a/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
+++ b/python/dotpromptz/tests/dotpromptz/dotprompt_test.py
@@ -559,7 +559,7 @@ def test_render_metadata() -> None:
         result = asyncio.run(dotprompt.render_metadata(parsed_source))
 
         resolve_metadata_mock.assert_called_with(
-            PromptMetadata(),
+            PromptMetadata(model='gemini-2.5-pro'),
             ParsedPrompt(
                 model='gemini-2.5-pro',
                 template='Template content',
@@ -612,7 +612,11 @@ def test_use_available_model_config() -> None:
 
     with patch.object(dotprompt, '_resolve_metadata', resolve_metadata_mock):
         result = asyncio.run(dotprompt.render_metadata(parsed_source))
-        resolve_metadata_mock.assert_called_with(PromptMetadata(config={'temperature': 0.7}), parsed_source, None)
+        resolve_metadata_mock.assert_called_with(
+            PromptMetadata(model='gemini-2.5-pro', config={'temperature': 0.7}),
+            parsed_source,
+            None,
+        )
 
         assert result.config == {'temperature': 0.7}
 

--- a/python/dotpromptz/tests/dotpromptz/render_defaults_test.py
+++ b/python/dotpromptz/tests/dotpromptz/render_defaults_test.py
@@ -29,7 +29,7 @@ def rendered_text(result: Any) -> str:
 
 
 @pytest.mark.asyncio
-async def test_render_uses_all_prompt_defaults_when_runtime_input_is_absent() -> None:
+async def test_prompt_file_defaults_do_not_fill_variables_when_runtime_input_is_absent() -> None:
     source = """---
 input:
   default:
@@ -40,11 +40,26 @@ input:
 
     result = await Dotprompt().render(source, DataArgument())
 
-    assert rendered_text(result) == 'Ada Lovelace'
+    assert result.messages == []
 
 
 @pytest.mark.asyncio
-async def test_runtime_input_overrides_one_default_and_keeps_default_siblings() -> None:
+async def test_empty_runtime_input_does_not_fill_prompt_file_defaults() -> None:
+    source = """---
+input:
+  default:
+    first: Ada
+    last: Lovelace
+---
+{{first}} {{last}}"""
+
+    result = await Dotprompt().render(source, DataArgument(input={}))
+
+    assert result.messages == []
+
+
+@pytest.mark.asyncio
+async def test_partial_runtime_input_does_not_keep_prompt_file_default_siblings() -> None:
     source = """---
 input:
   default:
@@ -55,7 +70,26 @@ input:
 
     result = await Dotprompt().render(source, DataArgument(input={'first': 'Grace'}))
 
-    assert rendered_text(result) == 'Grace Lovelace'
+    assert rendered_text(result) == 'Grace '
+
+
+@pytest.mark.asyncio
+async def test_call_defaults_fill_variables_and_prompt_file_defaults_do_not() -> None:
+    source = """---
+input:
+  default:
+    name: Ada
+    city: Paris
+---
+{{name}} lives in {{city}}"""
+
+    result = await Dotprompt().render(
+        source,
+        DataArgument(),
+        PromptMetadata(input=PromptInputConfig(default={'city': 'Paris'})),
+    )
+
+    assert rendered_text(result) == ' lives in Paris'
 
 
 @pytest.mark.asyncio
@@ -99,7 +133,7 @@ input:
         DataArgument(input={'profile': {'name': 'Grace'}}),
     )
 
-    assert rendered_text(result) == 'Grace||analytical-engine'
+    assert rendered_text(result) == 'Grace||'
 
 
 @pytest.mark.asyncio
@@ -123,7 +157,7 @@ input:
         options,
     )
 
-    assert rendered_text(result) == 'runtime/prompt/call'
+    assert rendered_text(result) == 'runtime//call'
     assert result.input == PromptInputConfig(
         default={
             'name': 'call',
@@ -181,7 +215,7 @@ input:
         ),
     )
 
-    assert rendered_text(result) == 'prompt/call'
+    assert rendered_text(result) == '/call'
     assert result.input == PromptInputConfig(
         default={'promptOnly': 'prompt', 'callOnly': 'call'},
         schema={'type': 'string'},
@@ -219,8 +253,8 @@ input:
     )
     compiled_baseline = await renderer(DataArgument())
 
-    assert rendered_text(overridden) == 'prompt/compile/call/runtime/runtime'
-    assert rendered_text(compiled_baseline) == 'prompt/compile///compile'
+    assert rendered_text(overridden) == '//call/runtime/runtime'
+    assert rendered_text(compiled_baseline) == '////'
     assert overridden.input is not None
     assert overridden.input.schema == {'type': 'object'}
     assert compile_defaults == {'compileOnly': 'compile', 'shared': 'compile'}
@@ -245,7 +279,7 @@ input:
     third = await renderer(DataArgument(input={'name': 'third'}))
 
     assert rendered_text(first) == 'first'
-    assert rendered_text(second) == 'default'
+    assert second.messages == []
     assert rendered_text(third) == 'third'
 
 

--- a/python/dotpromptz/tests/dotpromptz/render_defaults_test.py
+++ b/python/dotpromptz/tests/dotpromptz/render_defaults_test.py
@@ -1,0 +1,495 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, cast
+
+import pytest
+
+from dotpromptz.dotprompt import Dotprompt
+from dotpromptz.typing import DataArgument, PromptInputConfig, PromptMetadata, TextPart
+
+
+def rendered_text(result: Any) -> str:
+    part = result.messages[0].content[0]
+    assert isinstance(part, TextPart)
+    return part.text
+
+
+@pytest.mark.asyncio
+async def test_render_uses_all_prompt_defaults_when_runtime_input_is_absent() -> None:
+    source = """---
+input:
+  default:
+    first: Ada
+    last: Lovelace
+---
+{{first}} {{last}}"""
+
+    result = await Dotprompt().render(source, DataArgument())
+
+    assert rendered_text(result) == 'Ada Lovelace'
+
+
+@pytest.mark.asyncio
+async def test_runtime_input_overrides_one_default_and_keeps_default_siblings() -> None:
+    source = """---
+input:
+  default:
+    first: Ada
+    last: Lovelace
+---
+{{first}} {{last}}"""
+
+    result = await Dotprompt().render(source, DataArgument(input={'first': 'Grace'}))
+
+    assert rendered_text(result) == 'Grace Lovelace'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        (None, ''),
+        (False, 'false'),
+        (0, '0'),
+        ('', ''),
+    ],
+    ids=['null', 'false', 'zero', 'empty-string'],
+)
+async def test_falsy_runtime_input_values_override_prompt_defaults(value: Any, expected: str) -> None:
+    source = """---
+input:
+  default:
+    value: default
+---
+[{{value}}]"""
+
+    result = await Dotprompt().render(source, DataArgument(input={'value': value}))
+
+    assert rendered_text(result) == f'[{expected}]'
+
+
+@pytest.mark.asyncio
+async def test_runtime_nested_object_replaces_default_object_without_deep_merge() -> None:
+    source = """---
+input:
+  default:
+    profile:
+      name: Ada
+      role: mathematician
+    tenant: analytical-engine
+---
+{{profile.name}}|{{profile.role}}|{{tenant}}"""
+
+    result = await Dotprompt().render(
+        source,
+        DataArgument(input={'profile': {'name': 'Grace'}}),
+    )
+
+    assert rendered_text(result) == 'Grace||analytical-engine'
+
+
+@pytest.mark.asyncio
+async def test_prompt_and_call_defaults_overlay_before_runtime_input() -> None:
+    source = """---
+input:
+  default:
+    name: prompt
+    promptOnly: prompt
+  schema:
+    type: object
+---
+{{name}}/{{promptOnly}}/{{callOnly}}"""
+    options = PromptMetadata(
+        input=PromptInputConfig(default={'name': 'call', 'callOnly': 'call'}),
+    )
+
+    result = await Dotprompt().render(
+        source,
+        DataArgument(input={'name': 'runtime'}),
+        options,
+    )
+
+    assert rendered_text(result) == 'runtime/prompt/call'
+    assert result.input == PromptInputConfig(
+        default={
+            'name': 'call',
+            'promptOnly': 'prompt',
+            'callOnly': 'call',
+        },
+        schema={'type': 'object'},
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_schema_replaces_prompt_schema_without_inventing_defaults() -> None:
+    source = """---
+input:
+  schema:
+    type: object
+---
+Hello"""
+
+    result = await Dotprompt().render(
+        source,
+        DataArgument(),
+        PromptMetadata(
+            input=PromptInputConfig(schema={'type': 'string'}),
+        ),
+    )
+
+    assert result.input == PromptInputConfig(
+        default=None,
+        schema={'type': 'string'},
+    )
+
+
+@pytest.mark.asyncio
+async def test_compile_schema_replaces_prompt_schema_while_defaults_still_overlay() -> None:
+    source = """---
+input:
+  default:
+    promptOnly: prompt
+  schema:
+    type: object
+---
+{{promptOnly}}/{{callOnly}}"""
+    renderer = await Dotprompt().compile(
+        source,
+        PromptMetadata(
+            input=PromptInputConfig(schema={'type': 'string'}),
+        ),
+    )
+
+    result = await renderer(
+        DataArgument(),
+        PromptMetadata(
+            input=PromptInputConfig(default={'callOnly': 'call'}),
+        ),
+    )
+
+    assert rendered_text(result) == 'prompt/call'
+    assert result.input == PromptInputConfig(
+        default={'promptOnly': 'prompt', 'callOnly': 'call'},
+        schema={'type': 'string'},
+    )
+
+
+@pytest.mark.asyncio
+async def test_compile_and_call_defaults_overlay_in_order_before_runtime_input() -> None:
+    source = """---
+input:
+  default:
+    promptOnly: prompt
+    shared: prompt
+  schema:
+    type: object
+---
+{{promptOnly}}/{{compileOnly}}/{{callOnly}}/{{runtimeOnly}}/{{shared}}"""
+    compile_defaults = {'compileOnly': 'compile', 'shared': 'compile'}
+    call_defaults = {'callOnly': 'call', 'shared': 'call'}
+    runtime_input = {'runtimeOnly': 'runtime', 'shared': 'runtime'}
+    compile_metadata = PromptMetadata(
+        input=PromptInputConfig(default=compile_defaults),
+    )
+    call_metadata = PromptMetadata(
+        input=PromptInputConfig(default=call_defaults),
+    )
+    renderer = await Dotprompt().compile(
+        source,
+        compile_metadata,
+    )
+
+    overridden = await renderer(
+        DataArgument(input=runtime_input),
+        call_metadata,
+    )
+    compiled_baseline = await renderer(DataArgument())
+
+    assert rendered_text(overridden) == 'prompt/compile/call/runtime/runtime'
+    assert rendered_text(compiled_baseline) == 'prompt/compile///compile'
+    assert overridden.input is not None
+    assert overridden.input.schema == {'type': 'object'}
+    assert compile_defaults == {'compileOnly': 'compile', 'shared': 'compile'}
+    assert call_defaults == {'callOnly': 'call', 'shared': 'call'}
+    assert runtime_input == {'runtimeOnly': 'runtime', 'shared': 'runtime'}
+    assert compile_metadata.input == PromptInputConfig(default=compile_defaults)
+    assert call_metadata.input == PromptInputConfig(default=call_defaults)
+
+
+@pytest.mark.asyncio
+async def test_reused_compiled_renderer_does_not_leak_prior_runtime_input() -> None:
+    source = """---
+input:
+  default:
+    name: default
+---
+{{name}}"""
+    renderer = await Dotprompt().compile(source)
+
+    first = await renderer(DataArgument(input={'name': 'first'}))
+    second = await renderer(DataArgument())
+    third = await renderer(DataArgument(input={'name': 'third'}))
+
+    assert rendered_text(first) == 'first'
+    assert rendered_text(second) == 'default'
+    assert rendered_text(third) == 'third'
+
+
+@pytest.mark.asyncio
+async def test_instance_default_model_and_config_apply_when_prompt_omits_model() -> None:
+    dotprompt = Dotprompt(
+        default_model='gemini-default',
+        model_configs={'gemini-default': {'temperature': 0.2}},
+    )
+
+    result = await dotprompt.render('Hello', DataArgument())
+
+    assert result.model == 'gemini-default'
+    assert result.config == {'temperature': 0.2}
+
+
+@pytest.mark.asyncio
+async def test_instance_default_model_survives_without_registered_config() -> None:
+    result = await Dotprompt(default_model='gemini-default').render(
+        'Hello',
+        DataArgument(),
+    )
+
+    assert result.model == 'gemini-default'
+
+
+@pytest.mark.asyncio
+async def test_empty_instance_default_model_is_treated_as_absent() -> None:
+    result = await Dotprompt(
+        default_model='',
+        model_configs={'': {'invalid': True}},
+    ).render('Hello', DataArgument())
+
+    assert result.model is None
+    assert result.config != {'invalid': True}
+
+
+@pytest.mark.asyncio
+async def test_prompt_model_wins_instance_default_and_selects_its_config() -> None:
+    source = """---
+model: gemini-prompt
+---
+Hello"""
+    dotprompt = Dotprompt(
+        default_model='gemini-default',
+        model_configs={
+            'gemini-default': {'temperature': 0.2},
+            'gemini-prompt': {'temperature': 0.4},
+        },
+    )
+
+    result = await dotprompt.render(source, DataArgument())
+
+    assert result.model == 'gemini-prompt'
+    assert result.config == {'temperature': 0.4}
+
+
+@pytest.mark.asyncio
+async def test_call_model_override_wins_prompt_model_and_selects_its_config() -> None:
+    source = """---
+model: gemini-prompt
+---
+Hello"""
+    dotprompt = Dotprompt(
+        model_configs={
+            'gemini-prompt': {'temperature': 0.4},
+            'gemini-call': {'temperature': 0.8},
+        },
+    )
+
+    result = await dotprompt.render(
+        source,
+        DataArgument(),
+        PromptMetadata(model='gemini-call'),
+    )
+
+    assert result.model == 'gemini-call'
+    assert result.config == {'temperature': 0.8}
+
+
+@pytest.mark.asyncio
+async def test_compile_model_override_wins_prompt_model_and_selects_its_config() -> None:
+    source = """---
+model: gemini-prompt
+---
+Hello"""
+    dotprompt = Dotprompt(
+        model_configs={
+            'gemini-prompt': {'temperature': 0.4},
+            'gemini-compile': {'temperature': 0.6},
+        },
+    )
+    renderer = await dotprompt.compile(
+        source,
+        PromptMetadata(model='gemini-compile'),
+    )
+
+    result = await renderer(DataArgument())
+
+    assert result.model == 'gemini-compile'
+    assert result.config == {'temperature': 0.6}
+
+
+@pytest.mark.asyncio
+async def test_empty_prompt_model_uses_instance_default_and_matching_config() -> None:
+    source = """---
+model: ""
+---
+Hello"""
+    dotprompt = Dotprompt(
+        default_model='gemini-default',
+        model_configs={'gemini-default': {'temperature': 0.2}},
+    )
+
+    result = await dotprompt.render(source, DataArgument())
+
+    assert result.model == 'gemini-default'
+    assert result.config == {'temperature': 0.2}
+
+
+@pytest.mark.asyncio
+async def test_empty_call_model_keeps_prompt_model_and_matching_config() -> None:
+    source = """---
+model: gemini-prompt
+---
+Hello"""
+    dotprompt = Dotprompt(
+        model_configs={'gemini-prompt': {'temperature': 0.4}},
+    )
+
+    result = await dotprompt.render(
+        source,
+        DataArgument(),
+        PromptMetadata(model=''),
+    )
+
+    assert result.model == 'gemini-prompt'
+    assert result.config == {'temperature': 0.4}
+
+
+@pytest.mark.asyncio
+async def test_empty_compile_model_keeps_prompt_model_and_matching_config() -> None:
+    source = """---
+model: gemini-prompt
+---
+Hello"""
+    dotprompt = Dotprompt(
+        model_configs={'gemini-prompt': {'temperature': 0.4}},
+    )
+    renderer = await dotprompt.compile(
+        source,
+        PromptMetadata(model=''),
+    )
+
+    result = await renderer(DataArgument())
+
+    assert result.model == 'gemini-prompt'
+    assert result.config == {'temperature': 0.4}
+
+
+@pytest.mark.asyncio
+async def test_selected_model_config_prompt_config_and_call_config_merge_in_order() -> None:
+    source = """---
+model: gemini-prompt
+config:
+  temperature: 0.4
+  topK: 10
+---
+Hello"""
+    dotprompt = Dotprompt(
+        model_configs={
+            'gemini-prompt': {
+                'temperature': 0.2,
+                'topK': 5,
+                'topP': 0.5,
+            }
+        },
+    )
+
+    result = await dotprompt.render(
+        source,
+        DataArgument(),
+        PromptMetadata(config={'topK': 20}),
+    )
+
+    assert result.model == 'gemini-prompt'
+    assert result.config == {
+        'temperature': 0.4,
+        'topK': 20,
+        'topP': 0.5,
+    }
+
+
+@pytest.mark.asyncio
+async def test_compile_and_call_model_metadata_merge_in_order() -> None:
+    source = """---
+model: gemini-prompt
+config:
+  promptOnly: prompt
+  shared: prompt
+---
+Hello"""
+    dotprompt = Dotprompt(
+        default_model='gemini-default',
+        model_configs={
+            'gemini-default': {'selected': 'default-model'},
+            'gemini-prompt': {'selected': 'prompt-model'},
+            'gemini-compile': {'selected': 'compile-model'},
+            'gemini-call': {
+                'selected': 'call-model',
+                'shared': 'model',
+            },
+        },
+    )
+    renderer = await dotprompt.compile(
+        source,
+        PromptMetadata(
+            model='gemini-compile',
+            config={'compileOnly': 'compile', 'shared': 'compile'},
+        ),
+    )
+
+    result = await renderer(
+        DataArgument(),
+        PromptMetadata(
+            model='gemini-call',
+            config={'callOnly': 'call', 'shared': 'call'},
+        ),
+    )
+
+    assert result.model == 'gemini-call'
+    assert result.config == {
+        'selected': 'call-model',
+        'promptOnly': 'prompt',
+        'compileOnly': 'compile',
+        'callOnly': 'call',
+        'shared': 'call',
+    }
+
+
+@pytest.mark.asyncio
+async def test_render_rejects_plain_dictionary_instead_of_treating_it_as_data_argument() -> None:
+    with pytest.raises(TypeError, match='data must be a DataArgument'):
+        await Dotprompt().render(
+            '{{name}}',
+            cast(Any, {'input': {'name': 'Ada'}}),
+        )

--- a/python/dotpromptz/tests/dotpromptz/render_defaults_test.py
+++ b/python/dotpromptz/tests/dotpromptz/render_defaults_test.py
@@ -29,7 +29,7 @@ def rendered_text(result: Any) -> str:
 
 
 @pytest.mark.asyncio
-async def test_prompt_file_defaults_do_not_fill_variables_when_runtime_input_is_absent() -> None:
+async def test_prompt_file_defaults_fill_when_runtime_input_is_absent() -> None:
     source = """---
 input:
   default:
@@ -40,11 +40,11 @@ input:
 
     result = await Dotprompt().render(source, DataArgument())
 
-    assert result.messages == []
+    assert rendered_text(result) == 'Ada Lovelace'
 
 
 @pytest.mark.asyncio
-async def test_empty_runtime_input_does_not_fill_prompt_file_defaults() -> None:
+async def test_empty_runtime_input_still_uses_prompt_file_defaults() -> None:
     source = """---
 input:
   default:
@@ -55,11 +55,11 @@ input:
 
     result = await Dotprompt().render(source, DataArgument(input={}))
 
-    assert result.messages == []
+    assert rendered_text(result) == 'Ada Lovelace'
 
 
 @pytest.mark.asyncio
-async def test_partial_runtime_input_does_not_keep_prompt_file_default_siblings() -> None:
+async def test_partial_runtime_input_keeps_other_prompt_file_defaults() -> None:
     source = """---
 input:
   default:
@@ -70,11 +70,11 @@ input:
 
     result = await Dotprompt().render(source, DataArgument(input={'first': 'Grace'}))
 
-    assert rendered_text(result) == 'Grace '
+    assert rendered_text(result) == 'Grace Lovelace'
 
 
 @pytest.mark.asyncio
-async def test_call_defaults_fill_variables_and_prompt_file_defaults_do_not() -> None:
+async def test_call_default_overrides_one_file_default_and_keeps_the_rest() -> None:
     source = """---
 input:
   default:
@@ -86,10 +86,10 @@ input:
     result = await Dotprompt().render(
         source,
         DataArgument(),
-        PromptMetadata(input=PromptInputConfig(default={'city': 'Paris'})),
+        PromptMetadata(input=PromptInputConfig(default={'city': 'London'})),
     )
 
-    assert rendered_text(result) == ' lives in Paris'
+    assert rendered_text(result) == 'Ada lives in London'
 
 
 @pytest.mark.asyncio
@@ -133,7 +133,7 @@ input:
         DataArgument(input={'profile': {'name': 'Grace'}}),
     )
 
-    assert rendered_text(result) == 'Grace||'
+    assert rendered_text(result) == 'Grace||analytical-engine'
 
 
 @pytest.mark.asyncio
@@ -157,7 +157,7 @@ input:
         options,
     )
 
-    assert rendered_text(result) == 'runtime//call'
+    assert rendered_text(result) == 'runtime/prompt/call'
     assert result.input == PromptInputConfig(
         default={
             'name': 'call',
@@ -215,7 +215,7 @@ input:
         ),
     )
 
-    assert rendered_text(result) == '/call'
+    assert rendered_text(result) == 'prompt/call'
     assert result.input == PromptInputConfig(
         default={'promptOnly': 'prompt', 'callOnly': 'call'},
         schema={'type': 'string'},
@@ -253,8 +253,8 @@ input:
     )
     compiled_baseline = await renderer(DataArgument())
 
-    assert rendered_text(overridden) == '//call/runtime/runtime'
-    assert rendered_text(compiled_baseline) == '////'
+    assert rendered_text(overridden) == 'prompt/compile/call/runtime/runtime'
+    assert rendered_text(compiled_baseline) == 'prompt/compile///compile'
     assert overridden.input is not None
     assert overridden.input.schema == {'type': 'object'}
     assert compile_defaults == {'compileOnly': 'compile', 'shared': 'compile'}
@@ -279,7 +279,7 @@ input:
     third = await renderer(DataArgument(input={'name': 'third'}))
 
     assert rendered_text(first) == 'first'
-    assert second.messages == []
+    assert rendered_text(second) == 'default'
     assert rendered_text(third) == 'third'
 
 


### PR DESCRIPTION
`input.default` in a `.prompt` file fills any template key the caller left out. Call defaults overlay the file. Runtime input wins that key. `render` and `compile` take a `DataArgument`, not a plain dict. Model and config layers compose: instance default, then the file, then compile metadata, then the call.

```python
from dotpromptz import Dotprompt
from dotpromptz.typing import DataArgument, PromptInputConfig, PromptMetadata

source = """
---
model: gemini-2.5-flash
input:
  default:
    name: World
---
Hello, {{name}}!
"""

await Dotprompt().render(source, DataArgument(input={}))
# model gemini-2.5-flash, text 'Hello, World!'

await Dotprompt().render(source, DataArgument(input={'name': 'Ada'}))
# 'Hello, Ada!'

await Dotprompt().render(
    """
---
input:
  default:
    first: Ada
    last: Lovelace
---
{{first}} {{last}}
""",
    DataArgument(input={'first': 'Grace'}),
)
# 'Grace Lovelace'

await Dotprompt().render(source, {'input': {'name': 'Ada'}})
# TypeError: data must be a DataArgument
```

## Decisions

- `DataArgument()` and `DataArgument(input={})` are both "no keys supplied." File defaults fill.
- A key the caller did set, including `None` / `False` / `0` / `''`, replaces the default. Nested objects replace; they do not deep-merge.
- Call `PromptMetadata(input=PromptInputConfig(default=…))` overlays the file for those keys. Compile metadata overlays the file; the call overlays compile; runtime input is last.
- The returned prompt config still carries the merged `input.default` map. That is the same overlay the template used.
- `render` and `compile` require `DataArgument`. A mapping is `TypeError`.
- Model: instance `default_model`, then file `model:`, then compile metadata, then the call. An empty string means absent, not a model named `""`.
- Config: the selected model's `model_configs` entry, then file `config:`, then compile, then the call. Later keys overlay.
- YAML `model:` is kept on the parsed prompt.

## Why model and input.default treat empty differently

Both are overlays: the later layer wins whatever it supplied. They split on whether the field can spend the empty string as an absence sentinel.

- `model` can. There is no model named `""`, so nothing is lost by reading `''` as "this layer did not pick one." A later layer therefore cannot clear a model the file set — which is what you want, since clearing would leave an unrunnable prompt.
- `input.default` keys cannot. `''` is a legitimate template value, and reserving it would make an empty `{{middle_name}}` unexpressible. So every value the caller sets is a value, and setting a key to `''` does override the default.

```python
source = '---\nmodel: gemini-2.5-flash\ninput:\n  default:\n    name: World\n---\n{{name}}'

await Dotprompt().render(source, DataArgument(input={}), PromptMetadata(model=''))
# model still gemini-2.5-flash — the blank named nothing

await Dotprompt().render(source, DataArgument(input={'name': ''}))
# text '' — the caller set the key, so the default is gone
```

Because `''` is only ever absence for a model name, it is dropped when a layer is dumped rather than handled during the merge. `_merged_metadata_dict` carries no model special case: every field follows one rule, and only `config` and `input.default` differ, by overlaying per key instead of whole.