### PR TITLE
fix: align frontmatter parsing across runtimes

### DIFF
--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -7,6 +7,11 @@ variable-interpolated UTF-8 encoded text templates, which can optionally use
 
 ![Dotprompt Format](../img/dotprompt-file-format.svg)
 
+YAML front matter is optional. When a file has no front matter delimiters, its
+entire contents are treated as the prompt template. When the delimiters are
+present but contain no YAML, the empty block is discarded and only the content
+after the closing delimiter is treated as the template.
+
 ## Examples
 
 === "Example 1"

--- a/go/dotprompt/parse.go
+++ b/go/dotprompt/parse.go
@@ -58,7 +58,7 @@ var (
 	// EmptyFrontmatterRegex is a regular expression to match empty YAML
 	// frontmatter (where there's no content between the frontmatter markers).
 	// Also allows blank lines and license headers before the first ---.
-	EmptyFrontmatterRegex = regexp.MustCompile(`^(?:(?:#[^\n]*|[ \t]*)\n)*---\s*\n---\s*\n([\s\S]*)$`)
+	EmptyFrontmatterRegex = regexp.MustCompile(`^(?:(?:#[^\r\n]*|[ \t]*)(?:\r\n|\r|\n))*---[ \t]*(?:\r\n|\r|\n)---[ \t]*(?:\r\n|\r|\n)([\s\S]*)$`)
 
 	// RoleAndHistoryMarkerRegex is a regular expression to match
 	// <<<dotprompt:role:xxx>>> and <<<dotprompt:history>>> markers in the
@@ -223,26 +223,39 @@ func convertNamespacedEntryToNestedObject(
 // extractFrontmatterAndBody extracts the frontmatter and body from a .prompt
 // file.
 func extractFrontmatterAndBody(source string) (string, string) {
+	frontmatter, body, matched := matchFrontmatterAndBody(source)
+	if !matched {
+		return "", source
+	}
+	return frontmatter, body
+}
+
+func matchFrontmatterAndBody(source string) (string, string, bool) {
 	match := FrontmatterAndBodyRegex.FindStringSubmatch(source)
 	if match == nil {
-		// Try the empty frontmatter pattern
 		match = EmptyFrontmatterRegex.FindStringSubmatch(source)
 		if match == nil {
-			return "", ""
+			return "", "", false
 		}
-		return "", match[1]
+		return "", match[1], true
 	}
 	frontmatter, body := match[1], match[2]
-	return frontmatter, body
+	return frontmatter, body, true
 }
 
 // ParseDocument parses a document containing YAML frontmatter and a template
 // content section.  The frontmatter contains metadata and configuration for the
 // prompt.
 func ParseDocument(source string) (ParsedPrompt, error) {
-	frontmatter, body := extractFrontmatterAndBody(source)
+	frontmatter, body, hasFrontmatter := matchFrontmatterAndBody(source)
 	promptMetadata := PromptMetadata{
 		Ext: make(map[string]map[string]any),
+	}
+	if !hasFrontmatter {
+		return ParsedPrompt{
+			PromptMetadata: promptMetadata,
+			Template:       source,
+		}, nil
 	}
 
 	if frontmatter != "" {
@@ -364,18 +377,10 @@ func ParseDocument(source string) (ParsedPrompt, error) {
 		}, nil
 	}
 
-	// If we have a body from frontmatter extraction, use it
-	if body != "" {
-		return ParsedPrompt{
-			PromptMetadata: promptMetadata,
-			Template:       trimUnicodeSpacesExceptNewlines(body),
-		}, nil
-	}
-
-	// No frontmatter or body extracted, return the original source as template
+	// An empty frontmatter block contributes no metadata.
 	return ParsedPrompt{
 		PromptMetadata: promptMetadata,
-		Template:       source,
+		Template:       trimUnicodeSpacesExceptNewlines(body),
 	}, nil
 }
 

--- a/go/dotprompt/parse_test.go
+++ b/go/dotprompt/parse_test.go
@@ -419,17 +419,14 @@ func TestExtractFrontmatterAndBody(t *testing.T) {
 		}
 	})
 
-	t.Run("should return empty strings when there is no frontmatter marker", func(t *testing.T) {
-		// TODO(#495): May be change this behavior to return a matching body when
-		// there is no frontmatter marker and we have a body. This may need to
-		// be done across all the runtimes.
+	t.Run("should return the source as the body when there is no frontmatter marker", func(t *testing.T) {
 		inputStr := "Hello World"
 		frontmatter, body := extractFrontmatterAndBody(inputStr)
 		if frontmatter != "" {
 			t.Errorf("frontmatter = %q, want \"\"", frontmatter)
 		}
-		if body != "" {
-			t.Errorf("body = %q, want \"\"", body)
+		if body != inputStr {
+			t.Errorf("body = %q, want %q", body, inputStr)
 		}
 	})
 }
@@ -1588,6 +1585,21 @@ Template content`
 		}
 		if result.Template != "Template content" {
 			t.Errorf("Template = %q, want \"Template content\"", result.Template)
+		}
+	})
+
+	t.Run("handle empty frontmatter and empty body", func(t *testing.T) {
+		source := "---\n---\n"
+
+		result, err := ParseDocument(source)
+		if err != nil {
+			t.Errorf("ParseDocument() returned error: %v", err)
+		}
+		if result.Ext == nil {
+			t.Error("Ext is nil")
+		}
+		if result.Template != "" {
+			t.Errorf("Template = %q, want \"\"", result.Template)
 		}
 	})
 

--- a/js/src/parse.test.ts
+++ b/js/src/parse.test.ts
@@ -291,13 +291,18 @@ describe('extractFrontmatterAndBody', () => {
     expect(body).toBe('This is the body.');
   });
 
-  it('should match as empty frontmatter and body when there is no frontmatter', () => {
-    // Both the frontmatter and the body match as empty when there is no
-    // frontmatter.
+  it('should return the source as the body when there is no frontmatter', () => {
     const source = 'No frontmatter here.';
     const { frontmatter, body } = extractFrontmatterAndBody(source);
     expect(frontmatter).toBe('');
-    expect(body).toBe('');
+    expect(body).toBe(source);
+  });
+
+  it('should extract the body when the frontmatter block is empty', () => {
+    const source = '---\n---\nThis is the body.';
+    const { frontmatter, body } = extractFrontmatterAndBody(source);
+    expect(frontmatter).toBe('');
+    expect(body).toBe('This is the body.');
   });
 });
 
@@ -856,12 +861,19 @@ Template content`;
   });
 
   it('should handle document with empty frontmatter', () => {
-    // TODO(#495): Check whether this is the correct behavior.
     const source = '---\n\n---\nJust template content';
     const result = parseDocument(source);
     expect(result).toMatchObject({
       ext: {},
-      template: source.trim(),
+      template: 'Just template content',
+    });
+  });
+
+  it('should handle empty frontmatter and an empty body', () => {
+    const result = parseDocument('---\n---\n');
+    expect(result).toMatchObject({
+      ext: {},
+      template: '',
     });
   });
 

--- a/js/src/parse.ts
+++ b/js/src/parse.ts
@@ -68,6 +68,12 @@ export const FRONTMATTER_AND_BODY_REGEX =
   /^(?:(?:#[^\n]*|[ \t]*)\n)*---\s*(?:\r\n|\r|\n)([\s\S]*?)(?:\r\n|\r|\n)---\s*(?:\r\n|\r|\n)([\s\S]*)$/;
 
 /**
+ * Regular expression to match an empty YAML frontmatter block and its body.
+ */
+const EMPTY_FRONTMATTER_AND_BODY_REGEX =
+  /^(?:(?:#[^\r\n]*|[ \t]*)(?:\r\n|\r|\n))*---[ \t]*(?:\r\n|\r|\n)---[ \t]*(?:\r\n|\r|\n)([\s\S]*)$/;
+
+/**
  * Regular expression to match <<<dotprompt:role:xxx>>> and
  * <<<dotprompt:history>>> markers in the template.
  *
@@ -187,8 +193,9 @@ export function convertNamespacedEntryToNestedObject(
  * Extracts the YAML frontmatter and body from a document.
  *
  * @param source The source document containing frontmatter and template
- * @returns An object containing the frontmatter and body If the pattern does
- *   not match, both the values returned will be empty.
+ * @returns An object containing the frontmatter and body. If the source has no
+ *   frontmatter block, the frontmatter is empty and the full source is the
+ *   body.
  */
 export function extractFrontmatterAndBody(source: string) {
   const match = source.match(FRONTMATTER_AND_BODY_REGEX);
@@ -196,7 +203,13 @@ export function extractFrontmatterAndBody(source: string) {
     const [, frontmatter, body] = match;
     return { frontmatter, body };
   }
-  return { frontmatter: '', body: '' };
+
+  const emptyMatch = source.match(EMPTY_FRONTMATTER_AND_BODY_REGEX);
+  if (emptyMatch) {
+    return { frontmatter: '', body: emptyMatch[1] };
+  }
+
+  return { frontmatter: '', body: source };
 }
 
 /**
@@ -233,8 +246,15 @@ export function parseDocument<ModelConfig = Record<string, any>>(
     }
   }
 
-  // No frontmatter, return a basic ParsedPrompt with just the template
-  return { ...BASE_METADATA, template: source };
+  const hasFrontmatterBlock =
+    FRONTMATTER_AND_BODY_REGEX.test(source) ||
+    EMPTY_FRONTMATTER_AND_BODY_REGEX.test(source);
+  if (hasFrontmatterBlock) {
+    return { ...BASE_METADATA, template: body.trim() };
+  }
+
+  // No frontmatter block, return the full source as the template.
+  return { ...BASE_METADATA, template: body };
 }
 
 /**

--- a/python/dotpromptz/src/dotpromptz/parse.py
+++ b/python/dotpromptz/src/dotpromptz/parse.py
@@ -83,6 +83,11 @@ FRONTMATTER_AND_BODY_REGEX = re.compile(
     r'^(?:(?:#[^\n]*|[ \t]*)\n)*---\s*(?:\r\n|\r|\n)([\s\S]*?)(?:\r\n|\r|\n)---\s*(?:\r\n|\r|\n)([\s\S]*)$'
 )
 
+# Regular expression to match an empty YAML frontmatter block and its body.
+EMPTY_FRONTMATTER_AND_BODY_REGEX = re.compile(
+    r'^(?:(?:#[^\r\n]*|[ \t]*)(?:\r\n|\r|\n))*---[ \t]*(?:\r\n|\r|\n)---[ \t]*(?:\r\n|\r|\n)([\s\S]*)$'
+)
+
 # Regular expression to match <<<dotprompt:role:xxx>>> and
 # <<<dotprompt:history>>> markers in the template.
 #
@@ -205,14 +210,20 @@ def extract_frontmatter_and_body(source: str) -> tuple[str, str]:
         source: The source document containing frontmatter and template
 
     Returns:
-        A tuple containing the frontmatter and body If the pattern does not
-        match, both the values returned will be empty.
+        A tuple containing the frontmatter and body. If the source has no
+        frontmatter block, the frontmatter is empty and the full source is the
+        body.
     """
     match = FRONTMATTER_AND_BODY_REGEX.match(source)
     if match:
         frontmatter, body = match.groups()
         return frontmatter, body
-    return '', ''
+
+    empty_match = EMPTY_FRONTMATTER_AND_BODY_REGEX.match(source)
+    if empty_match:
+        return '', empty_match.group(1)
+
+    return '', source
 
 
 def parse_document(source: str) -> ParsedPrompt[T]:
@@ -228,8 +239,12 @@ def parse_document(source: str) -> ParsedPrompt[T]:
     """
     frontmatter, body = extract_frontmatter_and_body(source)
     if not frontmatter:
-        # No frontmatter, return a basic ParsedPrompt with just the template
-        return ParsedPrompt(ext={}, config=None, metadata={}, tool_defs=None, template=source)
+        has_frontmatter_block = (
+            FRONTMATTER_AND_BODY_REGEX.match(source) is not None
+            or EMPTY_FRONTMATTER_AND_BODY_REGEX.match(source) is not None
+        )
+        template = body.strip() if has_frontmatter_block else body
+        return ParsedPrompt(ext={}, config=None, metadata={}, tool_defs=None, template=template)
 
     try:
         parsed_metadata = yaml.safe_load(frontmatter)

--- a/python/dotpromptz/tests/dotpromptz/parse_test.py
+++ b/python/dotpromptz/tests/dotpromptz/parse_test.py
@@ -348,13 +348,19 @@ class TestExtractFrontmatterAndBody(unittest.TestCase):
     def test_extract_frontmatter_and_body_no_frontmatter(self) -> None:
         """Test extracting body when no frontmatter is present.
 
-        Both the frontmatter and body are empty strings, when there
-        is no frontmatter marker.
+        The full source is the body when there is no frontmatter marker.
         """
         input_str = 'Hello World'
         frontmatter, body = extract_frontmatter_and_body(input_str)
         assert frontmatter == ''
-        assert body == ''
+        assert body == input_str
+
+    def test_extract_frontmatter_and_body_empty_block(self) -> None:
+        """Test extracting the body after an empty frontmatter block."""
+        input_str = '---\n---\nThis is the body.'
+        frontmatter, body = extract_frontmatter_and_body(input_str)
+        assert frontmatter == ''
+        assert body == 'This is the body.'
 
 
 class TestTransformMessagesToHistory(unittest.TestCase):
@@ -725,8 +731,14 @@ Template content"""
 
         self.assertEqual(result.ext, {})
 
-        # TODO(#495): Check whether this is the correct behavior.
-        self.assertEqual(result.template, source.strip())
+        self.assertEqual(result.template, 'Template content')
+
+    def test_handle_empty_frontmatter_and_empty_body(self) -> None:
+        """Test handling empty frontmatter followed by an empty body."""
+        result: ParsedPrompt[dict[str, str]] = parse_document('---\n---\n')
+
+        self.assertEqual(result.ext, {})
+        self.assertEqual(result.template, '')
 
     def test_handle_multiple_namespaced_entries(self) -> None:
         """Test handling multiple namespaced entries."""


### PR DESCRIPTION
## Summary

- Return the full source as the body when a document has no frontmatter block.
- Discard empty frontmatter delimiters consistently in JavaScript, Python, and Go, including when the template body is empty.
- Document the optional frontmatter contract in the file format guide.

## Why

JavaScript and Python previously returned the frontmatter delimiters as template content for an empty block, while Go already discarded them when a body was present. The lower-level extraction helpers also returned an empty body for documents without frontmatter. This change gives all three runtimes one explicit contract.

## Testing

- JavaScript: `vitest run` (317 tests passed)
- Python: `pytest python/dotpromptz/tests/dotpromptz/parse_test.py -q` (68 tests passed)
- Go: `go test -C go ./dotprompt/...` (2 packages passed)

Fixes #495